### PR TITLE
Release 3.2.0: pre-P3 refactor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,6 +321,107 @@ jobs:
           ls -la npm/decibri/index.js
           ls -la npm/decibri/index.d.ts
 
+      # Copy README into npm package directory before publish. Relocated
+      # upward from its previous position (between platform-package and
+      # main-package publishes) so the `Verify npm package contents` gate
+      # below sees the main package fully staged — otherwise verify_pack
+      # would fail on the main package with ":README.md missing".
+      - name: Copy README for npm package
+        run: cp README.md npm/decibri/README.md
+
+      # Defense-in-depth: verify npm package contents one final time before
+      # publishing. release-dryrun.yml runs the same check, but this ensures
+      # the gate fires even if someone skips dryrun before tagging.
+      # Ports verify_pack function from release-dryrun.yml verbatim.
+      - name: Verify npm package contents (pre-publish gate)
+        shell: bash
+        run: |
+          set -o pipefail
+          FAIL=0
+
+          verify_pack() {
+            local pkg_dir="$1"
+            local label="$2"
+            shift 2
+            # Remaining args: required files prefixed with ':',
+            #                 forbidden regex patterns prefixed with '~'.
+            local required=()
+            local forbidden=()
+            for arg in "$@"; do
+              case "$arg" in
+                :*) required+=("${arg#:}") ;;
+                ~*) forbidden+=("${arg#~}") ;;
+              esac
+            done
+
+            echo ""
+            echo "=== $label ($pkg_dir) ==="
+            local files
+            files=$(cd "$pkg_dir" && npm pack --dry-run --json | jq -r '.[0].files[].path')
+            echo "Would pack:"
+            echo "$files" | sort | sed 's/^/  * /'
+
+            for f in "${required[@]}"; do
+              if echo "$files" | grep -Fxq "$f"; then
+                echo "  [OK]   required present: $f"
+              else
+                echo "  [FAIL] required MISSING: $f"
+                FAIL=1
+              fi
+            done
+
+            for p in "${forbidden[@]}"; do
+              local matches
+              matches=$(echo "$files" | grep -E "$p" || true)
+              if [ -n "$matches" ]; then
+                echo "  [FAIL] forbidden pattern '$p' matched:"
+                echo "$matches" | sed 's/^/         /'
+                FAIL=1
+              else
+                echo "  [OK]   forbidden absent: $p"
+              fi
+            done
+          }
+
+          # Main package: should carry JS source, models, README, napi loader;
+          # must NOT carry the native .node file or any ORT dylib (those belong
+          # in the platform packages).
+          verify_pack npm/decibri "main package (decibri)" \
+            :package.json \
+            :README.md \
+            :src/decibri.js \
+            :index.js \
+            :models/silero_vad.onnx \
+            '~\.node$' \
+            '~onnxruntime'
+
+          verify_pack npm/platform-darwin-arm64 "@decibri/decibri-darwin-arm64" \
+            :decibri.darwin-arm64.node \
+            :libonnxruntime.dylib
+
+          verify_pack npm/platform-linux-x64-gnu "@decibri/decibri-linux-x64-gnu" \
+            :decibri.linux-x64-gnu.node \
+            :libonnxruntime.so \
+            :libonnxruntime_providers_shared.so
+
+          verify_pack npm/platform-linux-arm64-gnu "@decibri/decibri-linux-arm64-gnu" \
+            :decibri.linux-arm64-gnu.node \
+            :libonnxruntime.so \
+            :libonnxruntime_providers_shared.so
+
+          verify_pack npm/platform-win32-x64-msvc "@decibri/decibri-win32-x64-msvc" \
+            :decibri.win32-x64-msvc.node \
+            :onnxruntime.dll
+
+          echo ""
+          if [ "$FAIL" -ne 0 ]; then
+            echo "================================================"
+            echo "  VERIFICATION FAILED - not publish-ready"
+            echo "================================================"
+            exit 1
+          fi
+          echo "All 5 packages pass verification."
+
       # Publish platform packages FIRST (main package depends on them)
       # Uses npm Trusted Publishing (OIDC). No token needed, provenance is automatic
       - name: Publish @decibri/decibri-win32-x64-msvc
@@ -334,10 +435,6 @@ jobs:
 
       - name: Publish @decibri/decibri-linux-arm64-gnu
         run: cd npm/platform-linux-arm64-gnu && npm publish --access public
-
-      # Copy README into npm package directory before publish
-      - name: Copy README for npm package
-        run: cp README.md npm/decibri/README.md
 
       # Publish main package (after platform packages are available)
       - name: Publish decibri

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,133 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2026-04-22
+
+Refactor release. Public Node.js and browser APIs are unchanged. Direct
+Rust crate consumers get a structured `DecibriError` taxonomy with full
+error-chain preservation, a new stable FFI-ready stream-reading API on
+`CaptureStream`, a declared minimum-supported-Rust-version, and a Windows
+hang fix in VAD initialization. See migration notes below.
+
+### Changed
+
+- `DecibriError` is now `#[non_exhaustive]` and the `Other(String)`
+  catch-all variant has been removed. All previous `Other(...)` failures
+  now have dedicated typed variants: `DeviceEnumerationFailed`,
+  `CaptureStreamClosed`, `OutputStreamClosed`, `VadSampleRateUnsupported`,
+  `VadThresholdOutOfRange`, `OrtInitFailed`, `OrtLoadFailed`,
+  `OrtPathInvalid`, `OrtSessionBuildFailed`, `OrtThreadsConfigFailed`,
+  `VadModelLoadFailed`, `OrtInferenceFailed`, `OrtTensorCreateFailed`,
+  `OrtTensorExtractFailed`. Path-carrying variants use `PathBuf`; ORT
+  variants carry `#[source] ort::Error` so `error.source()` walks the
+  error chain. Display strings (and therefore `error.message` in Node
+  and `str(exception)` in future Python bindings) are byte-identical
+  to 3.1.0.
+- `VadConfig` now has a public `validate()` method returning
+  `Result<usize, DecibriError>` where the `usize` is the Silero VAD
+  `window_size` for the validated sample rate. Called automatically by
+  `SileroVad::new`; can be called explicitly to fail-fast before paying
+  ORT-initialization cost.
+- Device enumeration and resolution logic in `crates/decibri/src/device.rs`
+  consolidated into a shared direction-generic implementation (input and
+  output share code paths via an internal `DeviceDirection` trait). No
+  public API change.
+- Workspace minimum-supported Rust version (MSRV) declared at rustc 1.88,
+  forced by `ort 2.0.0-rc.12` which requires `edition = "2024"`.
+
+### Added
+
+- `CaptureStream::try_next_chunk()`: non-blocking read, returns
+  `Result<Option<AudioChunk>, DecibriError>` with a three-state return
+  (`Some` chunk / `None` if no data yet / `Err(CaptureStreamClosed)` if
+  terminal). Declared stable across 3.x as part of decibri's canonical
+  FFI-consumer surface.
+- `CaptureStream::next_chunk(timeout: Option<Duration>)`: blocking read
+  with optional timeout, same three-state return shape. Declared stable
+  across 3.x. Concurrent `stop()` unblocks a waiter within approximately
+  20 ms via internal polling.
+- `DecibriError::is_ort_path_error()`: helper that returns true for both
+  `OrtLoadFailed` and `OrtPathInvalid`. Consumers handling path-level ORT
+  failures should match this rather than enumerating both variants
+  manually. The split between the two variants is a mechanical necessity
+  (constructing `ort::Error` under `ort-load-dynamic` triggers an ORT C
+  API call and would reintroduce the Windows hang).
+- Crate-level rustdoc on `decibri`'s `lib.rs` covering capabilities,
+  feature flags, ORT distribution modes, an end-to-end capture-plus-VAD
+  example, the process-global ORT initialization constraint, thread-safety
+  summary, and the 3.x FFI-surface stability contract.
+- Rust integration tests for the VAD / ORT pipeline in
+  `crates/decibri/tests/vad_integration.rs` (happy path, model-not-found,
+  config validation, end-to-end silence inference) and
+  `crates/decibri/tests/vad_ort_load_failure.rs` (load-failure path
+  isolation, feature-gated to `ort-load-dynamic`). All CI-safe; no audio
+  hardware required.
+- Unit tests for `try_next_chunk` / `next_chunk` semantics (7 tests
+  covering empty-queue, chunk-available, buffered-flush-before-closed,
+  timeout, blocking-until-arrival, and polling-interval-correctness after
+  concurrent `stop()`).
+- Pre-publish packaging gate in `.github/workflows/release.yml`:
+  ports the `verify_pack` function from `release-dryrun.yml` to run
+  `npm pack --dry-run` against all 5 packages before any `npm publish`
+  step. Closes the dryrun-skip honor-system gap: release-dryrun.yml
+  previously caught packaging bugs but only if it was actually run before
+  tagging.
+
+### Fixed
+
+- Windows hang in VAD initialization: passing a nonexistent or
+  directory path as `VadConfig::ort_library_path` (or via the Node
+  binding's `ortLibraryPath`) caused `ort::init_from` to hang
+  indefinitely on Windows against pyke/ort 2.0.0-rc.12 with
+  onnxruntime 1.24.4. `init_ort_once` now performs a filesystem-level
+  `Path::is_file()` pre-check before handing the path to ORT, returning
+  `DecibriError::OrtPathInvalid` immediately for any path that fails the
+  check. The pre-check never touches ORT symbols, so it cannot itself
+  trigger the dylib load it is designed to prevent.
+
+### Migration notes for direct Rust crate consumers
+
+- Matches against `DecibriError::Other(msg)` will stop compiling. Replace
+  with matches against the specific new variants. The `error.message`
+  text is unchanged; code using `.to_string()` rather than pattern
+  matching continues to work unaffected.
+- `DecibriError` is now `#[non_exhaustive]`: match expressions against
+  it must include a `_ =>` catch-all arm. New variants added in future
+  releases are non-breaking under this constraint.
+- Consumers handling "ORT path failed" should prefer
+  `err.is_ort_path_error()` or match both `OrtLoadFailed { .. }` and
+  `OrtPathInvalid { .. }`. The two variants represent the same
+  conceptual failure mode split for FFI-side-effect reasons.
+- MSRV raised to rustc 1.88 (from effectively-unpinned in 3.1.x). This
+  is forced by `ort 2.0.0-rc.12` declaring `edition = "2024"`. Projects
+  on older rustc cannot build decibri 3.2.0 directly; stay on 3.1.x or
+  upgrade the toolchain.
+- `VadConfig::validate()` was new in 3.2.0 (no 3.1.x public signature
+  to break) and has the final form `Result<usize, DecibriError>`. If you
+  only need pass/fail, call `.is_ok()` or `.map(|_| ())`.
+
+Node.js and browser consumers: no API or behaviour change. `error.message`
+text from the native addon is byte-identical to 3.1.0 (verified against
+the 38-assertion CI suite).
+
+### Internal
+
+- `ort` crate version unchanged at `2.0.0-rc.12`.
+- Bundled ONNX Runtime version unchanged at `1.24.4`.
+- Node binding error mapping at `bindings/node/src/lib.rs::to_napi_error`
+  explicitly enumerates every variant (compiler-enforced exhaustive
+  during the refactor by temporarily removing `#[non_exhaustive]` and
+  the `_ =>` arm; both restored). New variants added upstream fall
+  through to `GenericFailure` at runtime rather than failing to compile.
+- `CaptureStream._stream` field type changed from `cpal::Stream` to
+  `Option<cpal::Stream>` purely to enable unit-test construction without
+  a real audio device. Production always stores `Some(stream)`; drop
+  semantics are identical.
+- docs.rs metadata added to target all 4 production platforms (Linux x64/ARM64,
+  macOS ARM64, Windows x64) for full platform-specific rustdoc rendering.
+  Future-proofs against the docs.rs change effective 2026-05-01 (building
+  fewer targets by default).
+
 ## [3.1.0] - 2026-04-22
 
 Internal rearchitecture: ONNX Runtime is now loaded dynamically at runtime
@@ -125,6 +252,7 @@ Initial release. C++ native addon wrapping PortAudio with pre-built binaries.
 - Int16 PCM output (little-endian)
 - Source build fallback via node-gyp
 
+[3.2.0]: https://github.com/decibri/decibri/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/decibri/decibri/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/decibri/decibri/compare/v1.0.0...v3.0.0
 [1.0.0]: https://github.com/analyticsinmotion/decibri/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,14 +6,12 @@ Before making any type of contribution, please read our [Code of Conduct](https:
 
 This guide walks through the contribution workflow, from opening an issue to submitting a pull request.
 
-
 ## New contributor resources
 
 For a good overview of the project, please first read the [README](https://github.com/decibri/decibri/blob/main/README.md). General resources for getting started with open-source contributions:
 
 - [Finding ways to contribute to open source on GitHub](https://docs.github.com/en/get-started/exploring-projects-on-github/finding-ways-to-contribute-to-open-source-on-github)
 - [Collaborating with pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests)
-
 
 ## Ways to contribute
 
@@ -26,7 +24,6 @@ There are multiple ways you can contribute to this project:
 - Adding or improving integration guides
 - Improving test coverage
 - Anything else we may have forgotten
-
 
 ## Getting started
 
@@ -44,18 +41,21 @@ To build from source you will need:
 ### Setting up the development environment
 
 1. Fork this repository to your own account and clone it to your local machine:
+
    ```bash
    git clone https://github.com/YOUR_USERNAME/decibri.git
    cd decibri
    ```
 
 2. Build the Rust crate and run its tests:
+
    ```bash
    cargo build --workspace
    cargo test-decibri
    ```
 
 3. Build the Node.js native addon:
+
    ```bash
    cd npm/decibri
    npm install --ignore-optional
@@ -63,12 +63,14 @@ To build from source you will need:
    ```
 
 4. Run the CI-safe Node.js test suite (no hardware required):
+
    ```bash
    cd ../..
    node tests/test-ci.js
    ```
 
 5. (Optional) Run the live capture, output, and VAD tests if you have a microphone and speakers connected:
+
    ```bash
    node tests/test-capture.js
    node tests/test-output.js
@@ -77,6 +79,7 @@ To build from source you will need:
    ```
 
 6. (Optional) Run the browser unit tests (mocked, no hardware required):
+
    ```bash
    npm install
    npx vitest run
@@ -135,7 +138,6 @@ Our team will review your PR and provide feedback. We may ask for additional cha
 Every pull request runs an automated CI pipeline covering lint, format, security audit, and test suites across Rust, Node.js, and browser targets. Your PR must pass CI before it can be merged. Details of the pipeline live in `.github/workflows/ci.yml`.
 
 We appreciate your contributions and thank you for your time in submitting a pull request.
-
 
 ## License
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,13 @@ members = [
 [workspace.package]
 version = "3.1.0"
 edition = "2021"
+# MSRV empirically verified 2026-04-22: rustc 1.88 is the minimum version
+# that compiles the workspace. Floors: ort 2.0.0-rc.12 declares
+# `rust-version = "1.88"` and `edition = "2024"`, which dominates our own
+# MSRV. Other direct deps (napi-rs v3 ~1.74, cpal 0.17 ~1.70,
+# crossbeam-channel 0.5 ~1.60) are below this floor. Bump when dependencies
+# force it; otherwise hold.
+rust-version = "1.88"
 license = "Apache-2.0"
 repository = "https://github.com/decibri/decibri"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.1.0"
+version = "3.2.0"
 edition = "2021"
 # MSRV empirically verified 2026-04-22: rustc 1.88 is the minimum version
 # that compiles the workspace. Floors: ort 2.0.0-rc.12 declares

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -2,6 +2,7 @@
 name = "decibri-node"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 
 [lib]

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -319,12 +319,49 @@ fn resolve_device_option(device: &Option<serde_json::Value>) -> Result<DeviceSel
 
 fn to_napi_error(e: decibri::error::DecibriError) -> Error {
     use decibri::error::DecibriError::*;
+    // Every variant is listed explicitly so the grep check in our release
+    // procedure can confirm coverage. A trailing `_ =>` arm is required
+    // because `DecibriError` is `#[non_exhaustive]`; it catches future
+    // variants added upstream and maps them to the safe default.
     let status = match &e {
+        // Config validation (bad caller input)
         SampleRateOutOfRange
         | ChannelsOutOfRange
         | FramesPerBufferOutOfRange
-        | DeviceIndexOutOfRange => Status::InvalidArg,
-        InvalidFormat | DeviceNotFound(_) | MultipleDevicesMatch { .. } => Status::InvalidArg,
+        | InvalidFormat
+        | VadSampleRateUnsupported(_)
+        | VadThresholdOutOfRange(_) => Status::InvalidArg,
+
+        // Device selection (bad caller input)
+        DeviceNotFound(_)
+        | MultipleDevicesMatch { .. }
+        | DeviceIndexOutOfRange
+        | NotAnInputDevice => Status::InvalidArg,
+
+        // Runtime / environmental failures
+        NoMicrophoneFound
+        | NoOutputDeviceFound
+        | DeviceEnumerationFailed(_)
+        | AlreadyRunning
+        | StreamOpenFailed(_)
+        | StreamStartFailed(_)
+        | PermissionDenied
+        | CaptureStreamClosed
+        | OutputStreamClosed
+        | OrtInitFailed { .. }
+        | OrtLoadFailed { .. }
+        | OrtSessionBuildFailed(_)
+        | OrtThreadsConfigFailed(_)
+        | VadModelLoadFailed { .. }
+        | OrtInferenceFailed(_)
+        | OrtTensorCreateFailed { .. }
+        | OrtTensorExtractFailed { .. } => Status::GenericFailure,
+
+        // `DecibriError` is `#[non_exhaustive]`. A new variant added upstream
+        // without a corresponding arm here falls through to `GenericFailure`
+        // at runtime rather than failing to compile. Variant coverage was
+        // compiler-enforced during the 3.2.0 refactor by temporarily removing
+        // both `#[non_exhaustive]` and this arm; both have been restored.
         _ => Status::GenericFailure,
     };
     Error::new(status, e.to_string())

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -350,6 +350,7 @@ fn to_napi_error(e: decibri::error::DecibriError) -> Error {
         | OutputStreamClosed
         | OrtInitFailed { .. }
         | OrtLoadFailed { .. }
+        | OrtPathInvalid { .. }
         | OrtSessionBuildFailed(_)
         | OrtThreadsConfigFailed(_)
         | VadModelLoadFailed { .. }

--- a/crates/decibri/Cargo.toml
+++ b/crates/decibri/Cargo.toml
@@ -2,6 +2,7 @@
 name = "decibri"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Cross-platform audio capture, output, and processing"

--- a/crates/decibri/Cargo.toml
+++ b/crates/decibri/Cargo.toml
@@ -10,6 +10,23 @@ readme = "../../README.md"
 keywords = ["audio", "microphone", "capture", "sound", "voice"]
 categories = ["multimedia::audio"]
 
+[package.metadata.docs.rs]
+# Build docs for all production targets to show platform-specific behavior.
+# cpal backends (WASAPI on Windows, CoreAudio on macOS, ALSA on Linux) and
+# ort loading paths differ per platform. Without explicit targets, docs.rs
+# after 2026-05-01 would only build x86_64-unknown-linux-gnu.
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]
+# docs.rs uses ort-download-binaries since ort-load-dynamic requires a runtime
+# dylib that docs.rs builders don't have. Mutually exclusive with ort-load-dynamic
+# per the compile_error! guard in lib.rs.
+features = ["capture", "output", "vad", "denoise", "gain", "ort-download-binaries"]
+no-default-features = true
+
 [features]
 # Default stack for consumers who want the full decibri experience on Node/Python bindings.
 # `ort-load-dynamic` is the distribution mode used by npm platform packages and P3 Python wheels.

--- a/crates/decibri/src/capture.rs
+++ b/crates/decibri/src/capture.rs
@@ -2,11 +2,13 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(feature = "capture")]
 use std::sync::Arc;
+#[cfg(feature = "capture")]
+use std::time::{Duration, Instant};
 
 #[cfg(feature = "capture")]
 use cpal::traits::{DeviceTrait, StreamTrait};
 #[cfg(feature = "capture")]
-use crossbeam_channel::{Receiver, Sender};
+use crossbeam_channel::{Receiver, RecvTimeoutError, Sender, TryRecvError};
 
 use crate::device::DeviceSelector;
 use crate::error::DecibriError;
@@ -65,7 +67,12 @@ pub struct AudioChunk {
 /// Handle to an active audio capture session.
 #[cfg(feature = "capture")]
 pub struct CaptureStream {
-    _stream: cpal::Stream,
+    /// Holds the cpal stream alive for the lifetime of this handle. Wrapped
+    /// in `Option` purely so the test-only `tests::test_stream()` helper can
+    /// construct a `CaptureStream` without a real audio device. Production
+    /// code always stores `Some(stream)`; drop semantics are identical (the
+    /// `Option`'s drop runs the inner `cpal::Stream`'s drop).
+    _stream: Option<cpal::Stream>,
     receiver: Receiver<AudioChunk>,
     running: Arc<AtomicBool>,
     #[allow(dead_code)]
@@ -76,9 +83,135 @@ pub struct CaptureStream {
 
 #[cfg(feature = "capture")]
 impl CaptureStream {
-    /// Get a reference to the receiver for reading audio chunks.
+    /// Direct access to the underlying `crossbeam_channel::Receiver`.
+    ///
+    /// Intended for **in-process Rust consumers** and for bindings (like the
+    /// decibri Node.js addon) that integrate the channel into their own
+    /// drain pump or event loop.
+    ///
+    /// FFI bindings targeting languages without native `crossbeam_channel`
+    /// support, such as Python and the eventual mobile platforms, should
+    /// prefer [`try_next_chunk`](Self::try_next_chunk) and
+    /// [`next_chunk`](Self::next_chunk): they expose the same data with a
+    /// three-state return (`Some` / `None` / `Err(CaptureStreamClosed)`)
+    /// that maps cleanly across a language boundary.
     pub fn receiver(&self) -> &Receiver<AudioChunk> {
         &self.receiver
+    }
+
+    /// Attempt to read the next audio chunk without blocking.
+    ///
+    /// # Returns
+    /// - `Ok(Some(chunk))` — a chunk was immediately available and has been
+    ///   dequeued.
+    /// - `Ok(None)` — the stream is open and running, but no chunk is
+    ///   currently buffered. Try again shortly, or call
+    ///   [`next_chunk`](Self::next_chunk) to block.
+    /// - `Err(DecibriError::CaptureStreamClosed)` — the stream is closed
+    ///   (either by explicit [`stop`](Self::stop) or by an audio-driver
+    ///   error reported via the cpal error callback). No further chunks
+    ///   will ever be available.
+    ///
+    /// Any chunks that were buffered before the stream closed are delivered
+    /// first; the closed signal is only returned once the buffer is empty.
+    ///
+    /// # Thread safety
+    /// May be called from any thread. Internally uses a lock-free
+    /// `crossbeam_channel::try_recv` and an atomic load.
+    ///
+    /// # Stability
+    /// Part of decibri's stable FFI-consumer API surface, alongside
+    /// [`next_chunk`](Self::next_chunk). Guaranteed signature-stable across
+    /// 3.x; any change will be a breaking version bump.
+    pub fn try_next_chunk(&self) -> Result<Option<AudioChunk>, DecibriError> {
+        match self.receiver.try_recv() {
+            Ok(chunk) => Ok(Some(chunk)),
+            Err(TryRecvError::Empty) => {
+                if self.is_open() {
+                    Ok(None)
+                } else {
+                    Err(DecibriError::CaptureStreamClosed)
+                }
+            }
+            Err(TryRecvError::Disconnected) => Err(DecibriError::CaptureStreamClosed),
+        }
+    }
+
+    /// Read the next audio chunk, blocking the calling thread until one
+    /// arrives, the stream closes, or `timeout` elapses.
+    ///
+    /// # Arguments
+    /// - `timeout = None` — block indefinitely until a chunk arrives or the
+    ///   stream closes.
+    /// - `timeout = Some(dur)` — block at most `dur`; return `Ok(None)` if
+    ///   the deadline passes with no chunk.
+    ///
+    /// # Returns
+    /// - `Ok(Some(chunk))` — chunk received within the deadline.
+    /// - `Ok(None)` — `timeout` elapsed without a chunk arriving. The stream
+    ///   is still open.
+    /// - `Err(DecibriError::CaptureStreamClosed)` — stream closed before a
+    ///   chunk could be delivered. Any chunks that were buffered at the time
+    ///   of close are delivered first; this error is only returned once the
+    ///   buffer is empty.
+    ///
+    /// # Thread safety
+    /// May be called from any thread. Blocks only the calling thread; other
+    /// threads can call [`stop`](Self::stop) concurrently to unblock this
+    /// call within approximately 20 ms.
+    ///
+    /// Implementation note: `stop()` does not disconnect the underlying
+    /// channel (the cpal `Stream` still holds the sender until the
+    /// `CaptureStream` is dropped), so this method internally polls both
+    /// the channel and [`is_open`](Self::is_open) at a short interval
+    /// rather than relying on channel disconnection alone to wake up.
+    ///
+    /// # Stability
+    /// Part of decibri's stable FFI-consumer API surface.
+    pub fn next_chunk(
+        &self,
+        timeout: Option<Duration>,
+    ) -> Result<Option<AudioChunk>, DecibriError> {
+        // Poll both the channel and `is_open` at this cadence so concurrent
+        // `stop()` calls unblock a waiter within one interval. 20 ms is well
+        // below a typical audio frame period (100 ms at 16 kHz / 1600
+        // frames) so the extra wakeups cost negligible CPU.
+        const POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+        let deadline = timeout.map(|t| Instant::now() + t);
+
+        loop {
+            let wait = match deadline {
+                Some(dl) => {
+                    let now = Instant::now();
+                    if now >= dl {
+                        // Timeout elapsed without a chunk. Drain any
+                        // last-moment arrival before reporting None.
+                        return Ok(self.receiver.try_recv().ok());
+                    }
+                    std::cmp::min(dl - now, POLL_INTERVAL)
+                }
+                None => POLL_INTERVAL,
+            };
+
+            match self.receiver.recv_timeout(wait) {
+                Ok(chunk) => return Ok(Some(chunk)),
+                Err(RecvTimeoutError::Timeout) => {
+                    // Re-check whether `stop()` fired while we waited.
+                    if !self.is_open() {
+                        // Drain any buffered chunk (stop() does not flush).
+                        return match self.receiver.try_recv() {
+                            Ok(chunk) => Ok(Some(chunk)),
+                            Err(_) => Err(DecibriError::CaptureStreamClosed),
+                        };
+                    }
+                    // Stream still alive; loop with whatever deadline remains.
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    return Err(DecibriError::CaptureStreamClosed);
+                }
+            }
+        }
     }
 
     /// Check whether the stream is still actively capturing.
@@ -87,6 +220,14 @@ impl CaptureStream {
     }
 
     /// Stop capturing audio.
+    ///
+    /// Signals the capture callback to stop producing chunks. Already-buffered
+    /// chunks remain readable via [`try_next_chunk`](Self::try_next_chunk) or
+    /// [`next_chunk`](Self::next_chunk) until the buffer is drained, at which
+    /// point those methods return `Err(CaptureStreamClosed)`.
+    ///
+    /// May be called from any thread; wakes a concurrent
+    /// [`next_chunk`](Self::next_chunk) waiter within approximately 20 ms.
     pub fn stop(&self) {
         self.running.store(false, Ordering::Relaxed);
     }
@@ -157,11 +298,152 @@ impl AudioCapture {
             .map_err(|e| DecibriError::StreamStartFailed(e.to_string()))?;
 
         Ok(CaptureStream {
-            _stream: stream,
+            _stream: Some(stream),
             receiver,
             running,
             sample_rate,
             channels,
         })
+    }
+}
+
+#[cfg(all(test, feature = "capture"))]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    /// Construct a synthetic `CaptureStream` with no underlying cpal device
+    /// for unit-testing the channel-reading methods. Returns the stream
+    /// plus test-side handles to inject chunks and flip the running flag.
+    fn test_stream() -> (CaptureStream, Sender<AudioChunk>, Arc<AtomicBool>) {
+        let (sender, receiver) = crossbeam_channel::unbounded::<AudioChunk>();
+        let running = Arc::new(AtomicBool::new(true));
+        let stream = CaptureStream {
+            _stream: None,
+            receiver,
+            running: running.clone(),
+            sample_rate: 16000,
+            channels: 1,
+        };
+        (stream, sender, running)
+    }
+
+    fn make_chunk(first_sample: f32) -> AudioChunk {
+        AudioChunk {
+            data: vec![first_sample],
+            sample_rate: 16000,
+            channels: 1,
+        }
+    }
+
+    #[test]
+    fn test_try_next_chunk_returns_none_when_empty() {
+        let (stream, _sender, _running) = test_stream();
+        let result = stream.try_next_chunk().unwrap();
+        assert!(
+            result.is_none(),
+            "try_next_chunk on empty open stream should return Ok(None)"
+        );
+    }
+
+    #[test]
+    fn test_try_next_chunk_returns_chunk_when_available() {
+        let (stream, sender, _running) = test_stream();
+        sender.send(make_chunk(0.42)).unwrap();
+
+        let result = stream.try_next_chunk().unwrap();
+        let chunk = result.expect("should have received the injected chunk");
+        assert_eq!(chunk.data, vec![0.42]);
+    }
+
+    #[test]
+    fn test_try_next_chunk_returns_err_when_closed() {
+        let (stream, sender, running) = test_stream();
+        drop(sender); // simulate cpal stream dropping the sender
+        running.store(false, Ordering::Relaxed);
+
+        let err = stream.try_next_chunk().unwrap_err();
+        assert!(matches!(err, DecibriError::CaptureStreamClosed));
+    }
+
+    #[test]
+    fn test_next_chunk_blocks_until_chunk_arrives() {
+        let (stream, sender, _running) = test_stream();
+
+        let producer = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(50));
+            sender.send(make_chunk(0.77)).unwrap();
+        });
+
+        let result = stream.next_chunk(None).unwrap();
+        let chunk = result.expect("should have received the eventually-pushed chunk");
+        assert_eq!(chunk.data, vec![0.77]);
+
+        producer.join().unwrap();
+    }
+
+    #[test]
+    fn test_next_chunk_timeout_returns_none() {
+        let (stream, _sender, _running) = test_stream();
+        let start = Instant::now();
+        let result = stream.next_chunk(Some(Duration::from_millis(50))).unwrap();
+        let elapsed = start.elapsed();
+
+        assert!(
+            result.is_none(),
+            "next_chunk with timeout and no arrivals should return Ok(None)"
+        );
+        // Lower bound: at least the requested timeout.
+        assert!(
+            elapsed >= Duration::from_millis(40),
+            "next_chunk returned too early: {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn test_next_chunk_flushes_buffered_before_closed_err() {
+        let (stream, sender, running) = test_stream();
+        sender.send(make_chunk(1.0)).unwrap();
+        sender.send(make_chunk(2.0)).unwrap();
+        drop(sender); // simulate cpal stream drop
+        running.store(false, Ordering::Relaxed);
+
+        // First two calls drain the buffer, third reports closed.
+        let c1 = stream.next_chunk(Some(Duration::from_millis(100))).unwrap();
+        assert_eq!(c1.unwrap().data, vec![1.0]);
+
+        let c2 = stream.next_chunk(Some(Duration::from_millis(100))).unwrap();
+        assert_eq!(c2.unwrap().data, vec![2.0]);
+
+        let err = stream
+            .next_chunk(Some(Duration::from_millis(100)))
+            .unwrap_err();
+        assert!(matches!(err, DecibriError::CaptureStreamClosed));
+    }
+
+    #[test]
+    fn test_next_chunk_returns_closed_within_polling_interval_after_stop() {
+        let (stream, _sender, running) = test_stream();
+
+        let r = running.clone();
+        let stopper = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(30));
+            r.store(false, Ordering::Relaxed);
+        });
+
+        // next_chunk with no timeout should wake up on the next 20 ms poll
+        // after stop() flips the running flag. Give a generous 250 ms ceiling
+        // to absorb scheduler jitter on loaded CI runners.
+        let start = Instant::now();
+        let err = stream.next_chunk(None).unwrap_err();
+        let elapsed = start.elapsed();
+
+        assert!(matches!(err, DecibriError::CaptureStreamClosed));
+        assert!(
+            elapsed < Duration::from_millis(250),
+            "next_chunk took too long to detect stop(): {elapsed:?}"
+        );
+
+        stopper.join().unwrap();
     }
 }

--- a/crates/decibri/src/device.rs
+++ b/crates/decibri/src/device.rs
@@ -88,21 +88,119 @@ fn compute_is_default<Id: PartialEq>(
         .collect()
 }
 
-/// Enumerate all available audio input devices.
+/// Internal trait abstracting the input vs output differences in cpal's
+/// device enumeration and resolution APIs. Allows one generic implementation
+/// of `enumerate_devices` and `resolve_device` to cover both directions.
+///
+/// Not part of the public API; lives here only to deduplicate the per-direction
+/// code paths. Each `impl` is a small table of function pointers into cpal.
 #[cfg(any(feature = "capture", feature = "output"))]
-pub fn enumerate_input_devices() -> Result<Vec<DeviceInfo>, DecibriError> {
+trait DeviceDirection {
+    type Info;
+
+    fn default_device(host: &cpal::Host) -> Option<cpal::Device>;
+    fn list_devices(host: &cpal::Host) -> Result<Vec<cpal::Device>, DecibriError>;
+    /// Returns `(channels, sample_rate)`; `(0, 0)` on config failure (matches
+    /// the pre-consolidation behaviour of surfacing an "unknown" device
+    /// rather than propagating the error).
+    fn default_config(device: &cpal::Device) -> (u16, u32);
+    fn build_info(row: ComputedRow) -> Self::Info;
+    fn no_device_error() -> DecibriError;
+}
+
+#[cfg(any(feature = "capture", feature = "output"))]
+struct Input;
+
+#[cfg(any(feature = "capture", feature = "output"))]
+struct Output;
+
+#[cfg(any(feature = "capture", feature = "output"))]
+impl DeviceDirection for Input {
+    type Info = DeviceInfo;
+
+    fn default_device(host: &cpal::Host) -> Option<cpal::Device> {
+        host.default_input_device()
+    }
+
+    fn list_devices(host: &cpal::Host) -> Result<Vec<cpal::Device>, DecibriError> {
+        host.input_devices()
+            .map(|it| it.collect())
+            .map_err(|e| DecibriError::DeviceEnumerationFailed(e.to_string()))
+    }
+
+    fn default_config(device: &cpal::Device) -> (u16, u32) {
+        match device.default_input_config() {
+            Ok(config) => (config.channels(), config.sample_rate()),
+            Err(_) => (0, 0),
+        }
+    }
+
+    fn build_info(row: ComputedRow) -> Self::Info {
+        DeviceInfo {
+            index: row.index,
+            name: row.name,
+            max_input_channels: row.channels,
+            default_sample_rate: row.sample_rate,
+            is_default: row.is_default,
+        }
+    }
+
+    fn no_device_error() -> DecibriError {
+        DecibriError::NoMicrophoneFound
+    }
+}
+
+#[cfg(any(feature = "capture", feature = "output"))]
+impl DeviceDirection for Output {
+    type Info = OutputDeviceInfo;
+
+    fn default_device(host: &cpal::Host) -> Option<cpal::Device> {
+        host.default_output_device()
+    }
+
+    fn list_devices(host: &cpal::Host) -> Result<Vec<cpal::Device>, DecibriError> {
+        host.output_devices()
+            .map(|it| it.collect())
+            .map_err(|e| DecibriError::DeviceEnumerationFailed(e.to_string()))
+    }
+
+    fn default_config(device: &cpal::Device) -> (u16, u32) {
+        match device.default_output_config() {
+            Ok(config) => (config.channels(), config.sample_rate()),
+            Err(_) => (0, 0),
+        }
+    }
+
+    fn build_info(row: ComputedRow) -> Self::Info {
+        OutputDeviceInfo {
+            index: row.index,
+            name: row.name,
+            max_output_channels: row.channels,
+            default_sample_rate: row.sample_rate,
+            is_default: row.is_default,
+        }
+    }
+
+    fn no_device_error() -> DecibriError {
+        DecibriError::NoOutputDeviceFound
+    }
+}
+
+/// Shared implementation for `enumerate_input_devices` / `enumerate_output_devices`.
+/// Direction-generic via the `DeviceDirection` trait.
+#[cfg(any(feature = "capture", feature = "output"))]
+fn enumerate_devices<D: DeviceDirection>() -> Result<Vec<D::Info>, DecibriError> {
     let host = cpal::default_host();
 
     // Stable per-host id (WASAPI endpoint ID / CoreAudio UID / ALSA pcm_id)
     // for the OS default device. `.id()` is fallible on rare host backends;
     // treat a failure as "no default" rather than propagating.
-    let default_id = host.default_input_device().and_then(|d| d.id().ok());
+    let default_id = D::default_device(&host).and_then(|d| d.id().ok());
 
-    let devices = host
-        .input_devices()
-        .map_err(|e| DecibriError::Other(format!("Failed to enumerate devices: {e}")))?;
+    let devices = D::list_devices(&host)?;
 
     let rows: Vec<(Option<cpal::DeviceId>, String, u16, u32)> = devices
+        .into_iter()
         .enumerate()
         .map(|(index, device)| {
             let id = device.id().ok();
@@ -110,56 +208,38 @@ pub fn enumerate_input_devices() -> Result<Vec<DeviceInfo>, DecibriError> {
                 .description()
                 .map(|d| d.name().to_string())
                 .unwrap_or_else(|_| format!("Unknown Device {index}"));
-            let (channels, sample_rate) = match device.default_input_config() {
-                Ok(config) => (config.channels(), config.sample_rate()),
-                Err(_) => (0, 0),
-            };
+            let (channels, sample_rate) = D::default_config(&device);
             (id, name, channels, sample_rate)
         })
         .collect();
 
     Ok(compute_is_default(rows, default_id)
         .into_iter()
-        .map(|r| DeviceInfo {
-            index: r.index,
-            name: r.name,
-            max_input_channels: r.channels,
-            default_sample_rate: r.sample_rate,
-            is_default: r.is_default,
-        })
+        .map(D::build_info)
         .collect())
 }
 
-/// Resolve a device selector to a cpal Device.
+/// Shared implementation for `resolve_device` / `resolve_output_device`.
 #[cfg(any(feature = "capture", feature = "output"))]
-pub fn resolve_device(selector: &DeviceSelector) -> Result<cpal::Device, DecibriError> {
+fn resolve_device_generic<D: DeviceDirection>(
+    selector: &DeviceSelector,
+) -> Result<cpal::Device, DecibriError> {
     let host = cpal::default_host();
 
     match selector {
-        DeviceSelector::Default => host
-            .default_input_device()
-            .ok_or(DecibriError::NoMicrophoneFound),
+        DeviceSelector::Default => D::default_device(&host).ok_or_else(D::no_device_error),
 
-        DeviceSelector::Index(idx) => {
-            let devices: Vec<_> = host
-                .input_devices()
-                .map_err(|e| DecibriError::Other(format!("Failed to enumerate devices: {e}")))?
-                .collect();
-
-            devices
-                .into_iter()
-                .nth(*idx)
-                .ok_or(DecibriError::DeviceIndexOutOfRange)
-        }
+        DeviceSelector::Index(idx) => D::list_devices(&host)?
+            .into_iter()
+            .nth(*idx)
+            .ok_or(DecibriError::DeviceIndexOutOfRange),
 
         DeviceSelector::Name(query) => {
             let query_lower = query.to_lowercase();
-            let devices = host
-                .input_devices()
-                .map_err(|e| DecibriError::Other(format!("Failed to enumerate devices: {e}")))?;
+            let devices = D::list_devices(&host)?;
 
             let mut matches: Vec<(usize, String, cpal::Device)> = Vec::new();
-            for (index, device) in devices.enumerate() {
+            for (index, device) in devices.into_iter().enumerate() {
                 let name = device
                     .description()
                     .map(|d| d.name().to_string())
@@ -188,107 +268,30 @@ pub fn resolve_device(selector: &DeviceSelector) -> Result<cpal::Device, Decibri
             }
         }
     }
+}
+
+/// Enumerate all available audio input devices.
+#[cfg(any(feature = "capture", feature = "output"))]
+pub fn enumerate_input_devices() -> Result<Vec<DeviceInfo>, DecibriError> {
+    enumerate_devices::<Input>()
 }
 
 /// Enumerate all available audio output devices.
 #[cfg(any(feature = "capture", feature = "output"))]
 pub fn enumerate_output_devices() -> Result<Vec<OutputDeviceInfo>, DecibriError> {
-    let host = cpal::default_host();
+    enumerate_devices::<Output>()
+}
 
-    // Stable per-host id for the OS default output device; see
-    // `enumerate_input_devices` for rationale (same Issue #14 fix pattern).
-    let default_id = host.default_output_device().and_then(|d| d.id().ok());
-
-    let devices = host
-        .output_devices()
-        .map_err(|e| DecibriError::Other(format!("Failed to enumerate devices: {e}")))?;
-
-    let rows: Vec<(Option<cpal::DeviceId>, String, u16, u32)> = devices
-        .enumerate()
-        .map(|(index, device)| {
-            let id = device.id().ok();
-            let name = device
-                .description()
-                .map(|d| d.name().to_string())
-                .unwrap_or_else(|_| format!("Unknown Device {index}"));
-            let (channels, sample_rate) = match device.default_output_config() {
-                Ok(config) => (config.channels(), config.sample_rate()),
-                Err(_) => (0, 0),
-            };
-            (id, name, channels, sample_rate)
-        })
-        .collect();
-
-    Ok(compute_is_default(rows, default_id)
-        .into_iter()
-        .map(|r| OutputDeviceInfo {
-            index: r.index,
-            name: r.name,
-            max_output_channels: r.channels,
-            default_sample_rate: r.sample_rate,
-            is_default: r.is_default,
-        })
-        .collect())
+/// Resolve a device selector to a cpal Device.
+#[cfg(any(feature = "capture", feature = "output"))]
+pub fn resolve_device(selector: &DeviceSelector) -> Result<cpal::Device, DecibriError> {
+    resolve_device_generic::<Input>(selector)
 }
 
 /// Resolve an output device selector to a cpal Device.
 #[cfg(any(feature = "capture", feature = "output"))]
 pub fn resolve_output_device(selector: &DeviceSelector) -> Result<cpal::Device, DecibriError> {
-    let host = cpal::default_host();
-
-    match selector {
-        DeviceSelector::Default => host
-            .default_output_device()
-            .ok_or(DecibriError::NoOutputDeviceFound),
-
-        DeviceSelector::Index(idx) => {
-            let devices: Vec<_> = host
-                .output_devices()
-                .map_err(|e| DecibriError::Other(format!("Failed to enumerate devices: {e}")))?
-                .collect();
-
-            devices
-                .into_iter()
-                .nth(*idx)
-                .ok_or(DecibriError::DeviceIndexOutOfRange)
-        }
-
-        DeviceSelector::Name(query) => {
-            let query_lower = query.to_lowercase();
-            let devices = host
-                .output_devices()
-                .map_err(|e| DecibriError::Other(format!("Failed to enumerate devices: {e}")))?;
-
-            let mut matches: Vec<(usize, String, cpal::Device)> = Vec::new();
-            for (index, device) in devices.enumerate() {
-                let name = device
-                    .description()
-                    .map(|d| d.name().to_string())
-                    .unwrap_or_default();
-                if name.to_lowercase().contains(&query_lower) {
-                    matches.push((index, name, device));
-                }
-            }
-
-            match matches.len() {
-                0 => Err(DecibriError::DeviceNotFound(query.clone())),
-                1 => Ok(matches.into_iter().next().unwrap().2),
-                _ => {
-                    let match_list = matches
-                        .iter()
-                        .map(|(idx, name, _)| format!("  [{idx}] {name}"))
-                        .collect::<Vec<_>>()
-                        .join("\n");
-                    Err(DecibriError::MultipleDevicesMatch {
-                        name: query.clone(),
-                        matches: format!(
-                            "{match_list}\nUse a more specific name or pass the device index directly."
-                        ),
-                    })
-                }
-            }
-        }
-    }
+    resolve_device_generic::<Output>(selector)
 }
 
 #[cfg(all(test, any(feature = "capture", feature = "output")))]

--- a/crates/decibri/src/error.rs
+++ b/crates/decibri/src/error.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use thiserror::Error;
 
 /// Errors produced by decibri operations.
@@ -79,37 +81,84 @@ pub enum DecibriError {
     VadThresholdOutOfRange(f32),
 
     // ── ORT and VAD model errors ───────────────────────────────────────
+    //
+    // These variants carry a structured `ort::Error` via `#[source]` so
+    // downstream consumers can walk `error.source()` to the underlying
+    // ORT error for programmatic handling. Paths are `PathBuf` (not
+    // `String`) so consumers retain path semantics without re-parsing.
     #[error(
-        "decibri: failed to initialize ONNX Runtime: {message}. \
+        "decibri: failed to initialize ONNX Runtime: {source}. \
          Either pass ort_library_path in VadConfig, set ORT_DYLIB_PATH to \
          point to a valid ONNX Runtime library, or enable the \
          `ort-download-binaries` feature for zero-config builds."
     )]
-    OrtInitFailed { message: String },
+    OrtInitFailed {
+        #[source]
+        source: ort::Error,
+    },
 
     #[error(
-        "decibri: failed to load ONNX Runtime from {path}: {message}. \
+        "decibri: failed to load ONNX Runtime from {}: {source}. \
          If ORT_DYLIB_PATH is set, verify it points to a valid ONNX Runtime \
          library for your platform. Otherwise the bundled ORT may be missing \
-         from your platform package. Try reinstalling decibri."
+         from your platform package. Try reinstalling decibri.",
+        path.display()
     )]
-    OrtLoadFailed { path: String, message: String },
+    OrtLoadFailed {
+        path: PathBuf,
+        #[source]
+        source: ort::Error,
+    },
+
+    /// The `ort_library_path` in `VadConfig` failed a pre-check before it
+    /// could be handed to `ort::init_from`. Used only by the Windows
+    /// hang-prevention pre-check in `init_ort_once`.
+    ///
+    /// Intentionally does *not* carry an `ort::Error` source, because
+    /// constructing an `ort::Error` under `ort-load-dynamic` calls into the
+    /// ORT C API (`ortsys![CreateStatus]`) — which is exactly the hang this
+    /// pre-check is designed to prevent. Keeping this variant string-only
+    /// means the pre-check never touches ORT symbols.
+    ///
+    /// Display message matches [`Self::OrtLoadFailed`] so Node, Python, and
+    /// future FFI consumers see the same actionable hint regardless of which
+    /// failure path was taken.
+    #[error(
+        "decibri: failed to load ONNX Runtime from {}: {reason}. \
+         If ORT_DYLIB_PATH is set, verify it points to a valid ONNX Runtime \
+         library for your platform. Otherwise the bundled ORT may be missing \
+         from your platform package. Try reinstalling decibri.",
+        path.display()
+    )]
+    OrtPathInvalid { path: PathBuf, reason: &'static str },
 
     #[error("Failed to create ort session builder: {0}")]
-    OrtSessionBuildFailed(String),
+    OrtSessionBuildFailed(#[source] ort::Error),
 
     #[error("Failed to set ort threads: {0}")]
-    OrtThreadsConfigFailed(String),
+    OrtThreadsConfigFailed(#[source] ort::Error),
 
-    #[error("Failed to load Silero VAD model from {path}: {message}")]
-    VadModelLoadFailed { path: String, message: String },
+    #[error("Failed to load Silero VAD model from {}: {source}", path.display())]
+    VadModelLoadFailed {
+        path: PathBuf,
+        #[source]
+        source: ort::Error,
+    },
 
     #[error("Silero VAD inference failed: {0}")]
-    OrtInferenceFailed(String),
+    OrtInferenceFailed(#[source] ort::Error),
 
-    #[error("Failed to create {kind} tensor: {message}")]
-    OrtTensorCreateFailed { kind: &'static str, message: String },
+    #[error("Failed to create {kind} tensor: {source}")]
+    OrtTensorCreateFailed {
+        kind: &'static str,
+        #[source]
+        source: ort::Error,
+    },
 
-    #[error("Failed to extract {kind} tensor: {message}")]
-    OrtTensorExtractFailed { kind: &'static str, message: String },
+    #[error("Failed to extract {kind} tensor: {source}")]
+    OrtTensorExtractFailed {
+        kind: &'static str,
+        #[source]
+        source: ort::Error,
+    },
 }

--- a/crates/decibri/src/error.rs
+++ b/crates/decibri/src/error.rs
@@ -162,3 +162,28 @@ pub enum DecibriError {
         source: ort::Error,
     },
 }
+
+impl DecibriError {
+    /// Returns true if this error represents a failure to use a specific
+    /// ORT library path.
+    ///
+    /// Consumers handling "the `ort_library_path` is wrong" logic should
+    /// match on this rather than enumerating [`Self::OrtLoadFailed`] and
+    /// [`Self::OrtPathInvalid`] separately:
+    ///
+    /// - [`Self::OrtLoadFailed`] fires when ORT tried to load the path and
+    ///   failed (e.g. wrong ORT version, corrupted dylib).
+    /// - [`Self::OrtPathInvalid`] fires when decibri's filesystem pre-check
+    ///   rejected the path before ORT saw it (nonexistent, directory, etc).
+    ///
+    /// Both represent the same user-facing failure mode: "this path cannot
+    /// be used to load ORT." The split is a mechanical necessity (see the
+    /// rustdoc on [`Self::OrtPathInvalid`]), not a categorization users
+    /// need to care about.
+    pub fn is_ort_path_error(&self) -> bool {
+        matches!(
+            self,
+            Self::OrtLoadFailed { .. } | Self::OrtPathInvalid { .. }
+        )
+    }
+}

--- a/crates/decibri/src/error.rs
+++ b/crates/decibri/src/error.rs
@@ -1,8 +1,14 @@
 use thiserror::Error;
 
 /// Errors produced by decibri operations.
+///
+/// This enum is `#[non_exhaustive]`: consumers pattern-matching on it must
+/// include a `_ =>` catch-all arm so future variant additions are not
+/// source-breaking.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum DecibriError {
+    // ── Config validation ──────────────────────────────────────────────
     #[error("sampleRate must be between 1000 and 384000")]
     SampleRateOutOfRange,
 
@@ -15,6 +21,7 @@ pub enum DecibriError {
     #[error("format must be 'int16' or 'float32'")]
     InvalidFormat,
 
+    // ── Device errors ──────────────────────────────────────────────────
     #[error("No audio input device found matching \"{0}\"")]
     DeviceNotFound(String),
 
@@ -33,6 +40,10 @@ pub enum DecibriError {
     #[error("Selected device is not a valid input device.")]
     NotAnInputDevice,
 
+    #[error("Failed to enumerate devices: {0}")]
+    DeviceEnumerationFailed(String),
+
+    // ── Stream errors ──────────────────────────────────────────────────
     #[error("Decibri is already running. Call stop() first.")]
     AlreadyRunning,
 
@@ -45,6 +56,60 @@ pub enum DecibriError {
     #[error("Microphone permission denied. Enable in System Preferences > Security & Privacy.")]
     PermissionDenied,
 
-    #[error("{0}")]
-    Other(String),
+    /// Capture stream has closed (stopped explicitly or by driver error).
+    /// Returned from `CaptureStream::try_next_chunk` / `next_chunk` when the
+    /// underlying channel has disconnected.
+    #[error("Capture stream is closed")]
+    CaptureStreamClosed,
+
+    /// Output stream has closed. Returned from `OutputStream::send` when the
+    /// underlying channel has disconnected.
+    #[error("Output stream closed")]
+    OutputStreamClosed,
+
+    // ── VAD config validation ──────────────────────────────────────────
+    /// Payload carries the offending sample rate; not formatted into the
+    /// Display string to preserve the 3.1.x message text.
+    #[error("Silero VAD only supports sample rates 8000 and 16000")]
+    VadSampleRateUnsupported(u32),
+
+    /// Payload carries the offending threshold; not formatted into the
+    /// Display string to preserve the 3.1.x message text.
+    #[error("VAD threshold must be between 0.0 and 1.0")]
+    VadThresholdOutOfRange(f32),
+
+    // ── ORT and VAD model errors ───────────────────────────────────────
+    #[error(
+        "decibri: failed to initialize ONNX Runtime: {message}. \
+         Either pass ort_library_path in VadConfig, set ORT_DYLIB_PATH to \
+         point to a valid ONNX Runtime library, or enable the \
+         `ort-download-binaries` feature for zero-config builds."
+    )]
+    OrtInitFailed { message: String },
+
+    #[error(
+        "decibri: failed to load ONNX Runtime from {path}: {message}. \
+         If ORT_DYLIB_PATH is set, verify it points to a valid ONNX Runtime \
+         library for your platform. Otherwise the bundled ORT may be missing \
+         from your platform package. Try reinstalling decibri."
+    )]
+    OrtLoadFailed { path: String, message: String },
+
+    #[error("Failed to create ort session builder: {0}")]
+    OrtSessionBuildFailed(String),
+
+    #[error("Failed to set ort threads: {0}")]
+    OrtThreadsConfigFailed(String),
+
+    #[error("Failed to load Silero VAD model from {path}: {message}")]
+    VadModelLoadFailed { path: String, message: String },
+
+    #[error("Silero VAD inference failed: {0}")]
+    OrtInferenceFailed(String),
+
+    #[error("Failed to create {kind} tensor: {message}")]
+    OrtTensorCreateFailed { kind: &'static str, message: String },
+
+    #[error("Failed to extract {kind} tensor: {message}")]
+    OrtTensorExtractFailed { kind: &'static str, message: String },
 }

--- a/crates/decibri/src/lib.rs
+++ b/crates/decibri/src/lib.rs
@@ -1,3 +1,94 @@
+//! Cross-platform audio capture, playback, and voice-activity detection.
+//!
+//! `decibri` is the Rust core behind the `decibri` npm package. It provides:
+//!
+//! - **Audio capture** ([`capture`]): microphone input with frame-exact
+//!   buffering, built on cpal.
+//! - **Audio playback** ([`output`]): speaker output with graceful drain
+//!   and immediate-stop semantics.
+//! - **Voice activity detection** ([`vad`]): Silero VAD v5 inference via
+//!   ONNX Runtime, per-call stateful.
+//! - **Device enumeration** ([`device`]): list and select audio devices
+//!   by index or case-insensitive name substring.
+//!
+//! # Feature flags
+//!
+//! | Flag                    | Default | Purpose                                      |
+//! |-------------------------|---------|----------------------------------------------|
+//! | `capture`               | on      | Microphone input stream support              |
+//! | `output`                | on      | Speaker output stream support                |
+//! | `vad`                   | on      | Silero VAD ONNX inference                    |
+//! | `denoise`               | on      | Reserved (stub)                              |
+//! | `gain`                  | on      | Reserved (stub)                              |
+//! | `ort-load-dynamic`      | on      | ORT loaded at runtime from a user path       |
+//! | `ort-download-binaries` | off     | ORT downloaded at build time, embedded       |
+//!
+//! `ort-load-dynamic` and `ort-download-binaries` are mutually exclusive;
+//! selecting both is a compile error.
+//!
+//! # Example: capture and run VAD
+//!
+//! [`CaptureStream::next_chunk`](capture::CaptureStream::next_chunk) is the
+//! recommended FFI-ready interface for reading audio chunks, returning a
+//! three-state `Result`: `Ok(Some(chunk))` / `Ok(None)` (timeout, stream
+//! still open) / `Err(DecibriError::CaptureStreamClosed)`.
+//!
+//! ```ignore
+//! use std::time::Duration;
+//! use decibri::capture::{AudioCapture, CaptureConfig};
+//! use decibri::error::DecibriError;
+//! use decibri::vad::{SileroVad, VadConfig};
+//!
+//! let capture = AudioCapture::new(CaptureConfig::default())?;
+//! let stream  = capture.start()?;
+//! let mut vad = SileroVad::new(VadConfig::default())?;
+//!
+//! loop {
+//!     match stream.next_chunk(Some(Duration::from_millis(100))) {
+//!         Ok(Some(chunk)) => {
+//!             let result = vad.process(&chunk.data)?;
+//!             if result.is_speech {
+//!                 println!("speech @ p={:.2}", result.probability);
+//!             }
+//!         }
+//!         Ok(None) => continue,
+//!         Err(DecibriError::CaptureStreamClosed) => break,
+//!         Err(e) => return Err(e.into()),
+//!     }
+//! }
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! # Process-global ORT initialization
+//!
+//! ONNX Runtime initializes exactly once per process. The first successful
+//! [`SileroVad::new`](vad::SileroVad::new) call wins; later constructions
+//! with a different [`vad::VadConfig::ort_library_path`] silently reuse the
+//! first path. See [`vad::VadConfig`] for details.
+//!
+//! # Thread safety
+//!
+//! All public types are `Send` and suitable for cross-thread handoff.
+//! [`capture::CaptureStream`] and [`output::OutputStream`] are `!Sync`
+//! because they hold a `cpal::Stream` internally; wrap them in a mutex or
+//! move them into a dedicated thread for shared access.
+//!
+//! # Stability
+//!
+//! Within 3.x, the following FFI-consumer surface is declared stable and
+//! will not change signature without a breaking version bump:
+//!
+//! - [`capture::CaptureStream`][] —
+//!   [`try_next_chunk`](capture::CaptureStream::try_next_chunk),
+//!   [`next_chunk`](capture::CaptureStream::next_chunk),
+//!   [`is_open`](capture::CaptureStream::is_open),
+//!   [`stop`](capture::CaptureStream::stop).
+//! - [`output::OutputStream`][] —
+//!   [`send`](output::OutputStream::send),
+//!   [`drain`](output::OutputStream::drain),
+//!   [`is_playing`](output::OutputStream::is_playing),
+//!   [`stop`](output::OutputStream::stop).
+
 #[cfg(all(feature = "ort-load-dynamic", feature = "ort-download-binaries"))]
 compile_error!(
     "features `ort-load-dynamic` and `ort-download-binaries` are mutually exclusive; \

--- a/crates/decibri/src/output.rs
+++ b/crates/decibri/src/output.rs
@@ -64,7 +64,7 @@ impl OutputStream {
         }
         self.sender
             .send(samples)
-            .map_err(|_| DecibriError::Other("Output stream closed".to_string()))
+            .map_err(|_| DecibriError::OutputStreamClosed)
     }
 
     /// Graceful drain: sends a sentinel (empty vec), then blocks until the

--- a/crates/decibri/src/output.rs
+++ b/crates/decibri/src/output.rs
@@ -56,8 +56,32 @@ pub struct OutputStream {
 
 #[cfg(feature = "output")]
 impl OutputStream {
-    /// Send f32 samples for playback. Blocks if the internal buffer is full
-    /// (backpressure propagates to the caller).
+    /// Send f32 samples for playback.
+    ///
+    /// Samples are queued into an internal bounded channel feeding the cpal
+    /// output callback. If the channel is full, this method **blocks** the
+    /// calling thread until the callback consumes enough samples to make
+    /// room, so that backpressure propagates naturally to the producer.
+    ///
+    /// Empty `samples` vectors are treated as a no-op and return `Ok(())`
+    /// without touching the channel.
+    ///
+    /// # Returns
+    /// - `Ok(())` — samples accepted into the playback queue (or buffer was
+    ///   empty).
+    /// - `Err(DecibriError::OutputStreamClosed)` — the output stream has
+    ///   been stopped or dropped; no further samples can be played.
+    ///
+    /// # Thread safety
+    /// `&self`-taking: may be called concurrently from multiple threads, but
+    /// the interleaving of their samples in the playback stream is not
+    /// defined. For deterministic output, serialize calls from a single
+    /// producer thread.
+    ///
+    /// # Stability
+    /// Part of decibri's stable FFI-consumer API surface. Signature and
+    /// three-state semantics (ok / empty-noop / closed) are guaranteed
+    /// stable across 3.x; any change will be a breaking version bump.
     pub fn send(&self, samples: Vec<f32>) -> Result<(), DecibriError> {
         if samples.is_empty() {
             return Ok(());

--- a/crates/decibri/src/vad.rs
+++ b/crates/decibri/src/vad.rs
@@ -55,6 +55,29 @@ impl Default for VadConfig {
     }
 }
 
+impl VadConfig {
+    /// Validate configuration values.
+    ///
+    /// Called automatically by [`SileroVad::new`]; exposed publicly so
+    /// callers can fail-fast before paying the cost of ORT init and
+    /// ONNX model load.
+    ///
+    /// # Errors
+    /// - [`DecibriError::VadSampleRateUnsupported`] if `sample_rate` is not
+    ///   8000 or 16000.
+    /// - [`DecibriError::VadThresholdOutOfRange`] if `threshold` is outside
+    ///   `[0.0, 1.0]`.
+    pub fn validate(&self) -> Result<(), DecibriError> {
+        if self.sample_rate != 8000 && self.sample_rate != 16000 {
+            return Err(DecibriError::VadSampleRateUnsupported(self.sample_rate));
+        }
+        if !(0.0..=1.0).contains(&self.threshold) {
+            return Err(DecibriError::VadThresholdOutOfRange(self.threshold));
+        }
+        Ok(())
+    }
+}
+
 /// Result of processing an audio chunk through Silero VAD.
 #[derive(Debug, Clone)]
 pub struct VadResult {
@@ -96,24 +119,20 @@ static ORT_INIT: OnceLock<Option<PathBuf>> = OnceLock::new();
 /// Kept as a standalone generic function (rather than an inline closure in
 /// `init_ort_once`) so it can be unit-tested without triggering a real ORT
 /// init failure. Tests pass a synthetic `err` value.
+///
+/// Returns one of two typed variants depending on whether a path was provided:
+/// [`DecibriError::OrtLoadFailed`] when `path.is_some()`, or
+/// [`DecibriError::OrtInitFailed`] otherwise.
 #[cfg(feature = "vad")]
 fn wrap_init_error<E: std::fmt::Display>(path: Option<&Path>, err: E) -> DecibriError {
     match path {
-        Some(p) => DecibriError::Other(format!(
-            "decibri: failed to load ONNX Runtime from {}: {}. \
-             If ORT_DYLIB_PATH is set, verify it points to a valid ONNX Runtime \
-             library for your platform. Otherwise the bundled ORT may be missing \
-             from your platform package. Try reinstalling decibri.",
-            p.display(),
-            err
-        )),
-        None => DecibriError::Other(format!(
-            "decibri: failed to initialize ONNX Runtime: {}. \
-             Either pass ort_library_path in VadConfig, set ORT_DYLIB_PATH to \
-             point to a valid ONNX Runtime library, or enable the \
-             `ort-download-binaries` feature for zero-config builds.",
-            err
-        )),
+        Some(p) => DecibriError::OrtLoadFailed {
+            path: p.display().to_string(),
+            message: err.to_string(),
+        },
+        None => DecibriError::OrtInitFailed {
+            message: err.to_string(),
+        },
     }
 }
 
@@ -175,36 +194,27 @@ fn init_ort_once(path: Option<&Path>) -> Result<(), DecibriError> {
 impl SileroVad {
     /// Create a new Silero VAD instance by loading the ONNX model.
     pub fn new(config: VadConfig) -> Result<Self, DecibriError> {
+        config.validate()?;
+
+        // Safe to unwrap-via-unreachable: validate() rejected anything else.
         let window_size = match config.sample_rate {
             16000 => 512,
             8000 => 256,
-            _ => {
-                return Err(DecibriError::Other(
-                    "Silero VAD only supports sample rates 8000 and 16000".to_string(),
-                ))
-            }
+            _ => unreachable!("VadConfig::validate accepts only 8000 and 16000"),
         };
-
-        if config.threshold < 0.0 || config.threshold > 1.0 {
-            return Err(DecibriError::Other(
-                "VAD threshold must be between 0.0 and 1.0".to_string(),
-            ));
-        }
 
         // Initialize ORT exactly once per process. Subsequent SileroVad
         // instances pass through immediately regardless of their ort_library_path.
         init_ort_once(config.ort_library_path.as_deref())?;
 
         let session = ort::session::Session::builder()
-            .map_err(|e| DecibriError::Other(format!("Failed to create ort session builder: {e}")))?
+            .map_err(|e| DecibriError::OrtSessionBuildFailed(e.to_string()))?
             .with_intra_threads(1)
-            .map_err(|e| DecibriError::Other(format!("Failed to set ort threads: {e}")))?
+            .map_err(|e| DecibriError::OrtThreadsConfigFailed(e.to_string()))?
             .commit_from_file(&config.model_path)
-            .map_err(|e| {
-                DecibriError::Other(format!(
-                    "Failed to load Silero VAD model from {}: {e}",
-                    config.model_path.display()
-                ))
+            .map_err(|e| DecibriError::VadModelLoadFailed {
+                path: config.model_path.display().to_string(),
+                message: e.to_string(),
             })?;
 
         Ok(Self {
@@ -266,12 +276,22 @@ impl SileroVad {
         //   sr:    i64 scalar
         let input_tensor =
             ort::value::Tensor::from_array(([1i64, self.window_size as i64], window.to_vec()))
-                .map_err(|e| DecibriError::Other(format!("Failed to create input tensor: {e}")))?;
+                .map_err(|e| DecibriError::OrtTensorCreateFailed {
+                    kind: "input",
+                    message: e.to_string(),
+                })?;
         let state_tensor =
-            ort::value::Tensor::from_array(([2i64, 1i64, 128i64], self.state.clone()))
-                .map_err(|e| DecibriError::Other(format!("Failed to create state tensor: {e}")))?;
+            ort::value::Tensor::from_array(([2i64, 1i64, 128i64], self.state.clone())).map_err(
+                |e| DecibriError::OrtTensorCreateFailed {
+                    kind: "state",
+                    message: e.to_string(),
+                },
+            )?;
         let sr_tensor = ort::value::Tensor::from_array(([1i64], vec![self.sample_rate as i64]))
-            .map_err(|e| DecibriError::Other(format!("Failed to create sr tensor: {e}")))?;
+            .map_err(|e| DecibriError::OrtTensorCreateFailed {
+                kind: "sr",
+                message: e.to_string(),
+            })?;
 
         let input_values = ort::inputs![
             "input" => input_tensor,
@@ -282,19 +302,25 @@ impl SileroVad {
         let outputs = self
             .session
             .run(input_values)
-            .map_err(|e| DecibriError::Other(format!("Silero VAD inference failed: {e}")))?;
+            .map_err(|e| DecibriError::OrtInferenceFailed(e.to_string()))?;
 
         // Read outputs using actual model tensor names:
         //   output: f32[1, 1] (speech probability)
         //   stateN: f32[2, 1, 128] (updated state)
-        let prob_tensor = outputs["output"]
-            .try_extract_tensor::<f32>()
-            .map_err(|e| DecibriError::Other(format!("Failed to extract output tensor: {e}")))?;
+        let prob_tensor = outputs["output"].try_extract_tensor::<f32>().map_err(|e| {
+            DecibriError::OrtTensorExtractFailed {
+                kind: "output",
+                message: e.to_string(),
+            }
+        })?;
         let probability = prob_tensor.1[0];
 
-        let state_tensor = outputs["stateN"]
-            .try_extract_tensor::<f32>()
-            .map_err(|e| DecibriError::Other(format!("Failed to extract state tensor: {e}")))?;
+        let state_tensor = outputs["stateN"].try_extract_tensor::<f32>().map_err(|e| {
+            DecibriError::OrtTensorExtractFailed {
+                kind: "state",
+                message: e.to_string(),
+            }
+        })?;
         self.state.copy_from_slice(state_tensor.1);
 
         Ok(probability)
@@ -461,7 +487,6 @@ mod tests {
         let samples = vec![0.0f32; 512];
         vad.process(&samples).unwrap();
         vad.accumulator.extend_from_slice(&[0.0; 100]); // add some leftover
-
         vad.reset();
 
         assert!(vad.state.iter().all(|&v| v == 0.0), "State should be zeros");

--- a/crates/decibri/src/vad.rs
+++ b/crates/decibri/src/vad.rs
@@ -116,23 +116,23 @@ static ORT_INIT: OnceLock<Option<PathBuf>> = OnceLock::new();
 
 /// Wrap an ORT init failure with a decibri-specific actionable message.
 ///
-/// Kept as a standalone generic function (rather than an inline closure in
+/// Kept as a standalone function (rather than an inline closure in
 /// `init_ort_once`) so it can be unit-tested without triggering a real ORT
-/// init failure. Tests pass a synthetic `err` value.
+/// init failure. Tests construct a synthetic `ort::Error` via
+/// [`ort::Error::new`].
 ///
 /// Returns one of two typed variants depending on whether a path was provided:
 /// [`DecibriError::OrtLoadFailed`] when `path.is_some()`, or
-/// [`DecibriError::OrtInitFailed`] otherwise.
+/// [`DecibriError::OrtInitFailed`] otherwise. The inner `ort::Error` is
+/// carried via `#[source]` so consumers can walk the error chain.
 #[cfg(feature = "vad")]
-fn wrap_init_error<E: std::fmt::Display>(path: Option<&Path>, err: E) -> DecibriError {
+fn wrap_init_error(path: Option<&Path>, err: ort::Error) -> DecibriError {
     match path {
         Some(p) => DecibriError::OrtLoadFailed {
-            path: p.display().to_string(),
-            message: err.to_string(),
+            path: p.to_path_buf(),
+            source: err,
         },
-        None => DecibriError::OrtInitFailed {
-            message: err.to_string(),
-        },
+        None => DecibriError::OrtInitFailed { source: err },
     }
 }
 
@@ -193,9 +193,14 @@ fn init_ort_once(path: Option<&Path>) -> Result<(), DecibriError> {
     #[cfg(feature = "ort-load-dynamic")]
     if let Some(p) = path {
         if !p.is_file() {
-            return Err(DecibriError::OrtLoadFailed {
-                path: p.display().to_string(),
-                message: "path does not exist or is not a regular file".to_string(),
+            // Use `OrtPathInvalid`, not `OrtLoadFailed`, precisely because
+            // constructing an `ort::Error` here would call `ortsys![
+            // CreateStatus]` — which triggers the ORT dylib load that this
+            // pre-check is designed to prevent. `OrtPathInvalid` is
+            // string-only and never touches ORT symbols.
+            return Err(DecibriError::OrtPathInvalid {
+                path: p.to_path_buf(),
+                reason: "path does not exist or is not a regular file",
             });
         }
     }
@@ -229,13 +234,16 @@ impl SileroVad {
         init_ort_once(config.ort_library_path.as_deref())?;
 
         let session = ort::session::Session::builder()
-            .map_err(|e| DecibriError::OrtSessionBuildFailed(e.to_string()))?
+            .map_err(DecibriError::OrtSessionBuildFailed)?
+            // `with_intra_threads` returns `ort::Error<SessionBuilder>`; use a
+            // closure with `.into()` to convert to `ort::Error<()>` via the
+            // upstream `From<Error<SessionBuilder>> for Error<()>` impl.
             .with_intra_threads(1)
-            .map_err(|e| DecibriError::OrtThreadsConfigFailed(e.to_string()))?
+            .map_err(|e| DecibriError::OrtThreadsConfigFailed(e.into()))?
             .commit_from_file(&config.model_path)
             .map_err(|e| DecibriError::VadModelLoadFailed {
-                path: config.model_path.display().to_string(),
-                message: e.to_string(),
+                path: config.model_path.clone(),
+                source: e,
             })?;
 
         Ok(Self {
@@ -299,19 +307,19 @@ impl SileroVad {
             ort::value::Tensor::from_array(([1i64, self.window_size as i64], window.to_vec()))
                 .map_err(|e| DecibriError::OrtTensorCreateFailed {
                     kind: "input",
-                    message: e.to_string(),
+                    source: e,
                 })?;
         let state_tensor =
             ort::value::Tensor::from_array(([2i64, 1i64, 128i64], self.state.clone())).map_err(
                 |e| DecibriError::OrtTensorCreateFailed {
                     kind: "state",
-                    message: e.to_string(),
+                    source: e,
                 },
             )?;
         let sr_tensor = ort::value::Tensor::from_array(([1i64], vec![self.sample_rate as i64]))
             .map_err(|e| DecibriError::OrtTensorCreateFailed {
                 kind: "sr",
-                message: e.to_string(),
+                source: e,
             })?;
 
         let input_values = ort::inputs![
@@ -323,7 +331,7 @@ impl SileroVad {
         let outputs = self
             .session
             .run(input_values)
-            .map_err(|e| DecibriError::OrtInferenceFailed(e.to_string()))?;
+            .map_err(DecibriError::OrtInferenceFailed)?;
 
         // Read outputs using actual model tensor names:
         //   output: f32[1, 1] (speech probability)
@@ -331,7 +339,7 @@ impl SileroVad {
         let prob_tensor = outputs["output"].try_extract_tensor::<f32>().map_err(|e| {
             DecibriError::OrtTensorExtractFailed {
                 kind: "output",
-                message: e.to_string(),
+                source: e,
             }
         })?;
         let probability = prob_tensor.1[0];
@@ -339,7 +347,7 @@ impl SileroVad {
         let state_tensor = outputs["stateN"].try_extract_tensor::<f32>().map_err(|e| {
             DecibriError::OrtTensorExtractFailed {
                 kind: "state",
-                message: e.to_string(),
+                source: e,
             }
         })?;
         self.state.copy_from_slice(state_tensor.1);
@@ -378,7 +386,10 @@ mod tests {
 
         // Platform-agnostic invalid path (guaranteed to not exist on any OS).
         let bogus_path = env::temp_dir().join("does-not-exist-onnxruntime-xyz-test");
-        let err = wrap_init_error(Some(bogus_path.as_path()), "simulated ort loader failure");
+        let err = wrap_init_error(
+            Some(bogus_path.as_path()),
+            ort::Error::new("simulated ort loader failure"),
+        );
         let msg = err.to_string();
 
         assert!(
@@ -397,7 +408,7 @@ mod tests {
 
     #[test]
     fn test_wrap_init_error_without_path() {
-        let err = wrap_init_error(None, "simulated ort init failure");
+        let err = wrap_init_error(None, ort::Error::new("simulated ort init failure"));
         let msg = err.to_string();
 
         assert!(

--- a/crates/decibri/src/vad.rs
+++ b/crates/decibri/src/vad.rs
@@ -179,6 +179,27 @@ fn init_ort_once(path: Option<&Path>) -> Result<(), DecibriError> {
         return Ok(());
     }
 
+    // Defensive pre-check (load-dynamic only): verify the path points at a
+    // regular file before handing it to `ort::init_from`. A nonexistent path
+    // or a path that points at a directory causes `ort::init_from` on Windows
+    // to hang indefinitely (reproduced 2026-04-22 against pyke/ort
+    // 2.0.0-rc.12 + onnxruntime 1.24.4). Failing fast here turns that hang
+    // into a clean typed error that Node, Python, and mobile consumers can
+    // surface to users.
+    //
+    // The check is intentionally scoped to `load-dynamic`: under
+    // `download-binaries`, ORT is statically linked and the path argument
+    // is ignored, so there is nothing to pre-validate.
+    #[cfg(feature = "ort-load-dynamic")]
+    if let Some(p) = path {
+        if !p.is_file() {
+            return Err(DecibriError::OrtLoadFailed {
+                path: p.display().to_string(),
+                message: "path does not exist or is not a regular file".to_string(),
+            });
+        }
+    }
+
     match do_ort_init(path) {
         Ok(_committed) => {
             // First-caller-wins. If another thread set it first, discard ours;

--- a/crates/decibri/src/vad.rs
+++ b/crates/decibri/src/vad.rs
@@ -56,25 +56,36 @@ impl Default for VadConfig {
 }
 
 impl VadConfig {
-    /// Validate configuration values.
+    /// Validate configuration values and return the Silero VAD window size
+    /// derived from the sample rate.
     ///
     /// Called automatically by [`SileroVad::new`]; exposed publicly so
     /// callers can fail-fast before paying the cost of ORT init and
-    /// ONNX model load.
+    /// ONNX model load. The returned `usize` is the `window_size` the
+    /// VAD model operates on (512 for 16 kHz, 256 for 8 kHz). Direct
+    /// consumers that only care about pass/fail can use `.is_ok()` or
+    /// `.map(|_| ())`.
+    ///
+    /// Pairing the window-size derivation with the sample-rate validation
+    /// means a future extension to `validate()` that accepts new sample
+    /// rates must also yield a corresponding window size, turning a
+    /// potential runtime `unreachable!` panic into a compile error.
     ///
     /// # Errors
     /// - [`DecibriError::VadSampleRateUnsupported`] if `sample_rate` is not
     ///   8000 or 16000.
     /// - [`DecibriError::VadThresholdOutOfRange`] if `threshold` is outside
     ///   `[0.0, 1.0]`.
-    pub fn validate(&self) -> Result<(), DecibriError> {
-        if self.sample_rate != 8000 && self.sample_rate != 16000 {
-            return Err(DecibriError::VadSampleRateUnsupported(self.sample_rate));
-        }
+    pub fn validate(&self) -> Result<usize, DecibriError> {
+        let window_size = match self.sample_rate {
+            8000 => 256,
+            16000 => 512,
+            _ => return Err(DecibriError::VadSampleRateUnsupported(self.sample_rate)),
+        };
         if !(0.0..=1.0).contains(&self.threshold) {
             return Err(DecibriError::VadThresholdOutOfRange(self.threshold));
         }
-        Ok(())
+        Ok(window_size)
     }
 }
 
@@ -220,14 +231,10 @@ fn init_ort_once(path: Option<&Path>) -> Result<(), DecibriError> {
 impl SileroVad {
     /// Create a new Silero VAD instance by loading the ONNX model.
     pub fn new(config: VadConfig) -> Result<Self, DecibriError> {
-        config.validate()?;
-
-        // Safe to unwrap-via-unreachable: validate() rejected anything else.
-        let window_size = match config.sample_rate {
-            16000 => 512,
-            8000 => 256,
-            _ => unreachable!("VadConfig::validate accepts only 8000 and 16000"),
-        };
+        // `validate` returns the `window_size` for the accepted sample rate,
+        // so `SileroVad::new` does not need its own match — and cannot panic
+        // if future `validate` extensions accept new sample rates.
+        let window_size = config.validate()?;
 
         // Initialize ORT exactly once per process. Subsequent SileroVad
         // instances pass through immediately regardless of their ort_library_path.
@@ -436,6 +443,78 @@ mod tests {
             ..default_config()
         };
         assert!(SileroVad::new(bad_rate).is_err());
+    }
+
+    /// Core guarantee of the commit 3.8 structured-error refactor:
+    /// `err.source()` walks to the underlying `ort::Error` for the wrapped
+    /// variants, and deliberately returns `None` for `OrtPathInvalid` (which
+    /// has no underlying ORT error because constructing one would trigger
+    /// the hang the pre-check prevents).
+    #[test]
+    fn test_ort_error_source_chain_preserved() {
+        use std::error::Error;
+
+        // OrtInitFailed (no path) carries an ort::Error source.
+        let inner = ort::Error::new("simulated underlying ort error");
+        let err = wrap_init_error(None, inner);
+        assert!(
+            err.source().is_some(),
+            "OrtInitFailed should carry an ort::Error source"
+        );
+
+        // OrtLoadFailed (with path) carries an ort::Error source.
+        let inner_with_path = ort::Error::new("another simulated error");
+        let path_err = wrap_init_error(Some(Path::new("/tmp/bogus")), inner_with_path);
+        assert!(
+            path_err.source().is_some(),
+            "OrtLoadFailed should carry an ort::Error source"
+        );
+
+        // OrtPathInvalid intentionally does NOT carry a source (documented
+        // asymmetry — see OrtPathInvalid's rustdoc in error.rs).
+        let path_invalid = DecibriError::OrtPathInvalid {
+            path: PathBuf::from("/tmp/nope"),
+            reason: "test",
+        };
+        assert!(
+            path_invalid.source().is_none(),
+            "OrtPathInvalid intentionally has no source (constructing ort::Error \
+             would trigger the hang the pre-check prevents)"
+        );
+    }
+
+    /// `DecibriError::is_ort_path_error` groups the two path-level ORT
+    /// failure variants so consumers handling "the path is wrong" logic
+    /// can match one predicate instead of enumerating both.
+    #[test]
+    fn test_is_ort_path_error() {
+        let load_failed = DecibriError::OrtLoadFailed {
+            path: PathBuf::from("/tmp/x"),
+            source: ort::Error::new("test"),
+        };
+        assert!(load_failed.is_ort_path_error());
+
+        let path_invalid = DecibriError::OrtPathInvalid {
+            path: PathBuf::from("/tmp/x"),
+            reason: "test",
+        };
+        assert!(path_invalid.is_ort_path_error());
+
+        // Other variants return false.
+        let init_failed = DecibriError::OrtInitFailed {
+            source: ort::Error::new("test"),
+        };
+        assert!(!init_failed.is_ort_path_error());
+
+        // `SampleRateOutOfRange` is a unit variant (applies to capture/output
+        // configs, not VAD); Ross's draft had `(999999)` which wouldn't
+        // compile. Using the correct unit form.
+        let sample_rate = DecibriError::SampleRateOutOfRange;
+        assert!(!sample_rate.is_ort_path_error());
+
+        // VAD-specific config error also false.
+        let vad_rate = DecibriError::VadSampleRateUnsupported(44_100);
+        assert!(!vad_rate.is_ort_path_error());
     }
 
     #[test]

--- a/crates/decibri/tests/vad_integration.rs
+++ b/crates/decibri/tests/vad_integration.rs
@@ -1,0 +1,133 @@
+//! Integration tests for the VAD / ORT resolution pipeline.
+//!
+//! These tests exercise `SileroVad` end-to-end against the bundled
+//! `models/silero_vad.onnx` file. They run under `cargo test-decibri`
+//! (which selects `--features ort-download-binaries`) and do not
+//! require audio hardware.
+//!
+//! The load-failure test for a bogus `ort_library_path` lives in
+//! `vad_ort_load_failure.rs` — a separate binary — because ORT
+//! initialization is process-global: once any test in this binary
+//! successfully initializes ORT, the `OnceLock` guard inside
+//! `init_ort_once` short-circuits later callers and the load-failure
+//! code path can no longer be reached.
+
+#![cfg(feature = "vad")]
+
+use std::path::{Path, PathBuf};
+
+use decibri::error::DecibriError;
+use decibri::vad::{SileroVad, VadConfig};
+
+/// Absolute path to the bundled Silero VAD model, resolved from the crate
+/// manifest directory. Matches the idiom used by the unit tests in
+/// `crates/decibri/src/vad.rs`.
+fn bundled_model_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("models")
+        .join("silero_vad.onnx")
+}
+
+#[test]
+fn test_ort_init_success_with_bundled_model() {
+    let config = VadConfig {
+        model_path: bundled_model_path(),
+        ..VadConfig::default()
+    };
+    let vad = SileroVad::new(config);
+    assert!(
+        vad.is_ok(),
+        "SileroVad::new should succeed with the bundled model: {:?}",
+        vad.err()
+    );
+}
+
+#[test]
+fn test_vad_model_load_fails_for_missing_file() {
+    let bogus = PathBuf::from("does-not-exist-silero-xyz.onnx");
+    let config = VadConfig {
+        model_path: bogus.clone(),
+        ..VadConfig::default()
+    };
+    let err = SileroVad::new(config)
+        .err()
+        .expect("expected VadModelLoadFailed");
+    match err {
+        DecibriError::VadModelLoadFailed { path, .. } => {
+            assert_eq!(
+                path,
+                bogus.display().to_string(),
+                "VadModelLoadFailed.path should match the input"
+            );
+        }
+        other => panic!("expected VadModelLoadFailed, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_vad_config_validate_typed_errors() {
+    // Unsupported sample rate
+    let bad_rate = VadConfig {
+        sample_rate: 44_100,
+        ..VadConfig::default()
+    };
+    match bad_rate
+        .validate()
+        .expect_err("expected VadSampleRateUnsupported")
+    {
+        DecibriError::VadSampleRateUnsupported(sr) => {
+            assert_eq!(sr, 44_100, "payload should carry the offending rate");
+        }
+        other => panic!("expected VadSampleRateUnsupported, got {other:?}"),
+    }
+
+    // Out-of-range threshold
+    let bad_threshold = VadConfig {
+        threshold: 1.5,
+        ..VadConfig::default()
+    };
+    match bad_threshold
+        .validate()
+        .expect_err("expected VadThresholdOutOfRange")
+    {
+        DecibriError::VadThresholdOutOfRange(t) => {
+            assert!(
+                (t - 1.5).abs() < f32::EPSILON,
+                "payload should carry the offending threshold, got {t}"
+            );
+        }
+        other => panic!("expected VadThresholdOutOfRange, got {other:?}"),
+    }
+
+    // A valid config passes
+    let good = VadConfig {
+        model_path: bundled_model_path(),
+        ..VadConfig::default()
+    };
+    assert!(good.validate().is_ok(), "default config should validate");
+}
+
+#[test]
+fn test_vad_end_to_end_silence_inference() {
+    let config = VadConfig {
+        model_path: bundled_model_path(),
+        ..VadConfig::default()
+    };
+    let mut vad = SileroVad::new(config).expect("model should load");
+
+    // 1600 samples = three 512-sample windows + 64-sample remainder at 16 kHz.
+    let silence = vec![0.0f32; 1600];
+    let result = vad.process(&silence).expect("inference should succeed");
+
+    assert!(
+        result.probability < 0.5,
+        "silence probability should be low, got {}",
+        result.probability
+    );
+    assert!(
+        !result.is_speech,
+        "silence should not be classified as speech"
+    );
+}

--- a/crates/decibri/tests/vad_integration.rs
+++ b/crates/decibri/tests/vad_integration.rs
@@ -57,9 +57,8 @@ fn test_vad_model_load_fails_for_missing_file() {
     match err {
         DecibriError::VadModelLoadFailed { path, .. } => {
             assert_eq!(
-                path,
-                bogus.display().to_string(),
-                "VadModelLoadFailed.path should match the input"
+                path, bogus,
+                "VadModelLoadFailed.path should match the input PathBuf"
             );
         }
         other => panic!("expected VadModelLoadFailed, got {other:?}"),

--- a/crates/decibri/tests/vad_ort_load_failure.rs
+++ b/crates/decibri/tests/vad_ort_load_failure.rs
@@ -1,0 +1,112 @@
+//! Integration tests for the ORT `load-dynamic` load-failure path.
+//!
+//! These tests live in their own file (separate test binary) because ORT
+//! initialization is process-global: once `init_ort_once` has stored `Some`
+//! in its `OnceLock`, any later call short-circuits and the load-failure
+//! code path is unreachable. Keeping these tests alone in a binary guarantees
+//! each run is the first ORT init in its process and thus actually exercises
+//! the load-failure branch.
+//!
+//! The tests rely on the defensive pre-check added in
+//! `crates/decibri/src/vad.rs::init_ort_once`, which validates that the
+//! provided `ort_library_path` points at a regular file before handing it
+//! to `ort::init_from`. Without that pre-check, Windows hangs indefinitely
+//! inside `ort::init_from` on a nonexistent path (reproduced 2026-04-22
+//! against pyke/ort 2.0.0-rc.12 + onnxruntime 1.24.4).
+//!
+//! Gated behind `feature = "ort-load-dynamic"` because the tests are
+//! meaningful only under the dynamic-load distribution mode: under
+//! `ort-download-binaries`, ORT is statically linked and any
+//! `ort_library_path` argument is ignored by design.
+//!
+//! Under `cargo test-decibri` (which uses `ort-download-binaries`) the cfg
+//! gate compiles these tests out. Run them explicitly with:
+//!
+//! ```text
+//! cargo test -p decibri \
+//!   --no-default-features \
+//!   --features capture,output,vad,denoise,gain,ort-load-dynamic \
+//!   --test vad_ort_load_failure
+//! ```
+
+#![cfg(all(feature = "vad", feature = "ort-load-dynamic"))]
+
+use std::path::{Path, PathBuf};
+
+use decibri::error::DecibriError;
+use decibri::vad::{SileroVad, VadConfig};
+
+fn bundled_model_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("models")
+        .join("silero_vad.onnx")
+}
+
+/// A nonexistent `ort_library_path` must fail fast with `OrtLoadFailed`.
+///
+/// Prior to the defensive pre-check this test hung on Windows because
+/// `ort::init_from` does not return for a nonexistent path; the pre-check
+/// short-circuits that case.
+#[test]
+fn test_ort_load_fails_with_nonexistent_path() {
+    let bogus = std::env::temp_dir().join("does-not-exist-onnxruntime-dylib-xyz");
+
+    let config = VadConfig {
+        model_path: bundled_model_path(),
+        ort_library_path: Some(bogus.clone()),
+        ..VadConfig::default()
+    };
+    let err = SileroVad::new(config)
+        .err()
+        .expect("expected OrtLoadFailed");
+
+    match &err {
+        DecibriError::OrtLoadFailed { path, .. } => {
+            assert!(
+                path.ends_with("does-not-exist-onnxruntime-dylib-xyz"),
+                "OrtLoadFailed.path should end with the bogus filename, got {path}"
+            );
+        }
+        other => panic!("expected OrtLoadFailed, got {other:?}"),
+    }
+
+    // Display message should carry the actionable guidance string.
+    let msg = err.to_string();
+    assert!(
+        msg.contains("ORT_DYLIB_PATH"),
+        "Display message should mention ORT_DYLIB_PATH, got: {msg}"
+    );
+}
+
+/// An `ort_library_path` that points at a directory (e.g. a user mistakenly
+/// passing the directory containing the dylib instead of the dylib itself)
+/// must also fail fast with `OrtLoadFailed`. Without the pre-check, pyke/ort
+/// likely hangs here on Windows as well because its dylib-load path does
+/// not validate the input is a regular file.
+#[test]
+fn test_ort_load_fails_when_path_is_directory() {
+    // `temp_dir()` is guaranteed to exist and is a directory on every platform.
+    let dir_path = std::env::temp_dir();
+
+    let config = VadConfig {
+        model_path: bundled_model_path(),
+        ort_library_path: Some(dir_path.clone()),
+        ..VadConfig::default()
+    };
+    let err = SileroVad::new(config)
+        .err()
+        .expect("expected OrtLoadFailed when path is a directory");
+
+    match &err {
+        DecibriError::OrtLoadFailed { path, .. } => {
+            assert_eq!(
+                path,
+                &dir_path.display().to_string(),
+                "OrtLoadFailed.path should match the passed directory"
+            );
+        }
+        other => panic!("expected OrtLoadFailed, got {other:?}"),
+    }
+}

--- a/crates/decibri/tests/vad_ort_load_failure.rs
+++ b/crates/decibri/tests/vad_ort_load_failure.rs
@@ -12,7 +12,11 @@
 //! provided `ort_library_path` points at a regular file before handing it
 //! to `ort::init_from`. Without that pre-check, Windows hangs indefinitely
 //! inside `ort::init_from` on a nonexistent path (reproduced 2026-04-22
-//! against pyke/ort 2.0.0-rc.12 + onnxruntime 1.24.4).
+//! against pyke/ort 2.0.0-rc.12 + onnxruntime 1.24.4). The pre-check
+//! returns [`DecibriError::OrtPathInvalid`] — deliberately a string-only
+//! variant that does *not* construct an `ort::Error`, because
+//! `ort::Error::new` itself calls `ortsys![CreateStatus]` and would
+//! re-trigger the very dylib load we're avoiding.
 //!
 //! Gated behind `feature = "ort-load-dynamic"` because the tests are
 //! meaningful only under the dynamic-load distribution mode: under
@@ -44,11 +48,11 @@ fn bundled_model_path() -> PathBuf {
         .join("silero_vad.onnx")
 }
 
-/// A nonexistent `ort_library_path` must fail fast with `OrtLoadFailed`.
+/// A nonexistent `ort_library_path` must fail fast with `OrtPathInvalid`.
 ///
 /// Prior to the defensive pre-check this test hung on Windows because
 /// `ort::init_from` does not return for a nonexistent path; the pre-check
-/// short-circuits that case.
+/// short-circuits that case without constructing an `ort::Error`.
 #[test]
 fn test_ort_load_fails_with_nonexistent_path() {
     let bogus = std::env::temp_dir().join("does-not-exist-onnxruntime-dylib-xyz");
@@ -60,19 +64,25 @@ fn test_ort_load_fails_with_nonexistent_path() {
     };
     let err = SileroVad::new(config)
         .err()
-        .expect("expected OrtLoadFailed");
+        .expect("expected OrtPathInvalid");
 
     match &err {
-        DecibriError::OrtLoadFailed { path, .. } => {
+        DecibriError::OrtPathInvalid { path, reason } => {
             assert!(
                 path.ends_with("does-not-exist-onnxruntime-dylib-xyz"),
-                "OrtLoadFailed.path should end with the bogus filename, got {path}"
+                "OrtPathInvalid.path should end with the bogus filename, got {}",
+                path.display()
+            );
+            assert!(
+                reason.contains("does not exist"),
+                "OrtPathInvalid.reason should mention 'does not exist', got: {reason}"
             );
         }
-        other => panic!("expected OrtLoadFailed, got {other:?}"),
+        other => panic!("expected OrtPathInvalid, got {other:?}"),
     }
 
-    // Display message should carry the actionable guidance string.
+    // Display message should carry the actionable guidance string — same
+    // wording as `OrtLoadFailed` so consumers see a uniform message.
     let msg = err.to_string();
     assert!(
         msg.contains("ORT_DYLIB_PATH"),
@@ -82,7 +92,7 @@ fn test_ort_load_fails_with_nonexistent_path() {
 
 /// An `ort_library_path` that points at a directory (e.g. a user mistakenly
 /// passing the directory containing the dylib instead of the dylib itself)
-/// must also fail fast with `OrtLoadFailed`. Without the pre-check, pyke/ort
+/// must also fail fast with `OrtPathInvalid`. Without the pre-check, pyke/ort
 /// likely hangs here on Windows as well because its dylib-load path does
 /// not validate the input is a regular file.
 #[test]
@@ -97,16 +107,15 @@ fn test_ort_load_fails_when_path_is_directory() {
     };
     let err = SileroVad::new(config)
         .err()
-        .expect("expected OrtLoadFailed when path is a directory");
+        .expect("expected OrtPathInvalid when path is a directory");
 
     match &err {
-        DecibriError::OrtLoadFailed { path, .. } => {
+        DecibriError::OrtPathInvalid { path, .. } => {
             assert_eq!(
-                path,
-                &dir_path.display().to_string(),
-                "OrtLoadFailed.path should match the passed directory"
+                path, &dir_path,
+                "OrtPathInvalid.path should match the passed directory PathBuf"
             );
         }
-        other => panic!("expected OrtLoadFailed, got {other:?}"),
+        other => panic!("expected OrtPathInvalid, got {other:?}"),
     }
 }

--- a/npm/decibri/package.json
+++ b/npm/decibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decibri",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Cross-platform audio capture, output, and processing for Node.js and browsers",
   "main": "src/decibri.js",
   "types": "src/decibri.d.ts",
@@ -69,10 +69,10 @@
     "README.md"
   ],
   "optionalDependencies": {
-    "@decibri/decibri-win32-x64-msvc": "3.1.0",
-    "@decibri/decibri-darwin-arm64": "3.1.0",
-    "@decibri/decibri-linux-x64-gnu": "3.1.0",
-    "@decibri/decibri-linux-arm64-gnu": "3.1.0"
+    "@decibri/decibri-win32-x64-msvc": "3.2.0",
+    "@decibri/decibri-darwin-arm64": "3.2.0",
+    "@decibri/decibri-linux-x64-gnu": "3.2.0",
+    "@decibri/decibri-linux-arm64-gnu": "3.2.0"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.0.0"

--- a/npm/platform-darwin-arm64/package.json
+++ b/npm/platform-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-darwin-arm64",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "os": ["darwin"],
   "cpu": ["arm64"],
   "main": "decibri.darwin-arm64.node",

--- a/npm/platform-linux-arm64-gnu/package.json
+++ b/npm/platform-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-arm64-gnu",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "os": ["linux"],
   "cpu": ["arm64"],
   "main": "decibri.linux-arm64-gnu.node",

--- a/npm/platform-linux-x64-gnu/package.json
+++ b/npm/platform-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-x64-gnu",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "os": ["linux"],
   "cpu": ["x64"],
   "main": "decibri.linux-x64-gnu.node",

--- a/npm/platform-win32-x64-msvc/package.json
+++ b/npm/platform-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-win32-x64-msvc",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "os": ["win32"],
   "cpu": ["x64"],
   "main": "decibri.win32-x64-msvc.node",


### PR DESCRIPTION
Pre-P3 refactor release. Public Node.js and browser APIs are unchanged. Direct Rust crate consumers see structured error variants with error-chain preservation, new stable FFI-ready stream adapter methods, and a dedicated `DecibriError` taxonomy for ORT-related failures.

## What's in this release

### Structured error taxonomy
- `DecibriError::Other(String)` removed; replaced with 13 typed variants covering all ORT and device-enumeration failure modes
- `DecibriError` is now `#[non_exhaustive]` so future variant additions are non-breaking
- ORT-originated errors carry `#[source] ort::Error`, preserving the full error chain
- Path-carrying variants now use `PathBuf` instead of `String`
- New `DecibriError::is_ort_path_error()` helper groups `OrtLoadFailed` and `OrtPathInvalid`

### Stable FFI stream adapters
- `CaptureStream::try_next_chunk()` — non-blocking, three-state return
- `CaptureStream::next_chunk(timeout)` — blocking with optional timeout
- Declared stable 3.x API in rustdoc
- Canonical interface for future FFI bindings (Python, mobile)

### Windows hang fix
- `init_ort_once` now runs a filesystem pre-check before calling into ORT
- New `OrtPathInvalid { path, reason }` variant fires when path is missing or not a regular file
- Prevents the indefinite process hang when Windows receives a bad `ortLibraryPath`

### Release workflow hardening
- `verify_pack` function ported from `release-dryrun.yml` into `release.yml` as a pre-publish packaging gate
- Closes the dryrun-skip honor-system gap from the P2.5 review
- Read-only validation; fails loud before any `npm publish` runs

### MSRV declaration
- Workspace MSRV declared as rustc 1.88
- Forced by `ort 2.0.0-rc.12`'s `edition = "2024"` requirement
- Dated maintainer comment in `Cargo.toml` documents the forcing function

### docs.rs metadata
- `[package.metadata.docs.rs]` section added targeting all 4 production platforms
- Future-proofs against docs.rs change effective 2026-05-01 (building fewer targets by default)
- Ensures platform-specific rustdoc renders correctly on docs.rs

### Documentation
- Crate-level rustdoc on `decibri::lib.rs` covering feature flags, ORT distribution modes, threading guarantees, stability contract
- Feature-flag matrix and mutual-exclusivity documented explicitly

### Testing
- 4 new VAD integration tests covering ORT init, model-load failure, config validation, end-to-end silence inference
- 2 new ORT load-failure tests (feature-gated to `ort-load-dynamic`)
- 7 new stream adapter unit tests
- 2 new polish tests: `.source()` chain preservation + `is_ort_path_error` helper
- Test count: 42 Rust tests + 38 Node CI assertions

## Commits (8 total)

1. `refactor: replace DecibriError::Other with typed variants, consolidate device enumeration`
2. `feat: add stable FFI-ready stream adapter methods with unit tests`
3. `chore: add VAD integration tests, declare MSRV 1.88, expand crate-level rustdoc`
4. `fix: prevent Windows hang in ort::init_from by pre-validating path exists`
5. `refactor: structured ort::Error in DecibriError + dedicated OrtPathInvalid variant`
6. `ci: port verify_pack into release.yml as pre-publish packaging gate`
7. `polish: chain preservation test, path-error helper, eliminate unreachable!`
8. `chore: bump version to 3.2.0`

## Migration notes for direct Rust crate consumers

- Pattern-matching on `DecibriError::Other(msg)` must migrate to the specific new variant. Display output is byte-identical to 3.1.0 for all error paths.
- `DecibriError` is now `#[non_exhaustive]`; match expressions must include a `_ => { ... }` catch-all arm.
- ORT-related errors now preserve the error chain via `.source()`. Downstream consumers can walk to the underlying `ort::Error`.
- MSRV bumped from implicit ~1.70 to explicit 1.88 (rustc 1.88 released June 2025).

No changes for Node.js or browser consumers. Node error messages are byte-identical to 3.1.0.

## Validation status

- All 8 commits individually CI-green on `development` branch
- 42/42 Rust tests pass (38 unit + 4 integration)
- 2/2 load-dynamic tests pass in 0.00s (Windows hang verified not regressed)
- 38/38 Node CI tests pass
- Independent code review performed on 3.2.0 changes — ship-it verdict with no blockers
- `cargo doc` clean under docs.rs feature combination

## Next steps

After this PR merges:
1. Run `release-dryrun` on `main` to validate the full release flow end-to-end
2. Tag `v3.2.0` annotated from `main`
3. Push tag to trigger `release.yml`
4. Post-publish smoke test with fresh `npm install decibri@3.2.0`

See [CHANGELOG.md](./CHANGELOG.md) for the full 3.2.0 entry.