### PR TITLE
Release 3.1.0: ORT load-dynamic migration + Issue #14 fix

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,7 +12,7 @@
 # error wrapped by decibri.
 #
 # This alias swaps `ort-load-dynamic` for `ort-download-binaries` for the test
-# run only. The tests exercise identical VAD code paths — they don't care which
+# run only. The tests exercise identical VAD code paths. They don't care which
 # distribution mode supplies libonnxruntime. Side benefit: the escape-hatch
 # feature gets exercised end-to-end by CI.
 #

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,26 @@
+# Cargo configuration for decibri workspace.
+#
+# Aliases defined here work with any `cargo <alias>` invocation in this workspace.
+
+[alias]
+# Test the decibri crate under the `ort-download-binaries` feature.
+#
+# The default feature set selects `ort-load-dynamic`, which requires ORT to be
+# available at runtime (either via an ORT_DYLIB_PATH env var or a bundled dylib
+# from an npm platform package). Neither is present during plain `cargo test`,
+# which would cause every model-loading test to fail with a dylib-not-found
+# error wrapped by decibri.
+#
+# This alias swaps `ort-load-dynamic` for `ort-download-binaries` for the test
+# run only. The tests exercise identical VAD code paths — they don't care which
+# distribution mode supplies libonnxruntime. Side benefit: the escape-hatch
+# feature gets exercised end-to-end by CI.
+#
+# The load-dynamic code path itself is covered by Node-level tests
+# (tests/test-vad-silero.js) against the built .node file with the bundled ORT,
+# which is the real production path.
+#
+# If you specifically want to test load-dynamic from Rust, set
+# `ORT_DYLIB_PATH=/path/to/libonnxruntime.{so,dylib,dll}` and run the plain
+# `cargo test -p decibri` instead.
+test-decibri = "test -p decibri --no-default-features --features capture,output,vad,denoise,gain,ort-download-binaries"

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -89,3 +89,106 @@ jobs:
 
           ort is pinned to an RC version. Check if stable 2.0.0 has been released."
           fi
+
+  check-onnxruntime:
+    name: Check ONNX Runtime upstream
+    runs-on: ubuntu-latest
+    # No per-job `permissions` block: inherits file-level
+    # `issues: write, contents: read` declared at top of this workflow
+    # (same pattern as the existing check-cpal and check-ort jobs).
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Ensure dependency-update label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Idempotent: `gh label create` returns non-zero if the label
+          # already exists, which we swallow. First-run in a fresh repo
+          # (or after a manual label deletion) will create it.
+          gh label create dependency-update \
+            --color "0366d6" \
+            --description "Upstream dependency version drift detected by check-upstream.yml" \
+            2>/dev/null || true
+
+      - name: Get decibri's pinned ORT_VERSION
+        id: pinned
+        run: |
+          # Anchored to the workflow-level `env:` declaration in release.yml,
+          # which is the single source of truth for ORT_VERSION. The anchor
+          # `^  ORT_VERSION:` (two-space indent) matches the env block line
+          # exactly and rejects any stray per-job bash assignments that might
+          # sneak in later.
+          VERSION=$(grep -oP '^\s+ORT_VERSION:\s*\K[0-9]+\.[0-9]+\.[0-9]+' .github/workflows/release.yml | head -1)
+          if [ -z "$VERSION" ]; then
+            echo "ERROR: could not extract ORT_VERSION from release.yml env block"
+            echo "Expected a workflow-level env: block containing 'ORT_VERSION: X.Y.Z'"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          echo "minor=${MINOR}" >> "$GITHUB_OUTPUT"
+
+      - name: Get latest Microsoft ORT release
+        id: latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG=$(gh api repos/microsoft/onnxruntime/releases/latest --jq '.tag_name')
+          VERSION="${TAG#v}"
+          DATE=$(gh api repos/microsoft/onnxruntime/releases/latest --jq '.published_at')
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "date=${DATE}" >> "$GITHUB_OUTPUT"
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          echo "minor=${MINOR}" >> "$GITHUB_OUTPUT"
+
+      - name: Get decibri's ort crate api-N baseline
+        id: baseline
+        run: |
+          # ort 2.0.0-rc.12 defaults to api-24. Hardcoded here to avoid
+          # a second Cargo.toml parse.
+          #
+          # IMPORTANT: when upgrading the ort crate, update this number to
+          # match the new crate's target api-N. See the maintainer comment
+          # in the workspace root Cargo.toml for the full upgrade procedure
+          # (step 4 of that comment lists this file explicitly).
+          echo "api_n=24" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update issue if upstream advanced
+        if: steps.pinned.outputs.version != steps.latest.outputs.version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PINNED="${{ steps.pinned.outputs.version }}"
+          LATEST="${{ steps.latest.outputs.version }}"
+          LATEST_MINOR="${{ steps.latest.outputs.minor }}"
+          API_N="${{ steps.baseline.outputs.api_n }}"
+          DATE="${{ steps.latest.outputs.date }}"
+
+          ABI_WARNING=""
+          if [ "$LATEST_MINOR" -gt "$API_N" ]; then
+            ABI_WARNING="
+
+          ⚠️ **ABI mismatch**: Microsoft released ORT 1.${LATEST_MINOR}.x but the \`ort\` crate is pinned to an \`api-${API_N}\` target (ONNX Runtime 1.${API_N}.x ABI). **Upgrading the bundled ORT to 1.${LATEST_MINOR}.x requires first upgrading the \`ort\` crate to a version that targets api-${LATEST_MINOR}**. Do NOT bump \`ORT_VERSION\` in \`release.yml\` until the crate upgrade is complete."
+          fi
+
+          TITLE="ONNX Runtime ${LATEST} available (pinned: ${PINNED})"
+          COUNT=$(gh issue list --label "dependency-update" --state open --search "ONNX Runtime" --json number --jq 'length')
+          BODY="Microsoft released **ONNX Runtime v${LATEST}** on ${DATE}.
+
+          **decibri pinned:** ${PINNED}
+          **Upstream latest:** ${LATEST}
+          **Release notes:** https://github.com/microsoft/onnxruntime/releases/tag/v${LATEST}
+
+          **Review upgrade path:**
+          1. Check that the current \`ort\` crate version still supports \`api-${LATEST_MINOR}\` (compare against [ort.pyke.io/setup/multiversion](https://ort.pyke.io/setup/multiversion)).
+          2. Update \`ORT_VERSION\` in \`.github/workflows/release.yml\`.
+          3. Update the \`api_n\` baseline in \`.github/workflows/check-upstream.yml\` if the ort crate was also upgraded.
+          4. Trigger \`release-dryrun.yml\` manually to confirm the new tarball URLs resolve and the bundled dylib loads across all four platforms.${ABI_WARNING}"
+
+          if [ "$COUNT" = "0" ]; then
+            gh issue create \
+              --title "$TITLE" \
+              --label "dependency-update" \
+              --body "$BODY"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, development]
   pull_request:
-    branches: [main]
+    branches: [main, development]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -52,7 +52,7 @@ jobs:
         with:
           shared-key: "rust"
       - run: sudo apt-get update && sudo apt-get install -y libasound2-dev
-      - run: cargo test -p decibri
+      - run: cargo test-decibri
 
   test-node:
     name: Node.js Tests

--- a/.github/workflows/release-dryrun.yml
+++ b/.github/workflows/release-dryrun.yml
@@ -3,6 +3,12 @@ name: Release Dry Run
 on:
   workflow_dispatch:
 
+# Must stay in sync with release.yml's ORT_VERSION. If the two diverge, dryrun
+# is no longer a valid pre-release validation gate. See the upgrade procedure
+# in the workspace Cargo.toml maintainer comment.
+env:
+  ORT_VERSION: 1.24.4
+
 jobs:
   build:
     name: Build ${{ matrix.target }}
@@ -13,14 +19,26 @@ jobs:
         include:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+            artifact: win32-x64-msvc
+            ort_platform_slug: win-x64
+            ort_ext: zip
           - os: macos-14
             target: aarch64-apple-darwin
+            artifact: darwin-arm64
+            ort_platform_slug: osx-arm64
+            ort_ext: tgz
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             setup: sudo apt-get update && sudo apt-get install -y libasound2-dev
+            artifact: linux-x64-gnu
+            ort_platform_slug: linux-x64
+            ort_ext: tgz
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             setup: sudo apt-get update && sudo apt-get install -y libasound2-dev
+            artifact: linux-arm64-gnu
+            ort_platform_slug: linux-aarch64
+            ort_ext: tgz
 
     steps:
       - uses: actions/checkout@v6
@@ -40,6 +58,76 @@ jobs:
       - name: Install npm dependencies
         run: cd npm/decibri && npm install --ignore-optional
 
+      - name: Verify ONNX Runtime tarball availability
+        shell: bash
+        run: |
+          URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}.${{ matrix.ort_ext }}"
+          echo "Verifying: $URL"
+          if ! curl -sIfL --retry 3 --retry-delay 2 -o /dev/null "$URL"; then
+            echo "ERROR: expected ONNX Runtime tarball not available at $URL"
+            echo "This may mean Microsoft renamed release assets, delayed a release,"
+            echo "or the pinned ORT_VERSION no longer exists upstream."
+            echo "Check: https://github.com/microsoft/onnxruntime/releases/tag/v${ORT_VERSION}"
+            exit 1
+          fi
+          echo "OK: tarball is available"
+
+      - name: Download and extract ONNX Runtime (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}.tgz"
+          curl -sL --retry 3 --retry-delay 2 -o ort.tgz "$URL"
+          tar -xzf ort.tgz
+          SRC="onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}"
+          cp -L "$SRC/lib/libonnxruntime.${ORT_VERSION}.dylib" npm/decibri/libonnxruntime.dylib
+
+      - name: Verify libonnxruntime.dylib codesign (macOS, diagnostic)
+        if: runner.os == 'macOS'
+        continue-on-error: true
+        # Non-gating diagnostic — byte-identical to the same step in
+        # release.yml. Surfaces codesign's assessment of the renamed
+        # dylib in CI logs before a release.
+        run: codesign -v --verbose=2 npm/decibri/libonnxruntime.dylib
+
+      - name: Download and extract ONNX Runtime (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}.tgz"
+          curl -sL --retry 3 --retry-delay 2 -o ort.tgz "$URL"
+          tar -xzf ort.tgz
+          SRC="onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}"
+          cp -L "$SRC/lib/libonnxruntime.so" npm/decibri/libonnxruntime.so
+          cp "$SRC/lib/libonnxruntime_providers_shared.so" npm/decibri/
+
+      - name: Download and extract ONNX Runtime (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ProgressPreference = 'SilentlyContinue'
+          $url = "https://github.com/microsoft/onnxruntime/releases/download/v$env:ORT_VERSION/onnxruntime-${{ matrix.ort_platform_slug }}-$env:ORT_VERSION.zip"
+          Invoke-WebRequest -Uri $url -OutFile ort.zip -MaximumRetryCount 3 -RetryIntervalSec 2
+          Expand-Archive -Path ort.zip -DestinationPath .
+          $src = "onnxruntime-${{ matrix.ort_platform_slug }}-$env:ORT_VERSION"
+          Copy-Item "$src/lib/onnxruntime.dll" npm/decibri/
+
+      - name: Inspect onnxruntime.dll imports (Windows, diagnostic)
+        if: runner.os == 'Windows'
+        continue-on-error: true
+        shell: pwsh
+        # Non-gating diagnostic — byte-identical to the same step in
+        # release.yml. Logs the DLL's import table so peer-DLL
+        # dependencies are visible pre-release.
+        run: |
+          $dumpbin = Get-ChildItem "C:\Program Files*\Microsoft Visual Studio\*\*\VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $dumpbin) {
+            Write-Host "dumpbin.exe not found under the Visual Studio install path"
+            exit 1
+          }
+          Write-Host "Using dumpbin: $($dumpbin.FullName)"
+          & $dumpbin.FullName /imports npm/decibri/onnxruntime.dll
+
       - name: Build native addon
         shell: bash
         run: |
@@ -53,7 +141,13 @@ jobs:
 
       - name: Verify binary exists
         shell: bash
-        run: ls -la npm/decibri/decibri.*.node
+        run: |
+          ls -la npm/decibri/decibri.*.node
+          # Verify the bundled ORT dylib was extracted next to the addon.
+          # Glob pattern matches whichever platform-specific file exists.
+          ls -la npm/decibri/libonnxruntime.* npm/decibri/onnxruntime.dll 2>/dev/null || \
+            ls -la npm/decibri/libonnxruntime.* 2>/dev/null || \
+            ls -la npm/decibri/onnxruntime.dll
 
       - name: Smoke test require()
         shell: bash
@@ -61,7 +155,175 @@ jobs:
 
       - uses: actions/upload-artifact@v7
         with:
-          name: decibri-${{ matrix.target }}
-          path: npm/decibri/decibri.*.node
+          name: decibri-${{ matrix.artifact }}
+          # Matches .node + whichever platform-specific ORT files exist.
+          # Non-matching patterns are silently skipped per upload-artifact
+          # v7 semantics; if-no-files-found still catches real failures
+          # because the .node pattern always matches.
+          path: |
+            npm/decibri/decibri.*.node
+            npm/decibri/libonnxruntime.dylib
+            npm/decibri/libonnxruntime.so
+            npm/decibri/libonnxruntime_providers_shared.so
+            npm/decibri/onnxruntime.dll
           retention-days: 7
           if-no-files-found: error
+
+      - name: Upload napi loader (Linux x64 only)
+        if: matrix.artifact == 'linux-x64-gnu'
+        uses: actions/upload-artifact@v7
+        with:
+          name: decibri-loader
+          path: |
+            npm/decibri/index.js
+            npm/decibri/index.d.ts
+          retention-days: 7
+          if-no-files-found: error
+
+  stage-and-verify:
+    name: Stage artifacts and verify package contents
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: artifacts/
+
+      - name: Debug artifact structure
+        run: find artifacts/ -type f | sort
+
+      # This staging block is intentionally BYTE-IDENTICAL to the "Stage
+      # platform binaries" step in .github/workflows/release.yml. The whole
+      # point of stage-and-verify is to catch bugs in release.yml's staging
+      # logic, which requires the two to stay in sync. If you update one,
+      # update the other.
+      - name: Stage platform binaries
+        shell: bash
+        run: |
+          # macOS (darwin-arm64)
+          find artifacts/decibri-darwin-arm64 -name "decibri.darwin-arm64.node" -exec cp {} npm/platform-darwin-arm64/ \;
+          find artifacts/decibri-darwin-arm64 -name "libonnxruntime.dylib"      -exec cp {} npm/platform-darwin-arm64/ \;
+          # Linux x64
+          find artifacts/decibri-linux-x64-gnu -name "decibri.linux-x64-gnu.node"         -exec cp {} npm/platform-linux-x64-gnu/ \;
+          find artifacts/decibri-linux-x64-gnu -name "libonnxruntime.so"                  -exec cp {} npm/platform-linux-x64-gnu/ \;
+          find artifacts/decibri-linux-x64-gnu -name "libonnxruntime_providers_shared.so" -exec cp {} npm/platform-linux-x64-gnu/ \;
+          # Linux arm64
+          find artifacts/decibri-linux-arm64-gnu -name "decibri.linux-arm64-gnu.node"         -exec cp {} npm/platform-linux-arm64-gnu/ \;
+          find artifacts/decibri-linux-arm64-gnu -name "libonnxruntime.so"                    -exec cp {} npm/platform-linux-arm64-gnu/ \;
+          find artifacts/decibri-linux-arm64-gnu -name "libonnxruntime_providers_shared.so"   -exec cp {} npm/platform-linux-arm64-gnu/ \;
+          # Windows
+          find artifacts/decibri-win32-x64-msvc -name "decibri.win32-x64-msvc.node" -exec cp {} npm/platform-win32-x64-msvc/ \;
+          find artifacts/decibri-win32-x64-msvc -name "onnxruntime.dll"             -exec cp {} npm/platform-win32-x64-msvc/ \;
+
+      - name: Verify staged binaries
+        run: |
+          ls -la npm/platform-win32-x64-msvc/decibri.*.node   npm/platform-win32-x64-msvc/onnxruntime.dll
+          ls -la npm/platform-darwin-arm64/decibri.*.node     npm/platform-darwin-arm64/libonnxruntime.dylib
+          ls -la npm/platform-linux-x64-gnu/decibri.*.node    npm/platform-linux-x64-gnu/libonnxruntime.so    npm/platform-linux-x64-gnu/libonnxruntime_providers_shared.so
+          ls -la npm/platform-linux-arm64-gnu/decibri.*.node  npm/platform-linux-arm64-gnu/libonnxruntime.so  npm/platform-linux-arm64-gnu/libonnxruntime_providers_shared.so
+
+      - name: Stage napi loader
+        run: |
+          cp artifacts/decibri-loader/index.js npm/decibri/
+          cp artifacts/decibri-loader/index.d.ts npm/decibri/
+
+      # Name matches release.yml's "Copy README for npm package" step so the
+      # two workflows remain byte-identical on README handling.
+      - name: Copy README for npm package
+        run: cp README.md npm/decibri/README.md
+
+      - name: Verify pack contents for each package
+        shell: bash
+        run: |
+          set -o pipefail
+          FAIL=0
+
+          verify_pack() {
+            local pkg_dir="$1"
+            local label="$2"
+            shift 2
+            # Remaining args: required files prefixed with ':',
+            #                 forbidden regex patterns prefixed with '~'.
+            local required=()
+            local forbidden=()
+            for arg in "$@"; do
+              case "$arg" in
+                :*) required+=("${arg#:}") ;;
+                ~*) forbidden+=("${arg#~}") ;;
+              esac
+            done
+
+            echo ""
+            echo "=== $label ($pkg_dir) ==="
+            local files
+            files=$(cd "$pkg_dir" && npm pack --dry-run --json | jq -r '.[0].files[].path')
+            echo "Would pack:"
+            echo "$files" | sort | sed 's/^/  * /'
+
+            for f in "${required[@]}"; do
+              if echo "$files" | grep -Fxq "$f"; then
+                echo "  [OK]   required present: $f"
+              else
+                echo "  [FAIL] required MISSING: $f"
+                FAIL=1
+              fi
+            done
+
+            for p in "${forbidden[@]}"; do
+              local matches
+              matches=$(echo "$files" | grep -E "$p" || true)
+              if [ -n "$matches" ]; then
+                echo "  [FAIL] forbidden pattern '$p' matched:"
+                echo "$matches" | sed 's/^/         /'
+                FAIL=1
+              else
+                echo "  [OK]   forbidden absent: $p"
+              fi
+            done
+          }
+
+          # Main package: should carry JS source, models, README, napi loader;
+          # must NOT carry the native .node file or any ORT dylib (those belong
+          # in the platform packages).
+          verify_pack npm/decibri "main package (decibri)" \
+            :package.json \
+            :README.md \
+            :src/decibri.js \
+            :index.js \
+            :models/silero_vad.onnx \
+            '~\.node$' \
+            '~onnxruntime'
+
+          verify_pack npm/platform-darwin-arm64 "@decibri/decibri-darwin-arm64" \
+            :decibri.darwin-arm64.node \
+            :libonnxruntime.dylib
+
+          verify_pack npm/platform-linux-x64-gnu "@decibri/decibri-linux-x64-gnu" \
+            :decibri.linux-x64-gnu.node \
+            :libonnxruntime.so \
+            :libonnxruntime_providers_shared.so
+
+          verify_pack npm/platform-linux-arm64-gnu "@decibri/decibri-linux-arm64-gnu" \
+            :decibri.linux-arm64-gnu.node \
+            :libonnxruntime.so \
+            :libonnxruntime_providers_shared.so
+
+          verify_pack npm/platform-win32-x64-msvc "@decibri/decibri-win32-x64-msvc" \
+            :decibri.win32-x64-msvc.node \
+            :onnxruntime.dll
+
+          echo ""
+          if [ "$FAIL" -ne 0 ]; then
+            echo "================================================"
+            echo "  VERIFICATION FAILED - not publish-ready"
+            echo "================================================"
+            exit 1
+          fi
+          echo "All 5 packages pass verification."

--- a/.github/workflows/release-dryrun.yml
+++ b/.github/workflows/release-dryrun.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Verify libonnxruntime.dylib codesign (macOS, diagnostic)
         if: runner.os == 'macOS'
         continue-on-error: true
-        # Non-gating diagnostic — byte-identical to the same step in
+        # Non-gating diagnostic. Byte-identical to the same step in
         # release.yml. Surfaces codesign's assessment of the renamed
         # dylib in CI logs before a release.
         run: codesign -v --verbose=2 npm/decibri/libonnxruntime.dylib
@@ -116,7 +116,7 @@ jobs:
         if: runner.os == 'Windows'
         continue-on-error: true
         shell: pwsh
-        # Non-gating diagnostic — byte-identical to the same step in
+        # Non-gating diagnostic. Byte-identical to the same step in
         # release.yml. Logs the DLL's import table so peer-DLL
         # dependencies are visible pre-release.
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,7 @@ jobs:
           # cp -L follows the symlink chain (libonnxruntime.so -> .so.1 ->
           # .so.1.24.4) and copies the real file as libonnxruntime.so. This
           # avoids repeating the version in the filename. libonnxruntime_
-          # providers_shared.so keeps its exact upstream name — the main
+          # providers_shared.so keeps its exact upstream name. The main
           # dylib dlopens it by that basename via $ORIGIN RUNPATH.
           cp -L "$SRC/lib/libonnxruntime.so" npm/decibri/libonnxruntime.so
           cp "$SRC/lib/libonnxruntime_providers_shared.so" npm/decibri/
@@ -191,7 +191,7 @@ jobs:
           Invoke-WebRequest -Uri $url -OutFile ort.zip -MaximumRetryCount 3 -RetryIntervalSec 2
           Expand-Archive -Path ort.zip -DestinationPath .
           $src = "onnxruntime-${{ matrix.ort_platform_slug }}-$env:ORT_VERSION"
-          # Upstream DLL is already named onnxruntime.dll — no rename.
+          # Upstream DLL is already named onnxruntime.dll. No rename.
           Copy-Item "$src/lib/onnxruntime.dll" npm/decibri/
 
       - name: Inspect onnxruntime.dll imports (Windows, diagnostic)
@@ -322,7 +322,7 @@ jobs:
           ls -la npm/decibri/index.d.ts
 
       # Publish platform packages FIRST (main package depends on them)
-      # Uses npm Trusted Publishing (OIDC) — no token needed, provenance is automatic
+      # Uses npm Trusted Publishing (OIDC). No token needed, provenance is automatic
       - name: Publish @decibri/decibri-win32-x64-msvc
         run: cd npm/platform-win32-x64-msvc && npm publish --access public
 
@@ -352,7 +352,7 @@ jobs:
         # v3.1.0-beta.1, etc). Semver defines pre-releases as anything
         # containing `-` after the version. Stable tags like v3.1.0 contain
         # no `-` so the condition is true and the step runs. Safety net for
-        # any future RC flows — under Path A (direct stable publish) this
+        # any future RC flows. Under Path A (direct stable publish) this
         # is a no-op for v3.1.0.
         if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
         run: cargo publish -p decibri

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,79 @@ permissions:
   id-token: write
   attestations: write
 
+# Single source of truth for the bundled ONNX Runtime version, read by
+# every platform job's preflight/download step. Also parsed by the
+# check-onnxruntime job in .github/workflows/check-upstream.yml via:
+#   grep -oP '^\s+ORT_VERSION:\s*\K[0-9]+\.[0-9]+\.[0-9]+' release.yml
+# Updating this value is step 3 of the ort-crate upgrade procedure
+# documented in the workspace Cargo.toml maintainer comment.
+env:
+  ORT_VERSION: 1.24.4
+
 jobs:
+  preflight:
+    name: Preflight (version match)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Assert tag version matches workspace and package manifests
+        shell: bash
+        run: |
+          # Tag form: refs/tags/v3.1.0 -> TAG_VERSION=3.1.0
+          # Pre-release tags (v3.1.0-rc.1) are allowed; the suffix is preserved
+          # and must match across every manifest if used.
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "Tag version: ${TAG_VERSION}"
+
+          # Workspace Cargo.toml: the `[workspace.package]` block's
+          # `version = "..."` line sits at column 0. Per-crate Cargo.toml
+          # files use `version.workspace = true` and have no literal version
+          # string, so the first unindented `version = "..."` match is
+          # always the workspace version.
+          CARGO_VERSION=$(grep -oP '^version\s*=\s*"\K[^"]+' Cargo.toml | head -1)
+          if [ -z "$CARGO_VERSION" ]; then
+            echo "ERROR: could not extract workspace version from Cargo.toml"
+            exit 1
+          fi
+          echo "Cargo.toml workspace version: ${CARGO_VERSION}"
+
+          MISMATCH=0
+          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+            echo "ERROR: tag v${TAG_VERSION} does not match Cargo.toml version ${CARGO_VERSION}"
+            MISMATCH=1
+          fi
+
+          # Every package.json must match the tag. jq is preinstalled on
+          # ubuntu-latest runners; no setup needed.
+          for pkg in \
+            npm/decibri/package.json \
+            npm/platform-darwin-arm64/package.json \
+            npm/platform-linux-arm64-gnu/package.json \
+            npm/platform-linux-x64-gnu/package.json \
+            npm/platform-win32-x64-msvc/package.json
+          do
+            PKG_VERSION=$(jq -r .version "$pkg")
+            echo "${pkg}: ${PKG_VERSION}"
+            if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+              echo "ERROR: tag v${TAG_VERSION} does not match ${pkg} version ${PKG_VERSION}"
+              MISMATCH=1
+            fi
+          done
+
+          if [ "$MISMATCH" = "1" ]; then
+            echo ""
+            echo "Release aborted: version mismatch detected."
+            echo "Bump Cargo.toml and all 5 package.json files to ${TAG_VERSION}, then re-tag."
+            exit 1
+          fi
+
+          echo "OK: tag, Cargo.toml, and all 5 package.json files agree on ${TAG_VERSION}"
+
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    needs: preflight
     strategy:
       fail-fast: false
       matrix:
@@ -21,17 +90,25 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: win32-x64-msvc
+            ort_platform_slug: win-x64
+            ort_ext: zip
           - os: macos-14
             target: aarch64-apple-darwin
             artifact: darwin-arm64
+            ort_platform_slug: osx-arm64
+            ort_ext: tgz
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact: linux-x64-gnu
             setup: sudo apt-get update && sudo apt-get install -y libasound2-dev
+            ort_platform_slug: linux-x64
+            ort_ext: tgz
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             artifact: linux-arm64-gnu
             setup: sudo apt-get update && sudo apt-get install -y libasound2-dev
+            ort_platform_slug: linux-aarch64
+            ort_ext: tgz
 
     steps:
       - uses: actions/checkout@v6
@@ -50,6 +127,94 @@ jobs:
 
       - name: Install npm dependencies
         run: cd npm/decibri && npm install --ignore-optional
+
+      - name: Verify ONNX Runtime tarball availability
+        shell: bash
+        run: |
+          URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}.${{ matrix.ort_ext }}"
+          echo "Verifying: $URL"
+          if ! curl -sIfL --retry 3 --retry-delay 2 -o /dev/null "$URL"; then
+            echo "ERROR: expected ONNX Runtime tarball not available at $URL"
+            echo "This may mean Microsoft renamed release assets, delayed a release,"
+            echo "or the pinned ORT_VERSION no longer exists upstream."
+            echo "Check: https://github.com/microsoft/onnxruntime/releases/tag/v${ORT_VERSION}"
+            exit 1
+          fi
+          echo "OK: tarball is available"
+
+      - name: Download and extract ONNX Runtime (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}.tgz"
+          curl -sL --retry 3 --retry-delay 2 -o ort.tgz "$URL"
+          tar -xzf ort.tgz
+          SRC="onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}"
+          # Upstream ships libonnxruntime.<version>.dylib; rename to unversioned
+          # to match the JS wrapper's PLATFORM_DYLIB table expectation.
+          cp -L "$SRC/lib/libonnxruntime.${ORT_VERSION}.dylib" npm/decibri/libonnxruntime.dylib
+
+      - name: Verify libonnxruntime.dylib codesign (macOS, diagnostic)
+        if: runner.os == 'macOS'
+        continue-on-error: true
+        # Non-gating: `cp -L` on a real file (not symlink) preserves the
+        # signed bytes, but does not preserve the original filename the
+        # signature may be scoped to. Microsoft's upstream dylib is signed;
+        # we want to see in the log whether the renamed file still
+        # validates. On failure the step is marked red but the workflow
+        # proceeds. Revisit making this gating once we have data from
+        # several releases.
+        run: codesign -v --verbose=2 npm/decibri/libonnxruntime.dylib
+
+      - name: Download and extract ONNX Runtime (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}.tgz"
+          curl -sL --retry 3 --retry-delay 2 -o ort.tgz "$URL"
+          tar -xzf ort.tgz
+          SRC="onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}"
+          # cp -L follows the symlink chain (libonnxruntime.so -> .so.1 ->
+          # .so.1.24.4) and copies the real file as libonnxruntime.so. This
+          # avoids repeating the version in the filename. libonnxruntime_
+          # providers_shared.so keeps its exact upstream name — the main
+          # dylib dlopens it by that basename via $ORIGIN RUNPATH.
+          cp -L "$SRC/lib/libonnxruntime.so" npm/decibri/libonnxruntime.so
+          cp "$SRC/lib/libonnxruntime_providers_shared.so" npm/decibri/
+
+      - name: Download and extract ONNX Runtime (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ProgressPreference = 'SilentlyContinue'  # speeds up Invoke-WebRequest
+          $url = "https://github.com/microsoft/onnxruntime/releases/download/v$env:ORT_VERSION/onnxruntime-${{ matrix.ort_platform_slug }}-$env:ORT_VERSION.zip"
+          Invoke-WebRequest -Uri $url -OutFile ort.zip -MaximumRetryCount 3 -RetryIntervalSec 2
+          Expand-Archive -Path ort.zip -DestinationPath .
+          $src = "onnxruntime-${{ matrix.ort_platform_slug }}-$env:ORT_VERSION"
+          # Upstream DLL is already named onnxruntime.dll — no rename.
+          Copy-Item "$src/lib/onnxruntime.dll" npm/decibri/
+
+      - name: Inspect onnxruntime.dll imports (Windows, diagnostic)
+        if: runner.os == 'Windows'
+        continue-on-error: true
+        shell: pwsh
+        # Non-gating: `dumpbin` ships with MSVC under the Visual Studio
+        # install path and is NOT on the default PATH on windows-latest
+        # runners. We locate it via a glob over the VS install directory
+        # rather than pulling in a third-party dev-env action for a
+        # one-shot inspection. Output (the DLL's import table) goes to
+        # the log so unexpected DLL dependencies (odd MSVC runtime,
+        # Windows SDK DLLs not on a user's box, etc) are visible before
+        # users hit "cannot find library X" at runtime. On failure the
+        # step is marked red but the workflow proceeds.
+        run: |
+          $dumpbin = Get-ChildItem "C:\Program Files*\Microsoft Visual Studio\*\*\VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $dumpbin) {
+            Write-Host "dumpbin.exe not found under the Visual Studio install path"
+            exit 1
+          }
+          Write-Host "Using dumpbin: $($dumpbin.FullName)"
+          & $dumpbin.FullName /imports npm/decibri/onnxruntime.dll
 
       - name: Build native addon
         shell: bash
@@ -74,7 +239,16 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: decibri-${{ matrix.artifact }}
-          path: npm/decibri/decibri.*.node
+          # Only one of the libonnxruntime.* / onnxruntime.dll patterns matches
+          # per platform; non-matching patterns are silently skipped. The
+          # `.node` pattern always matches, so `if-no-files-found: error`
+          # still correctly catches the real failure (missing build output).
+          path: |
+            npm/decibri/decibri.*.node
+            npm/decibri/libonnxruntime.dylib
+            npm/decibri/libonnxruntime.so
+            npm/decibri/libonnxruntime_providers_shared.so
+            npm/decibri/onnxruntime.dll
           if-no-files-found: error
 
       - name: Upload napi loader (Linux x64 only)
@@ -115,17 +289,27 @@ jobs:
       - name: Stage platform binaries
         shell: bash
         run: |
-          find artifacts/ -name "decibri.win32-x64-msvc.node" -exec cp {} npm/platform-win32-x64-msvc/ \;
-          find artifacts/ -name "decibri.darwin-arm64.node" -exec cp {} npm/platform-darwin-arm64/ \;
-          find artifacts/ -name "decibri.linux-x64-gnu.node" -exec cp {} npm/platform-linux-x64-gnu/ \;
-          find artifacts/ -name "decibri.linux-arm64-gnu.node" -exec cp {} npm/platform-linux-arm64-gnu/ \;
+          # macOS (darwin-arm64)
+          find artifacts/decibri-darwin-arm64 -name "decibri.darwin-arm64.node" -exec cp {} npm/platform-darwin-arm64/ \;
+          find artifacts/decibri-darwin-arm64 -name "libonnxruntime.dylib"      -exec cp {} npm/platform-darwin-arm64/ \;
+          # Linux x64
+          find artifacts/decibri-linux-x64-gnu -name "decibri.linux-x64-gnu.node"         -exec cp {} npm/platform-linux-x64-gnu/ \;
+          find artifacts/decibri-linux-x64-gnu -name "libonnxruntime.so"                  -exec cp {} npm/platform-linux-x64-gnu/ \;
+          find artifacts/decibri-linux-x64-gnu -name "libonnxruntime_providers_shared.so" -exec cp {} npm/platform-linux-x64-gnu/ \;
+          # Linux arm64
+          find artifacts/decibri-linux-arm64-gnu -name "decibri.linux-arm64-gnu.node"         -exec cp {} npm/platform-linux-arm64-gnu/ \;
+          find artifacts/decibri-linux-arm64-gnu -name "libonnxruntime.so"                    -exec cp {} npm/platform-linux-arm64-gnu/ \;
+          find artifacts/decibri-linux-arm64-gnu -name "libonnxruntime_providers_shared.so"   -exec cp {} npm/platform-linux-arm64-gnu/ \;
+          # Windows
+          find artifacts/decibri-win32-x64-msvc -name "decibri.win32-x64-msvc.node" -exec cp {} npm/platform-win32-x64-msvc/ \;
+          find artifacts/decibri-win32-x64-msvc -name "onnxruntime.dll"             -exec cp {} npm/platform-win32-x64-msvc/ \;
 
       - name: Verify staged binaries
         run: |
-          ls -la npm/platform-win32-x64-msvc/decibri.*.node
-          ls -la npm/platform-darwin-arm64/decibri.*.node
-          ls -la npm/platform-linux-x64-gnu/decibri.*.node
-          ls -la npm/platform-linux-arm64-gnu/decibri.*.node
+          ls -la npm/platform-win32-x64-msvc/decibri.*.node   npm/platform-win32-x64-msvc/onnxruntime.dll
+          ls -la npm/platform-darwin-arm64/decibri.*.node     npm/platform-darwin-arm64/libonnxruntime.dylib
+          ls -la npm/platform-linux-x64-gnu/decibri.*.node    npm/platform-linux-x64-gnu/libonnxruntime.so    npm/platform-linux-x64-gnu/libonnxruntime_providers_shared.so
+          ls -la npm/platform-linux-arm64-gnu/decibri.*.node  npm/platform-linux-arm64-gnu/libonnxruntime.so  npm/platform-linux-arm64-gnu/libonnxruntime_providers_shared.so
 
       - name: Stage napi loader
         run: |
@@ -164,6 +348,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev
 
       - name: Publish to crates.io
+        # Skip crates.io publish for any pre-release tag (v3.1.0-rc.1,
+        # v3.1.0-beta.1, etc). Semver defines pre-releases as anything
+        # containing `-` after the version. Stable tags like v3.1.0 contain
+        # no `-` so the condition is true and the step runs. Safety net for
+        # any future RC flows — under Path A (direct stable publish) this
+        # is a no-op for v3.1.0.
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
         run: cargo publish -p decibri
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,84 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-04-22
+
+Internal rearchitecture: ONNX Runtime is now loaded dynamically at runtime
+instead of embedded statically at build time. Public Node.js and browser
+APIs are unchanged. Direct Rust crate consumers see a behaviour change;
+see migration notes below.
+
+### Changed
+
+- ORT integration switched from `ort/download-binaries` to `ort/load-dynamic`.
+  npm platform packages now bundle the ONNX Runtime shared library alongside
+  the native addon. No change to `npm install decibri` workflow or to
+  Decibri construction.
+- Silero VAD now loads ONNX Runtime dynamically from the bundled shared
+  library inside the installed platform package. Path resolution is
+  automatic; the `ORT_DYLIB_PATH` environment variable is honoured as a
+  developer escape hatch when set before Node.js starts.
+- Bundled ONNX Runtime pinned to 1.24.4 (matches `ort 2.0.0-rc.12`'s
+  `api-24` ABI target).
+- Native addon size reduced from ~20 MB (3.0.x) to ~817 KB on Windows x64.
+  ORT runtime now shipped separately as a ~13.5 MB bundled dylib inside
+  the platform package. Net platform package size roughly unchanged, with
+  better separation of concerns.
+- Error message text in `decibri-*` error variants has been normalized
+  for style consistency (em-dashes replaced with sentence splits). The
+  error message prefixes (e.g., `"device index out of range"`) are
+  unchanged, so consumers matching those prefixes are unaffected.
+  Consumers matching full error message strings may need to update.
+
+### Added
+
+- Cargo features on the `decibri` crate for direct Rust consumers:
+  `ort-load-dynamic` (default), `ort-download-binaries` (opt-in, restores
+  3.0.x zero-config build behaviour), and execution-provider passthroughs
+  `coreml`, `cuda`, `directml`, `rocm` (off by default).
+- Rust unit tests for device enumeration (`is_default` correctness under
+  duplicate display names).
+- Release pipeline hardening: version-match preflight, `curl --retry` on
+  ORT downloads, macOS code-signature verification, Windows DLL imports
+  inspection, stage-and-verify packaging validation in release-dryrun.
+- Upstream dependency monitoring for Microsoft's ONNX Runtime releases
+  (notification-only; guards against ABI mismatch upgrades).
+
+### Fixed
+
+- Issue #14: when two audio devices share a display name (e.g. two USB
+  microphones both reporting "Microphone"), both were previously marked
+  `is_default: true`. Now uses cpal 0.17's `Device::id()` for stable
+  per-host device identity (WASAPI endpoint ID, CoreAudio UID, ALSA
+  PCM ID). Fix applies to both input and output device enumeration.
+
+### Migration notes for direct Rust crate consumers
+
+If you depend on `decibri` directly via `cargo add decibri` and use the
+`vad` feature:
+
+- **Option 1 (recommended for zero-config builds):** pin with
+  `--features ort-download-binaries` on the dependency, which restores
+  the 3.0.x behaviour (ORT downloaded at build time, embedded statically).
+- **Option 2 (recommended for production deployments):** keep default
+  features and either set `ORT_DYLIB_PATH=/path/to/libonnxruntime.so`
+  before first use, or call `ort::init_from(path).commit()` at startup,
+  or pass `ort_library_path` on `VadConfig` when constructing `SileroVad`.
+
+Known limitation: ONNX Runtime is initialized once per process. Multiple
+`Decibri`/`SileroVad` instances constructed with different `ort_library_path`
+values will silently use the first-constructed instance's path. Pick one
+path and use it consistently.
+
+Direct consumers using only `capture`, `output`, `denoise`, or `gain`
+features (no `vad`) are unaffected.
+
+### Internal
+
+- `ort` crate version unchanged at `2.0.0-rc.12`.
+- `tls-native` ORT feature removed (was only required for `download-binaries`'
+  HTTPS fetch).
+
 ## [3.0.0] - 2026-04-11
 
 Complete rewrite from C++ (PortAudio) to Rust (cpal). One unified package for Node.js and browsers. Version jumps from 1.0.0 to 3.0.0 because this release replaces both `decibri` (v1) and `decibri-web` (v0.1.1). v2.x was never published.
@@ -47,5 +125,6 @@ Initial release. C++ native addon wrapping PortAudio with pre-built binaries.
 - Int16 PCM output (little-endian)
 - Source build fallback via node-gyp
 
+[3.1.0]: https://github.com/decibri/decibri/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/decibri/decibri/compare/v1.0.0...v3.0.0
 [1.0.0]: https://github.com/analyticsinmotion/decibri/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,10 +84,10 @@ To build from source you will need:
 
 ### Workspace layout
 
-- `crates/decibri/` — Rust crate
-- `bindings/node/` — Node.js bindings
-- `npm/decibri/` — JavaScript package (Node.js + browser)
-- `npm/platform-*/` — platform-specific binary packages
+- `crates/decibri/`: Rust crate
+- `bindings/node/`: Node.js bindings
+- `npm/decibri/`: JavaScript package (Node.js + browser)
+- `npm/platform-*/`: platform-specific binary packages
 
 ### Reporting a bug
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,16 +32,14 @@ There are multiple ways you can contribute to this project:
 
 ### Prerequisites
 
-decibri is built in Rust with Node.js bindings via napi-rs. To build from source you will need:
+To build from source you will need:
 
 - **Rust** (latest stable) via [rustup](https://rustup.rs/)
 - **Node.js 20 or later**
-- Platform-specific audio development headers:
-  - **Windows**: no extra dependencies (cpal uses WASAPI via the Windows SDK)
-  - **macOS**: no extra dependencies (cpal uses CoreAudio via the system SDK)
-  - **Linux**: `libasound2-dev` (`sudo apt-get install libasound2-dev`)
-
-You do NOT need Python, node-gyp, or a C/C++ compiler toolchain. The previous v1.x C++/PortAudio implementation has been replaced by a native Rust implementation using [cpal](https://crates.io/crates/cpal).
+- Platform-specific dependencies:
+  - **Windows**: none
+  - **macOS**: none
+  - **Linux**: `sudo apt-get install libasound2-dev`
 
 ### Setting up the development environment
 
@@ -54,7 +52,7 @@ You do NOT need Python, node-gyp, or a C/C++ compiler toolchain. The previous v1
 2. Build the Rust crate and run its tests:
    ```bash
    cargo build --workspace
-   cargo test -p decibri
+   cargo test-decibri
    ```
 
 3. Build the Node.js native addon:
@@ -63,14 +61,12 @@ You do NOT need Python, node-gyp, or a C/C++ compiler toolchain. The previous v1
    npm install --ignore-optional
    npm run build
    ```
-   The `--ignore-optional` flag skips the prebuilt platform packages (which only exist on npm) and forces a local build via napi-rs.
 
 4. Run the CI-safe Node.js test suite (no hardware required):
    ```bash
    cd ../..
    node tests/test-ci.js
    ```
-   This runs approximately 38 static assertions that verify the module loads, error messages are correct, and the API surface is intact.
 
 5. (Optional) Run the live capture, output, and VAD tests if you have a microphone and speakers connected:
    ```bash
@@ -86,15 +82,12 @@ You do NOT need Python, node-gyp, or a C/C++ compiler toolchain. The previous v1
    npx vitest run
    ```
 
-### Architecture overview
+### Workspace layout
 
-The project is a Cargo workspace with three layers:
-
-- **Rust crate** (`crates/decibri/`): Core audio capture, playback, and VAD logic built on [cpal](https://crates.io/crates/cpal) and [ort](https://crates.io/crates/ort). Published to [crates.io](https://crates.io/crates/decibri) as the `decibri` crate.
-- **Node.js bindings** (`bindings/node/`): napi-rs wrapper exposing the Rust crate to Node.js. Produces platform-specific `.node` binaries (Windows x64, macOS ARM64, Linux x64, Linux ARM64).
-- **JavaScript API** (`npm/decibri/src/`): Thin JavaScript layer wrapping the native addon as Node.js Readable and Writable streams. Includes browser support via conditional exports (`npm/decibri/src/browser/`).
-
-Platform-specific packages are published under the `@decibri` scope (`@decibri/decibri-win32-x64-msvc`, etc.) and resolved automatically via npm's `optionalDependencies`.
+- `crates/decibri/` — Rust crate
+- `bindings/node/` — Node.js bindings
+- `npm/decibri/` — JavaScript package (Node.js + browser)
+- `npm/platform-*/` — platform-specific binary packages
 
 ### Reporting a bug
 
@@ -123,10 +116,11 @@ We welcome contributions from everyone interested in making decibri better. To p
 2. Create a new branch from `main` with a descriptive name that reflects your changes.
 3. Make your changes.
 4. Test your changes thoroughly:
-   - `cargo test -p decibri` for Rust changes
+   - `cargo test-decibri` for Rust changes
    - `cd npm/decibri && npm run build && cd ../.. && node tests/test-ci.js` for Node.js binding changes
    - `npx vitest run` for browser-side changes
    - Live hardware tests if your change affects capture or playback behavior
+   - Update `npm/decibri/src/decibri.d.ts` if your change affects the public API surface
 5. Run the linters:
    - `cargo clippy --workspace -- -D warnings`
    - `cargo fmt --all -- --check`
@@ -135,13 +129,6 @@ We welcome contributions from everyone interested in making decibri better. To p
 8. Open a pull request against the `main` branch of this repository. Include a description of your changes, the reasons for them, and the benefits they provide.
 
 Our team will review your PR and provide feedback. We may ask for additional changes, so please be prepared to iterate before merging.
-
-### Important notes for native code changes
-
-- Changes to `crates/decibri/src/` or `bindings/node/src/` require rebuilding the native addon. Run `cd npm/decibri && npm run build` to regenerate the `.node` file and the napi-generated `index.js` loader.
-- Prebuilt platform binaries for all four supported targets (Windows x64, macOS ARM64, Linux x64, Linux ARM64) are produced by the CI pipeline on release tags. You do not need to produce prebuilt binaries for a PR.
-- If your change affects the public API surface, please update both the Rust crate docs and `npm/decibri/src/decibri.d.ts` to match.
-- Run `cargo fmt --all` before committing to ensure consistent formatting. CI enforces formatting via `cargo fmt --all -- --check`.
 
 ### CI pipeline
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,44 @@ dasp_sample = "0.11"
 thiserror = "2"
 parking_lot = "0.12"
 crossbeam-channel = "0.5"
-ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "download-binaries", "tls-native"] }
+# ort 2.0.0-rc.12 targets ONNX Runtime C API version 24 (ORT_API_VERSION = 24).
+# We bundle ONNX Runtime 1.24.4 tarballs into each npm platform package.
+# Verified via:
+#   - https://raw.githubusercontent.com/pykeio/ort/v2.0.0-rc.12/ort-sys/src/version.rs
+#   - https://ort.pyke.io/setup/multiversion
+#   - https://github.com/microsoft/onnxruntime/releases/tag/v1.24.1 (ORT_API_VERSION bump)
+#
+# Feature rationale:
+#   - `std`:     required for non-no_std targets (all of ours).
+#   - `api-24`:  matches the ORT 1.24.x ABI we bundle in npm platform packages.
+#                Must be kept in sync with the bundled ORT tarball version.
+#                If omitted, ort silently falls back to api-17 (the baseline) and its
+#                own EP modules fail to compile against the older OrtApi struct.
+# We deliberately exclude ort's other defaults (`download-binaries`, `tls-native`,
+# `copy-dylibs`, `ndarray`, `tracing`) because:
+#   - `download-binaries` / `tls-native` / `copy-dylibs` are the old embedding path
+#     we're migrating away from in 3.1.0 (available opt-in via
+#     `ort-download-binaries` feature on crates/decibri for pure-Rust consumers).
+#   - `ndarray` / `tracing` are optional integrations decibri doesn't use.
+#
+# Distribution mode (load-dynamic vs download-binaries) is selected by crates/decibri
+# via the `ort-load-dynamic` / `ort-download-binaries` features.
+#
+# When upgrading the ort crate (e.g. 2.0.0-rc.12 -> 2.0.0 stable -> future versions):
+#   1. Inspect the new ort's Cargo.toml `description` and `default` features for the
+#      new api-N (pyke bumps the default with each minor ORT target). Update the
+#      `api-24` in the `features = [...]` list below to match the new api-N.
+#   2. Update the bundled ORT version to match (e.g. api-25 -> ORT 1.25.x).
+#   3. Update the single `env.ORT_VERSION` declaration in .github/workflows/release.yml
+#      (workflow-level env block, not a per-job bash assignment — one source of truth).
+#   4. Update the `api_n` baseline in .github/workflows/check-upstream.yml.
+#   5. Re-run the release-dryrun workflow to confirm the tarball URL pattern still
+#      resolves.
+# Steps 1-4 MUST move together — leaving any one out produces an ABI mismatch that
+# either fails to compile (step 1 skipped) or fails at runtime dylib-load time
+# (step 2 skipped — pyke/ort performs a version-string check in load_dylib_from_path
+# and returns Err for too-old ORT minors).
+ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "api-24"] }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.0.0"
+version = "3.1.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/decibri/decibri"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,13 +46,13 @@ crossbeam-channel = "0.5"
 #      `api-24` in the `features = [...]` list below to match the new api-N.
 #   2. Update the bundled ORT version to match (e.g. api-25 -> ORT 1.25.x).
 #   3. Update the single `env.ORT_VERSION` declaration in .github/workflows/release.yml
-#      (workflow-level env block, not a per-job bash assignment — one source of truth).
+#      (workflow-level env block, not a per-job bash assignment: one source of truth).
 #   4. Update the `api_n` baseline in .github/workflows/check-upstream.yml.
 #   5. Re-run the release-dryrun workflow to confirm the tarball URL pattern still
 #      resolves.
-# Steps 1-4 MUST move together — leaving any one out produces an ABI mismatch that
+# Steps 1-4 MUST move together. Leaving any one out produces an ABI mismatch that
 # either fails to compile (step 1 skipped) or fails at runtime dylib-load time
-# (step 2 skipped — pyke/ort performs a version-string check in load_dylib_from_path
+# (step 2 skipped, because pyke/ort performs a version-string check in load_dylib_from_path
 # and returns Err for too-old ORT minors).
 ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "api-24"] }
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,49 @@ Requires Node.js >= 18. TypeScript definitions are bundled.
 
 ---
 
+## Using from Rust
+
+Most users want the npm package above. If you're building a Rust
+application directly against the [`decibri`](https://crates.io/crates/decibri) crate on crates.io:
+
+```bash
+cargo add decibri
+```
+
+The `vad` feature (enabled by default) uses ONNX Runtime via the
+[`ort`](https://crates.io/crates/ort) crate. From 3.1.0 onwards, `ort` is
+configured with `load-dynamic` by default, meaning ONNX Runtime is loaded
+from a shared library at runtime. Choose one of:
+
+- **Zero-config builds.** Opt into the download-binaries mode:
+
+  ```toml
+  decibri = { version = "3.1", features = ["ort-download-binaries"], default-features = false }
+  ```
+
+  Add back any other features you need (`capture`, `output`, `vad`,
+  `denoise`, `gain`). ORT is downloaded during `cargo build` and embedded
+  in your binary (the 3.0.x behaviour).
+
+- **Production deployments with bundled ORT.** Take default features,
+  then either set `ORT_DYLIB_PATH=/path/to/libonnxruntime.{so,dylib,dll}`
+  before first use, or call `ort::init_from(path).commit()` at startup.
+  ONNX Runtime is initialized once per process. If your app creates
+  multiple `SileroVad` instances with different paths, the first one
+  wins and later paths are silently ignored. Pick one path and reuse it.
+
+If you only need capture, output, or DSP (no Silero VAD), you won't pull
+in `ort` at all:
+
+```toml
+decibri = { version = "3.1", features = ["capture", "output"], default-features = false }
+```
+
+See the [`ort` crate linking docs](https://ort.pyke.io/setup/linking)
+for runtime-loading details.
+
+---
+
 ## Quick Start
 
 ### Capture audio

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -37,7 +37,7 @@ enum SampleFormat {
 ///
 /// Users who need to override ORT resolution (e.g. point at a system ORT, or
 /// A/B between bundled and custom builds) should set the `ORT_DYLIB_PATH`
-/// environment variable before Node starts — that's the supported public
+/// environment variable before Node starts. That's the supported public
 /// mechanism.
 ///
 /// If this field is `None` (the default when not injected by the wrapper),
@@ -245,7 +245,7 @@ impl DecibriBridge {
         self.running.load(Ordering::Relaxed)
     }
 
-    /// Latest VAD speech probability (0.0–1.0). Updated by pump thread.
+    /// Latest VAD speech probability (0.0 to 1.0). Updated by pump thread.
     /// Returns 0.0 if VAD is not active.
     #[napi(getter)]
     pub fn vad_probability(&self) -> f64 {

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -20,6 +20,28 @@ enum SampleFormat {
 }
 
 /// Options passed from JS constructor.
+///
+/// Note on `ort_library_path` (exposed to JS as `ortLibraryPath`): this is an
+/// internal plumbing field used by the JS wrapper in
+/// `npm/decibri/src/decibri.js`. The wrapper auto-resolves the bundled ORT
+/// dylib path via `require.resolve('@decibri/decibri-<platform>')` and passes
+/// the absolute path through to here so Rust's `ort::init_from` can load the
+/// correct library for the user's platform.
+///
+/// The field is hidden from the auto-generated TypeScript definitions via
+/// `#[napi(skip_typescript)]` so TS/JS consumers do not see `ortLibraryPath`
+/// on the public options surface. It is still marshaled at runtime, so the
+/// JS wrapper can pass it through. Rationale: adding a typed public option
+/// later is non-breaking; removing one is breaking, so we default to not
+/// exposing it until a concrete use case arises.
+///
+/// Users who need to override ORT resolution (e.g. point at a system ORT, or
+/// A/B between bundled and custom builds) should set the `ORT_DYLIB_PATH`
+/// environment variable before Node starts — that's the supported public
+/// mechanism.
+///
+/// If this field is `None` (the default when not injected by the wrapper),
+/// Rust calls `ort::init()` which honours `ORT_DYLIB_PATH`.
 #[napi(object)]
 #[derive(Default)]
 pub struct DecibriOptions {
@@ -30,6 +52,8 @@ pub struct DecibriOptions {
     pub device: Option<serde_json::Value>,
     pub vad_mode: Option<String>,
     pub model_path: Option<String>,
+    #[napi(skip_typescript)]
+    pub ort_library_path: Option<String>,
 }
 
 /// Native bridge class exposed to Node.js via napi-rs.
@@ -92,6 +116,10 @@ impl DecibriBridge {
                 model_path: std::path::PathBuf::from(model_path),
                 sample_rate,
                 threshold: 0.5, // JS wrapper controls the actual threshold
+                // Populated by the JS wrapper from require.resolve on the
+                // resolved platform package. When `None`, Rust falls through
+                // to `ort::init()` which honours the `ORT_DYLIB_PATH` env var.
+                ort_library_path: opts.ort_library_path.as_deref().map(std::path::PathBuf::from),
             };
             Some(SileroVad::new(vad_config).map_err(to_napi_error)?)
         } else {

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -119,7 +119,10 @@ impl DecibriBridge {
                 // Populated by the JS wrapper from require.resolve on the
                 // resolved platform package. When `None`, Rust falls through
                 // to `ort::init()` which honours the `ORT_DYLIB_PATH` env var.
-                ort_library_path: opts.ort_library_path.as_deref().map(std::path::PathBuf::from),
+                ort_library_path: opts
+                    .ort_library_path
+                    .as_deref()
+                    .map(std::path::PathBuf::from),
             };
             Some(SileroVad::new(vad_config).map_err(to_napi_error)?)
         } else {

--- a/crates/decibri/Cargo.toml
+++ b/crates/decibri/Cargo.toml
@@ -10,12 +10,28 @@ keywords = ["audio", "microphone", "capture", "sound", "voice"]
 categories = ["multimedia::audio"]
 
 [features]
-default = ["capture", "output", "vad", "denoise", "gain"]
+# Default stack for consumers who want the full decibri experience on Node/Python bindings.
+# `ort-load-dynamic` is the distribution mode used by npm platform packages and P3 Python wheels.
+default = ["capture", "output", "vad", "denoise", "gain", "ort-load-dynamic"]
+
+# Core feature set (unchanged from 3.0.x).
 capture = ["dep:cpal", "dep:crossbeam-channel"]
 output = ["dep:cpal", "dep:crossbeam-channel"]
 vad = ["dep:ort"]
 denoise = []
 gain = []
+
+# ORT distribution mode (mutually exclusive; pick exactly one).
+# A compile_error! guard in src/lib.rs enforces the exclusivity.
+ort-load-dynamic = ["ort?/load-dynamic"]
+ort-download-binaries = ["ort?/download-binaries", "ort?/tls-native"]
+
+# Execution-provider passthrough features. Off by default.
+# Enabled by bindings that want GPU acceleration on specific platforms.
+coreml = ["ort?/coreml"]
+cuda = ["ort?/cuda"]
+directml = ["ort?/directml"]
+rocm = ["ort?/rocm"]
 
 [dependencies]
 cpal = { workspace = true, optional = true }

--- a/crates/decibri/src/device.rs
+++ b/crates/decibri/src/device.rs
@@ -52,7 +52,7 @@ struct ComputedRow {
 /// Given a list of `(id, name, channels, sample_rate)` tuples representing
 /// enumerated devices and an optional default-device id, produce one
 /// `ComputedRow` per input with `is_default` resolved by identity comparison
-/// (NOT by name-equality — see [#14](https://github.com/decibri/decibri/issues/14)).
+/// (NOT by name-equality. See [#14](https://github.com/decibri/decibri/issues/14) for context.)
 ///
 /// Semantics:
 /// - A row's `id` of `None` (caller couldn't fetch a cpal `DeviceId` for that
@@ -295,7 +295,7 @@ pub fn resolve_output_device(selector: &DeviceSelector) -> Result<cpal::Device, 
 mod tests {
     use super::*;
 
-    // Synthetic id type for testing — any `PartialEq` works because
+    // Synthetic id type for testing. Any `PartialEq` works because
     // `compute_is_default` is generic over the id type. Using String keeps the
     // tests readable and avoids any dependency on a live cpal host.
     fn row(id: Option<&str>, name: &str) -> (Option<String>, String, u16, u32) {
@@ -321,7 +321,7 @@ mod tests {
             result[1].is_default,
             "second duplicate-named mic (matching default id) must be flagged"
         );
-        // Both rows keep their shared display name — the bug was never about
+        // Both rows keep their shared display name. The bug was never about
         // renaming devices, only about misattribution of is_default.
         assert_eq!(result[0].name, "Microphone");
         assert_eq!(result[1].name, "Microphone");

--- a/crates/decibri/src/device.rs
+++ b/crates/decibri/src/device.rs
@@ -34,45 +34,100 @@ pub enum DeviceSelector {
     Name(String),
 }
 
+/// Internal: enumerated device row with `is_default` already resolved.
+/// Used as the output of the pure `compute_is_default` helper so both input
+/// and output enumeration can share the same device-identity matching logic
+/// (and so the logic is testable without mocking `cpal::Host`).
+#[cfg(any(feature = "capture", feature = "output"))]
+struct ComputedRow {
+    index: usize,
+    name: String,
+    channels: u16,
+    sample_rate: u32,
+    is_default: bool,
+}
+
+/// Pure helper for Issue #14 fix.
+///
+/// Given a list of `(id, name, channels, sample_rate)` tuples representing
+/// enumerated devices and an optional default-device id, produce one
+/// `ComputedRow` per input with `is_default` resolved by identity comparison
+/// (NOT by name-equality — see [#14](https://github.com/decibri/decibri/issues/14)).
+///
+/// Semantics:
+/// - A row's `id` of `None` (caller couldn't fetch a cpal `DeviceId` for that
+///   device) is treated as "not default".
+/// - A `default_id` of `None` (no default device reported by the host) means
+///   no row is flagged default.
+/// - Otherwise, a row is default iff its id equals `default_id`. With a stable
+///   per-host id (WASAPI endpoint ID, CoreAudio UID, ALSA pcm_id) exactly one
+///   row matches even when multiple devices share a display name.
+///
+/// Generic over `Id: PartialEq` so unit tests can use `String` ids and verify
+/// the matching logic without depending on a live cpal host.
+#[cfg(any(feature = "capture", feature = "output"))]
+fn compute_is_default<Id: PartialEq>(
+    rows: Vec<(Option<Id>, String, u16, u32)>,
+    default_id: Option<Id>,
+) -> Vec<ComputedRow> {
+    rows.into_iter()
+        .enumerate()
+        .map(|(index, (id, name, channels, sample_rate))| {
+            let is_default = match (id.as_ref(), default_id.as_ref()) {
+                (Some(row_id), Some(default)) => row_id == default,
+                _ => false,
+            };
+            ComputedRow {
+                index,
+                name,
+                channels,
+                sample_rate,
+                is_default,
+            }
+        })
+        .collect()
+}
+
 /// Enumerate all available audio input devices.
 #[cfg(any(feature = "capture", feature = "output"))]
 pub fn enumerate_input_devices() -> Result<Vec<DeviceInfo>, DecibriError> {
     let host = cpal::default_host();
 
-    let default_device_name = host
-        .default_input_device()
-        .and_then(|d| d.description().ok())
-        .map(|desc| desc.name().to_string());
+    // Stable per-host id (WASAPI endpoint ID / CoreAudio UID / ALSA pcm_id)
+    // for the OS default device. `.id()` is fallible on rare host backends;
+    // treat a failure as "no default" rather than propagating.
+    let default_id = host.default_input_device().and_then(|d| d.id().ok());
 
     let devices = host
         .input_devices()
         .map_err(|e| DecibriError::Other(format!("Failed to enumerate devices: {e}")))?;
 
-    let mut result = Vec::new();
-    for (index, device) in devices.enumerate() {
-        let name = device
-            .description()
-            .map(|d| d.name().to_string())
-            .unwrap_or_else(|_| format!("Unknown Device {index}"));
+    let rows: Vec<(Option<cpal::DeviceId>, String, u16, u32)> = devices
+        .enumerate()
+        .map(|(index, device)| {
+            let id = device.id().ok();
+            let name = device
+                .description()
+                .map(|d| d.name().to_string())
+                .unwrap_or_else(|_| format!("Unknown Device {index}"));
+            let (channels, sample_rate) = match device.default_input_config() {
+                Ok(config) => (config.channels(), config.sample_rate()),
+                Err(_) => (0, 0),
+            };
+            (id, name, channels, sample_rate)
+        })
+        .collect();
 
-        let default_config = device.default_input_config();
-        let (max_channels, default_rate) = match default_config {
-            Ok(config) => (config.channels(), config.sample_rate()),
-            Err(_) => (0, 0),
-        };
-
-        let is_default = default_device_name.as_ref() == Some(&name);
-
-        result.push(DeviceInfo {
-            index,
-            name,
-            max_input_channels: max_channels,
-            default_sample_rate: default_rate,
-            is_default,
-        });
-    }
-
-    Ok(result)
+    Ok(compute_is_default(rows, default_id)
+        .into_iter()
+        .map(|r| DeviceInfo {
+            index: r.index,
+            name: r.name,
+            max_input_channels: r.channels,
+            default_sample_rate: r.sample_rate,
+            is_default: r.is_default,
+        })
+        .collect())
 }
 
 /// Resolve a device selector to a cpal Device.
@@ -140,40 +195,40 @@ pub fn resolve_device(selector: &DeviceSelector) -> Result<cpal::Device, Decibri
 pub fn enumerate_output_devices() -> Result<Vec<OutputDeviceInfo>, DecibriError> {
     let host = cpal::default_host();
 
-    let default_device_name = host
-        .default_output_device()
-        .and_then(|d| d.description().ok())
-        .map(|desc| desc.name().to_string());
+    // Stable per-host id for the OS default output device; see
+    // `enumerate_input_devices` for rationale (same Issue #14 fix pattern).
+    let default_id = host.default_output_device().and_then(|d| d.id().ok());
 
     let devices = host
         .output_devices()
         .map_err(|e| DecibriError::Other(format!("Failed to enumerate devices: {e}")))?;
 
-    let mut result = Vec::new();
-    for (index, device) in devices.enumerate() {
-        let name = device
-            .description()
-            .map(|d| d.name().to_string())
-            .unwrap_or_else(|_| format!("Unknown Device {index}"));
+    let rows: Vec<(Option<cpal::DeviceId>, String, u16, u32)> = devices
+        .enumerate()
+        .map(|(index, device)| {
+            let id = device.id().ok();
+            let name = device
+                .description()
+                .map(|d| d.name().to_string())
+                .unwrap_or_else(|_| format!("Unknown Device {index}"));
+            let (channels, sample_rate) = match device.default_output_config() {
+                Ok(config) => (config.channels(), config.sample_rate()),
+                Err(_) => (0, 0),
+            };
+            (id, name, channels, sample_rate)
+        })
+        .collect();
 
-        let default_config = device.default_output_config();
-        let (max_channels, default_rate) = match default_config {
-            Ok(config) => (config.channels(), config.sample_rate()),
-            Err(_) => (0, 0),
-        };
-
-        let is_default = default_device_name.as_ref() == Some(&name);
-
-        result.push(OutputDeviceInfo {
-            index,
-            name,
-            max_output_channels: max_channels,
-            default_sample_rate: default_rate,
-            is_default,
-        });
-    }
-
-    Ok(result)
+    Ok(compute_is_default(rows, default_id)
+        .into_iter()
+        .map(|r| OutputDeviceInfo {
+            index: r.index,
+            name: r.name,
+            max_output_channels: r.channels,
+            default_sample_rate: r.sample_rate,
+            is_default: r.is_default,
+        })
+        .collect())
 }
 
 /// Resolve an output device selector to a cpal Device.
@@ -233,5 +288,89 @@ pub fn resolve_output_device(selector: &DeviceSelector) -> Result<cpal::Device, 
                 }
             }
         }
+    }
+}
+
+#[cfg(all(test, any(feature = "capture", feature = "output")))]
+mod tests {
+    use super::*;
+
+    // Synthetic id type for testing — any `PartialEq` works because
+    // `compute_is_default` is generic over the id type. Using String keeps the
+    // tests readable and avoids any dependency on a live cpal host.
+    fn row(id: Option<&str>, name: &str) -> (Option<String>, String, u16, u32) {
+        (id.map(String::from), name.to_string(), 2, 48_000)
+    }
+
+    /// Issue #14: two devices with the same display name but different per-host
+    /// IDs; only the device whose id matches the default is flagged.
+    #[test]
+    fn test_is_default_two_devices_same_name_different_ids() {
+        let rows = vec![
+            row(Some("usb-mic-A"), "Microphone"),
+            row(Some("usb-mic-B"), "Microphone"),
+        ];
+        let result = compute_is_default(rows, Some("usb-mic-B".to_string()));
+
+        assert_eq!(result.len(), 2);
+        assert!(
+            !result[0].is_default,
+            "first duplicate-named mic must NOT be flagged when default is the second"
+        );
+        assert!(
+            result[1].is_default,
+            "second duplicate-named mic (matching default id) must be flagged"
+        );
+        // Both rows keep their shared display name — the bug was never about
+        // renaming devices, only about misattribution of is_default.
+        assert_eq!(result[0].name, "Microphone");
+        assert_eq!(result[1].name, "Microphone");
+    }
+
+    /// Host reports no default device (rare but possible on headless Linux /
+    /// CI runners with no audio devices): no row is flagged.
+    #[test]
+    fn test_is_default_no_default_reported() {
+        let rows = vec![row(Some("mic-A"), "Mic A"), row(Some("mic-B"), "Mic B")];
+        let result = compute_is_default::<String>(rows, None);
+
+        assert_eq!(result.len(), 2);
+        assert!(
+            result.iter().all(|r| !r.is_default),
+            "no row may be flagged when host reports no default"
+        );
+    }
+
+    /// A device whose `id()` call failed (represented as `None` in the helper
+    /// input) is never flagged default, even if the host reports some default.
+    #[test]
+    fn test_is_default_row_with_failed_id() {
+        let rows = vec![
+            row(None, "Mystery device with unavailable id"),
+            row(Some("mic-B"), "Mic B"),
+        ];
+        let result = compute_is_default(rows, Some("mic-B".to_string()));
+
+        assert_eq!(result.len(), 2);
+        assert!(
+            !result[0].is_default,
+            "row with id() == None must never be flagged default"
+        );
+        assert!(
+            result[1].is_default,
+            "row whose id matches the default must be flagged"
+        );
+    }
+
+    /// Empty device list produces an empty result, regardless of what the
+    /// host reports as the default.
+    #[test]
+    fn test_is_default_empty_device_list() {
+        let rows: Vec<(Option<String>, String, u16, u32)> = vec![];
+        let result_no_default = compute_is_default::<String>(rows.clone(), None);
+        let result_with_default = compute_is_default(rows, Some("phantom-mic".to_string()));
+
+        assert!(result_no_default.is_empty());
+        assert!(result_with_default.is_empty());
     }
 }

--- a/crates/decibri/src/error.rs
+++ b/crates/decibri/src/error.rs
@@ -21,7 +21,7 @@ pub enum DecibriError {
     #[error("Multiple devices match \"{name}\":\n{matches}")]
     MultipleDevicesMatch { name: String, matches: String },
 
-    #[error("device index out of range — call Decibri.devices() to list available devices")]
+    #[error("device index out of range. Call Decibri.devices() to list available devices")]
     DeviceIndexOutOfRange,
 
     #[error("No microphone found. Check system audio input settings.")]

--- a/crates/decibri/src/lib.rs
+++ b/crates/decibri/src/lib.rs
@@ -1,3 +1,10 @@
+#[cfg(all(feature = "ort-load-dynamic", feature = "ort-download-binaries"))]
+compile_error!(
+    "features `ort-load-dynamic` and `ort-download-binaries` are mutually exclusive; \
+     select exactly one. The default feature set enables `ort-load-dynamic`; \
+     if you want `ort-download-binaries`, disable default features first."
+);
+
 pub mod error;
 pub mod sample;
 

--- a/crates/decibri/src/vad.rs
+++ b/crates/decibri/src/vad.rs
@@ -16,7 +16,9 @@
 //!   - `stateN`: f32[2, batch, 128]       (updated LSTM state)
 
 #[cfg(feature = "vad")]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+#[cfg(feature = "vad")]
+use std::sync::OnceLock;
 
 use crate::error::DecibriError;
 
@@ -29,6 +31,17 @@ pub struct VadConfig {
     pub sample_rate: u32,
     /// Speech probability threshold (0.0–1.0). Default: 0.5.
     pub threshold: f32,
+    /// Optional absolute path to the ONNX Runtime shared library.
+    ///
+    /// When `Some(path)`, ORT is initialized from the given library path via
+    /// `ort::init_from`. When `None`, `ort::init()` is called and ORT honours
+    /// the `ORT_DYLIB_PATH` environment variable if set.
+    ///
+    /// ORT is initialized exactly once per process. If multiple `SileroVad`
+    /// instances are constructed with different `ort_library_path` values,
+    /// the first path wins and later paths are silently ignored. This matches
+    /// ORT's own single-global-runtime model.
+    pub ort_library_path: Option<PathBuf>,
 }
 
 impl Default for VadConfig {
@@ -37,6 +50,7 @@ impl Default for VadConfig {
             model_path: PathBuf::from("silero_vad.onnx"),
             sample_rate: 16000,
             threshold: 0.5,
+            ort_library_path: None,
         }
     }
 }
@@ -71,6 +85,92 @@ pub struct SileroVad {
 /// State size: 2 (hidden + cell layers) × batch(1) × hidden_dim(128).
 const STATE_SIZE: usize = 256;
 
+/// Process-global ORT init tracker. Stores the library path used on first
+/// successful init (None if init used `ort::init()` with env-var fallback).
+/// Subsequent `init_ort_once` calls see this as populated and return immediately.
+#[cfg(feature = "vad")]
+static ORT_INIT: OnceLock<Option<PathBuf>> = OnceLock::new();
+
+/// Wrap an ORT init failure with a decibri-specific actionable message.
+///
+/// Kept as a standalone generic function (rather than an inline closure in
+/// `init_ort_once`) so it can be unit-tested without triggering a real ORT
+/// init failure. Tests pass a synthetic `err` value.
+#[cfg(feature = "vad")]
+fn wrap_init_error<E: std::fmt::Display>(path: Option<&Path>, err: E) -> DecibriError {
+    match path {
+        Some(p) => DecibriError::Other(format!(
+            "decibri: failed to load ONNX Runtime from {}: {}. \
+             If ORT_DYLIB_PATH is set, verify it points to a valid ONNX Runtime \
+             library for your platform. Otherwise the bundled ORT may be missing \
+             from your platform package — try reinstalling decibri.",
+            p.display(),
+            err
+        )),
+        None => DecibriError::Other(format!(
+            "decibri: failed to initialize ONNX Runtime: {}. \
+             Either pass ort_library_path in VadConfig, set ORT_DYLIB_PATH to \
+             point to a valid ONNX Runtime library, or enable the \
+             `ort-download-binaries` feature for zero-config builds.",
+            err
+        )),
+    }
+}
+
+/// Perform the actual ORT init call. Split out by distribution-mode feature
+/// so `init_ort_once` stays single-path.
+///
+/// Under `ort-load-dynamic`: `ort::init_from(path)` is available and is
+/// fallible (validates the dylib up-front).
+///
+/// Under `ort-download-binaries`: `ort::init_from` does NOT exist — ORT is
+/// statically linked into the binary and any path argument is meaningless.
+/// The path is ignored; we call `ort::init()` to commit an
+/// `EnvironmentBuilder` so our OnceLock bookkeeping fires.
+#[cfg(all(feature = "vad", feature = "ort-load-dynamic"))]
+fn do_ort_init(path: Option<&Path>) -> Result<bool, ort::Error> {
+    match path {
+        Some(p) => ort::init_from(p).map(|b| b.with_name("decibri").commit()),
+        None => Ok(ort::init().with_name("decibri").commit()),
+    }
+}
+
+#[cfg(all(feature = "vad", not(feature = "ort-load-dynamic")))]
+fn do_ort_init(_path: Option<&Path>) -> Result<bool, ort::Error> {
+    Ok(ort::init().with_name("decibri").commit())
+}
+
+/// Initialize ORT exactly once per process.
+///
+/// - If ORT is already initialized (by this or any prior caller), returns
+///   immediately. The `path` argument is silently ignored — ORT's global
+///   state cannot be re-initialized. See `VadConfig::ort_library_path` docs.
+/// - Otherwise delegates to the feature-gated `do_ort_init` helper.
+/// - On failure, the `OnceLock` is NOT set, so a subsequent caller can retry.
+///
+/// Note: `e` in the error-wrapping path below is always an `ort::Error` (ORT's
+/// own error type), never a `DecibriError`. This function is the single place
+/// where ORT errors enter decibri's error hierarchy — do NOT apply the same
+/// wrapping pattern elsewhere or the `decibri:` prefix and guidance string
+/// will be duplicated in the message users see.
+#[cfg(feature = "vad")]
+fn init_ort_once(path: Option<&Path>) -> Result<(), DecibriError> {
+    // Fast path: ORT already initialized.
+    if ORT_INIT.get().is_some() {
+        return Ok(());
+    }
+
+    match do_ort_init(path) {
+        Ok(_committed) => {
+            // First-caller-wins. If another thread set it first, discard ours;
+            // ORT's own global init is idempotent (first takes effect).
+            let _ = ORT_INIT.set(path.map(|p| p.to_path_buf()));
+            Ok(())
+        }
+        Err(e) => Err(wrap_init_error(path, e)),
+    }
+}
+
 #[cfg(feature = "vad")]
 impl SileroVad {
     /// Create a new Silero VAD instance by loading the ONNX model.
@@ -90,6 +190,10 @@ impl SileroVad {
                 "VAD threshold must be between 0.0 and 1.0".to_string(),
             ));
         }
+
+        // Initialize ORT exactly once per process. Subsequent SileroVad
+        // instances pass through immediately regardless of their ort_library_path.
+        init_ort_once(config.ort_library_path.as_deref())?;
 
         let session = ort::session::Session::builder()
             .map_err(|e| DecibriError::Other(format!("Failed to create ort session builder: {e}")))?
@@ -217,7 +321,54 @@ mod tests {
             model_path: model_path(),
             sample_rate: 16000,
             threshold: 0.5,
+            ort_library_path: None,
         }
+    }
+
+    #[test]
+    fn test_wrap_init_error_with_path() {
+        use std::env;
+
+        // Platform-agnostic invalid path (guaranteed to not exist on any OS).
+        let bogus_path = env::temp_dir().join("does-not-exist-onnxruntime-xyz-test");
+        let err = wrap_init_error(Some(bogus_path.as_path()), "simulated ort loader failure");
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains(&bogus_path.display().to_string()),
+            "error message should contain the attempted path, got: {msg}"
+        );
+        assert!(
+            msg.contains("If ORT_DYLIB_PATH is set"),
+            "error message should contain actionable guidance phrase, got: {msg}"
+        );
+        assert!(
+            msg.contains("simulated ort loader failure"),
+            "error message should include the underlying ort error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_wrap_init_error_without_path() {
+        let err = wrap_init_error(None, "simulated ort init failure");
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("ort_library_path"),
+            "None-path error should mention the VadConfig field, got: {msg}"
+        );
+        assert!(
+            msg.contains("ORT_DYLIB_PATH"),
+            "None-path error should mention the env var, got: {msg}"
+        );
+        assert!(
+            msg.contains("ort-download-binaries"),
+            "None-path error should mention the opt-out feature, got: {msg}"
+        );
+        assert!(
+            msg.contains("simulated ort init failure"),
+            "error message should include the underlying ort error, got: {msg}"
+        );
     }
 
     #[test]

--- a/crates/decibri/src/vad.rs
+++ b/crates/decibri/src/vad.rs
@@ -29,7 +29,7 @@ pub struct VadConfig {
     pub model_path: PathBuf,
     /// Sample rate: 8000 or 16000 Hz.
     pub sample_rate: u32,
-    /// Speech probability threshold (0.0–1.0). Default: 0.5.
+    /// Speech probability threshold (0.0 to 1.0). Default: 0.5.
     pub threshold: f32,
     /// Optional absolute path to the ONNX Runtime shared library.
     ///
@@ -103,7 +103,7 @@ fn wrap_init_error<E: std::fmt::Display>(path: Option<&Path>, err: E) -> Decibri
             "decibri: failed to load ONNX Runtime from {}: {}. \
              If ORT_DYLIB_PATH is set, verify it points to a valid ONNX Runtime \
              library for your platform. Otherwise the bundled ORT may be missing \
-             from your platform package — try reinstalling decibri.",
+             from your platform package. Try reinstalling decibri.",
             p.display(),
             err
         )),
@@ -123,7 +123,7 @@ fn wrap_init_error<E: std::fmt::Display>(path: Option<&Path>, err: E) -> Decibri
 /// Under `ort-load-dynamic`: `ort::init_from(path)` is available and is
 /// fallible (validates the dylib up-front).
 ///
-/// Under `ort-download-binaries`: `ort::init_from` does NOT exist — ORT is
+/// Under `ort-download-binaries`: `ort::init_from` does NOT exist. ORT is
 /// statically linked into the binary and any path argument is meaningless.
 /// The path is ignored; we call `ort::init()` to commit an
 /// `EnvironmentBuilder` so our OnceLock bookkeeping fires.
@@ -143,14 +143,14 @@ fn do_ort_init(_path: Option<&Path>) -> Result<bool, ort::Error> {
 /// Initialize ORT exactly once per process.
 ///
 /// - If ORT is already initialized (by this or any prior caller), returns
-///   immediately. The `path` argument is silently ignored — ORT's global
+///   immediately. The `path` argument is silently ignored. ORT's global
 ///   state cannot be re-initialized. See `VadConfig::ort_library_path` docs.
 /// - Otherwise delegates to the feature-gated `do_ort_init` helper.
 /// - On failure, the `OnceLock` is NOT set, so a subsequent caller can retry.
 ///
 /// Note: `e` in the error-wrapping path below is always an `ort::Error` (ORT's
 /// own error type), never a `DecibriError`. This function is the single place
-/// where ORT errors enter decibri's error hierarchy — do NOT apply the same
+/// where ORT errors enter decibri's error hierarchy. Do NOT apply the same
 /// wrapping pattern elsewhere or the `decibri:` prefix and guidance string
 /// will be duplicated in the message users see.
 #[cfg(feature = "vad")]

--- a/npm/decibri/package.json
+++ b/npm/decibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decibri",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Cross-platform audio capture, output, and processing for Node.js and browsers",
   "main": "src/decibri.js",
   "types": "src/decibri.d.ts",
@@ -69,10 +69,10 @@
     "README.md"
   ],
   "optionalDependencies": {
-    "@decibri/decibri-win32-x64-msvc": "3.0.0",
-    "@decibri/decibri-darwin-arm64": "3.0.0",
-    "@decibri/decibri-linux-x64-gnu": "3.0.0",
-    "@decibri/decibri-linux-arm64-gnu": "3.0.0"
+    "@decibri/decibri-win32-x64-msvc": "3.1.0",
+    "@decibri/decibri-darwin-arm64": "3.1.0",
+    "@decibri/decibri-linux-x64-gnu": "3.1.0",
+    "@decibri/decibri-linux-arm64-gnu": "3.1.0"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.0.0"

--- a/npm/decibri/src/decibri-output.js
+++ b/npm/decibri/src/decibri-output.js
@@ -50,7 +50,7 @@ class DecibriOutput extends Writable {
     } else if (typeof options.device === 'number') {
       const devices = DecibriOutputBridge.devices();
       if (options.device < 0 || options.device >= devices.length) {
-        throw new RangeError('device index out of range — call DecibriOutput.devices() to list available devices');
+        throw new RangeError('device index out of range. Call DecibriOutput.devices() to list available devices');
       }
       resolvedDevice = options.device;
     }

--- a/npm/decibri/src/decibri.js
+++ b/npm/decibri/src/decibri.js
@@ -131,7 +131,7 @@ class Decibri extends Readable {
     } else if (typeof options.device === 'number') {
       const devices = DecibriBridge.devices();
       if (options.device < 0 || options.device >= devices.length) {
-        throw new RangeError('device index out of range — call Decibri.devices() to list available devices');
+        throw new RangeError('device index out of range. Call Decibri.devices() to list available devices');
       }
       resolvedDevice = options.device;
     }

--- a/npm/decibri/src/decibri.js
+++ b/npm/decibri/src/decibri.js
@@ -5,6 +5,61 @@ const path = require('path');
 const fs = require('fs');
 const { DecibriBridge } = require('../index.js');
 
+// ─── Bundled ONNX Runtime path resolution ────────────────────────────────────
+
+/**
+ * Map (process.platform, process.arch) → { pkg: npm platform package name,
+ *                                           file: bundled ORT dylib filename }
+ *
+ * Dylib filenames are unversioned across all platforms for consistency. The
+ * release workflow (.github/workflows/release.yml) copies Microsoft's
+ * versioned upstream tarball file (e.g. libonnxruntime.1.24.4.dylib) into the
+ * platform package with the unversioned name listed here.
+ *
+ * If you add a new platform, update this table AND the matching platform job
+ * in release.yml.
+ */
+const PLATFORM_DYLIB = {
+  'darwin-arm64': { pkg: '@decibri/decibri-darwin-arm64',    file: 'libonnxruntime.dylib' },
+  'linux-x64':    { pkg: '@decibri/decibri-linux-x64-gnu',   file: 'libonnxruntime.so' },
+  'linux-arm64':  { pkg: '@decibri/decibri-linux-arm64-gnu', file: 'libonnxruntime.so' },
+  'win32-x64':    { pkg: '@decibri/decibri-win32-x64-msvc',  file: 'onnxruntime.dll' },
+};
+
+/**
+ * Resolve the absolute path to the bundled ONNX Runtime shared library for
+ * this platform.
+ *
+ * Returns a string path on success. Returns undefined when:
+ *   - the platform/arch pair is not in PLATFORM_DYLIB (unsupported target);
+ *   - the platform package is not installed (MODULE_NOT_FOUND from
+ *     require.resolve, e.g. during pre-publish development);
+ *   - any other path-resolution error occurs.
+ *
+ * When this returns undefined, the Rust layer falls back to the
+ * ORT_DYLIB_PATH environment variable via ort::init(); if that is also
+ * missing, the first Silero VAD construction fails with a decibri-specific
+ * error message telling the user what to do.
+ *
+ * This function deliberately does NOT check that the dylib file exists on
+ * disk. If the platform package was installed but is missing the dylib,
+ * that's a packaging bug that should surface loudly via the Rust error path,
+ * not be silently masked here.
+ */
+function resolveBundledOrtPath() {
+  const entry = PLATFORM_DYLIB[`${process.platform}-${process.arch}`];
+  if (!entry) return undefined;
+  try {
+    // require.resolve on the package name gives us the absolute path of its
+    // main entry (the .node binary). path.dirname() yields the package dir
+    // where the bundled ORT dylib sits alongside.
+    const nodeBinaryPath = require.resolve(entry.pkg);
+    return path.join(path.dirname(nodeBinaryPath), entry.file);
+  } catch (_) {
+    return undefined;
+  }
+}
+
 // ─── RMS helper ──────────────────────────────────────────────────────────────
 
 function computeRMS(chunk, format) {
@@ -89,11 +144,17 @@ class Decibri extends Readable {
     }
 
     let modelPath = undefined;
+    let ortLibraryPath = undefined;
     if (vadMode === 'silero' && options.vad) {
       modelPath = options.modelPath || path.join(__dirname, '..', 'models', 'silero_vad.onnx');
       if (!fs.existsSync(modelPath)) {
         throw new Error(`Silero VAD model not found at ${modelPath}. Ensure the models/ directory is included in your installation.`);
       }
+      // Internal plumbing: inject the bundled ORT dylib path into the napi
+      // constructor. If resolution fails (unknown platform, platform package
+      // not installed), leaves ortLibraryPath as undefined and lets Rust fall
+      // through to ORT_DYLIB_PATH or surface a decibri-specific init error.
+      ortLibraryPath = resolveBundledOrtPath();
     }
 
     // ── Store config ───────────────────────────────────────────────────────
@@ -117,6 +178,7 @@ class Decibri extends Readable {
       device: resolvedDevice,
       vadMode: (options.vad && vadMode === 'silero') ? 'silero' : 'energy',
       modelPath,
+      ortLibraryPath,
     });
   }
 

--- a/npm/platform-darwin-arm64/package.json
+++ b/npm/platform-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-darwin-arm64",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "os": ["darwin"],
   "cpu": ["arm64"],
   "main": "decibri.darwin-arm64.node",

--- a/npm/platform-darwin-arm64/package.json
+++ b/npm/platform-darwin-arm64/package.json
@@ -4,7 +4,10 @@
   "os": ["darwin"],
   "cpu": ["arm64"],
   "main": "decibri.darwin-arm64.node",
-  "files": ["decibri.darwin-arm64.node"],
+  "files": [
+    "decibri.darwin-arm64.node",
+    "libonnxruntime.dylib"
+  ],
   "license": "Apache-2.0",
   "description": "decibri native binary for macOS arm64",
   "repository": {

--- a/npm/platform-linux-arm64-gnu/package.json
+++ b/npm/platform-linux-arm64-gnu/package.json
@@ -4,7 +4,11 @@
   "os": ["linux"],
   "cpu": ["arm64"],
   "main": "decibri.linux-arm64-gnu.node",
-  "files": ["decibri.linux-arm64-gnu.node"],
+  "files": [
+    "decibri.linux-arm64-gnu.node",
+    "libonnxruntime.so",
+    "libonnxruntime_providers_shared.so"
+  ],
   "license": "Apache-2.0",
   "description": "decibri native binary for Linux arm64",
   "repository": {

--- a/npm/platform-linux-arm64-gnu/package.json
+++ b/npm/platform-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-arm64-gnu",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "os": ["linux"],
   "cpu": ["arm64"],
   "main": "decibri.linux-arm64-gnu.node",

--- a/npm/platform-linux-x64-gnu/package.json
+++ b/npm/platform-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-x64-gnu",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "os": ["linux"],
   "cpu": ["x64"],
   "main": "decibri.linux-x64-gnu.node",

--- a/npm/platform-linux-x64-gnu/package.json
+++ b/npm/platform-linux-x64-gnu/package.json
@@ -4,7 +4,11 @@
   "os": ["linux"],
   "cpu": ["x64"],
   "main": "decibri.linux-x64-gnu.node",
-  "files": ["decibri.linux-x64-gnu.node"],
+  "files": [
+    "decibri.linux-x64-gnu.node",
+    "libonnxruntime.so",
+    "libonnxruntime_providers_shared.so"
+  ],
   "license": "Apache-2.0",
   "description": "decibri native binary for Linux x64",
   "repository": {

--- a/npm/platform-win32-x64-msvc/package.json
+++ b/npm/platform-win32-x64-msvc/package.json
@@ -4,7 +4,10 @@
   "os": ["win32"],
   "cpu": ["x64"],
   "main": "decibri.win32-x64-msvc.node",
-  "files": ["decibri.win32-x64-msvc.node"],
+  "files": [
+    "decibri.win32-x64-msvc.node",
+    "onnxruntime.dll"
+  ],
   "license": "Apache-2.0",
   "description": "decibri native binary for Windows x64",
   "repository": {

--- a/npm/platform-win32-x64-msvc/package.json
+++ b/npm/platform-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-win32-x64-msvc",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "os": ["win32"],
   "cpu": ["x64"],
   "main": "decibri.win32-x64-msvc.node",


### PR DESCRIPTION
## Summary

Migrates ONNX Runtime from statically-embedded (`download-binaries`) to dynamically-loaded (`load-dynamic`) with per-platform bundled dylibs. Fixes Issue #14 (duplicate-named audio devices both marked as default).

Public Node.js and browser APIs are unchanged. Direct Rust crate consumers see a behaviour change; see migration notes in CHANGELOG.md.

## Key changes

- ORT integration switched to `ort/load-dynamic` with bundled ONNX Runtime 1.24.4 dylibs in each platform package
- Issue #14 fixed via `cpal::Device::id()` for stable per-host device identity
- Native addon size reduced from ~20 MB to ~817 KB on Windows x64 (ORT now ships separately as ~13.5 MB dylib)
- New Cargo features for direct Rust consumers: `ort-load-dynamic` (default), `ort-download-binaries` (escape hatch), plus EP passthroughs (`coreml`, `cuda`, `directml`, `rocm`)
- Release pipeline hardening: version-match preflight, `curl --retry`, macOS codesign verification, Windows DLL imports inspection, stage-and-verify packaging validation
- Upstream dependency monitoring for Microsoft ORT releases
- Style cleanup: em-dashes removed across codebase, error messages normalized

## Validation

- CI passing on development (lint, audit, test-rust, test-node, test-browser — 64/64 browser tests, 29/29 rust tests)
- Release-dryrun passing on all 5 jobs across 4 platforms + stage-and-verify
- Local Windows hardware smoke test confirmed VAD loads and constructs with bundled ORT
- macOS codesign verified: `valid on disk`, `satisfies its Designated Requirement`
- Windows DLL imports verified: all standard Windows system DLLs + MSVC runtime, no surprises

## Release plan

After this merge:
1. Tag v3.1.0 from main
2. Release workflow fires (~15 min to publish npm + crates.io)
3. Post-publish smoke test on fresh directory
4. Deprecate 3.1.0 and ship 3.1.1 only if a regression surfaces (per §5.4)

## Follow-ups

Tracked separately:
- Code quality items from independent review (device.rs consolidation, structured ORT error variants, DeviceSelector::Id, others)

See `CHANGELOG.md` for the full 3.1.0 entry.