### PR TITLE
Fix Windows PowerShell build, add github-actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,11 @@ updates:
     groups:
       npm-deps:
         patterns: ["*"]
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/release-dryrun.yml
+++ b/.github/workflows/release-dryrun.yml
@@ -38,6 +38,7 @@ jobs:
         run: cd npm/decibri && npm install --ignore-optional
 
       - name: Build native addon
+        shell: bash
         run: |
           cd npm/decibri
           npx napi build --platform --release \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
         run: cd npm/decibri && npm install --ignore-optional
 
       - name: Build native addon
+        shell: bash
         run: |
           cd npm/decibri
           npx napi build --platform --release \


### PR DESCRIPTION
Windows build was failing in release-dryrun.yml due to PowerShell not understanding \ line continuation. Adding shell: bash forces Git Bash on Windows runners. Also adds github-actions ecosystem to dependabot for action version updates.