### PR TITLE
Patch 3.3.1: audience-neutral error message pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.3.1] - Unreleased
+## [3.3.1] - 2026-04-25
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1] - Unreleased
+
+### Changed
+
+- **Audience-neutral error message pass.** Five `DecibriError` `Display` strings refined to remove cross-binding and platform-specific awkwardness. No variant identity, layout, or count change; no API-surface change. Strict patch release.
+  - `SampleRateOutOfRange`: `"sampleRate must be between 1000 and 384000"` -> `"sample rate must be between 1000 and 384000"`. The previous camelCase form was Node-API-targeting and matched no other field-name convention in the rest of the Rust crate (snake_case fields throughout, natural-language rustdoc voice).
+  - `FramesPerBufferOutOfRange`: `"framesPerBuffer must be between 64 and 65536"` -> `"frames per buffer must be between 64 and 65536"`. Same rationale.
+  - `AlreadyRunning`: `"Decibri is already running. Call stop() first."` -> `"audio stream is already running. Call stop() first."`. Hardcoded class name was misleading when raised from `DecibriOutput`; "audio stream" matches the existing `error.rs` vocabulary ("capture stream", "output stream", "audio stream").
+  - `OrtInitFailed`: `"Either pass ort_library_path in VadConfig, ..."` -> `"Either pass ort_library_path when constructing the VAD, ..."`. Drops Rust-internal `VadConfig` type reference; phrasing now correct for Node, Python, and direct-Rust crate consumers alike.
+  - `OrtLoadFailed` and `OrtPathInvalid`: `"the bundled ORT may be missing from your platform package"` -> `"the bundled ONNX Runtime may be missing from your installation"`. Drops npm-internal "platform package" phrasing; "installation" works for npm platform packages, Python wheels, and direct-Rust crate use.
+  - `PermissionDenied`: macOS-specific `"Enable in System Preferences > Security & Privacy."` replaced with attribute-gated per-platform guidance. macOS hint extended to specifically reference `> Microphone`. Windows hint references the modern `Settings > Privacy & Security > Microphone` UX. Linux hint references PulseAudio / PipeWire (the user-facing audio control layer over cpal's ALSA backend).
+- Lockstep updates to `bindings/node/src/lib.rs` (one duplicate `AlreadyRunning` message in the napi `start()` pre-running check), `npm/decibri/src/errors.js` (two prefix-match strings in the typed-error shim), `npm/decibri/src/decibri.js` (two thrown messages in client-side validation; line 101's `channels` message is already natural-language and unchanged), `npm/decibri/src/decibri-output.js` (one thrown message), `npm/decibri/src/browser/decibri-browser.js` (two thrown messages in browser-side validation), `tests/test-ci.js`, `tests/test-api.js`, `tests/test-output.js` (15 hardcoded message-substring assertions).
+
+### Migration notes
+
+Error message wording on shipped `DecibriError` variants has historically been stable across the 3.x line. 3.3.1 explicitly refines five messages to remove audience-leak issues identified during P3 Phase 2 planning: Node-API-targeted camelCase parameter names, class-name hardcoding in `AlreadyRunning`, a Rust-internal type reference (`VadConfig`) in `OrtInitFailed`, npm-internal phrasing ("platform package") in `OrtLoadFailed` / `OrtPathInvalid`, and macOS-only platform guidance in `PermissionDenied`. Future releases re-establish wording stability; 3.3.1 is the consolidation point.
+
+- **Direct Rust crate consumers** asserting on `DecibriError::Display` strings should update assertions for the five refined messages. Type-level matching on `DecibriError` variants is unaffected; only string-text assertions need updating.
+- **Node consumers** using `e.message.includes(prefix)` or `e.message.startsWith(prefix)` patterns should update for `sampleRate` -> `sample rate`, `framesPerBuffer` -> `frames per buffer`, and the `AlreadyRunning` message text. Type-level matching on `RangeError` / `TypeError` is unaffected.
+- **Python consumers**: P3 Phase 2's first wheel (still pre-release) consumes `decibri@3.3.1`, so the messages it sees are the corrected forms from day one. No migration needed (Phase 1 wheel was scaffold-only with no error message surface).
+
 ## [3.3.0] - 2026-04-23
 
 Groundwork release for upcoming P3 Python bindings. Adds a stable-ID form

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.3.0"
+version = "3.3.1"
 edition = "2021"
 # MSRV empirically verified 2026-04-22: rustc 1.88 is the minimum version
 # that compiles the workspace. Floors: ort 2.0.0-rc.12 declares

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -149,7 +149,7 @@ impl DecibriBridge {
         if self.running.load(Ordering::Relaxed) {
             return Err(Error::new(
                 Status::GenericFailure,
-                "Decibri is already running. Call stop() first.",
+                "audio stream is already running. Call stop() first.",
             ));
         }
 

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -28,7 +28,7 @@ crate-type = ["cdylib"]
 # features across both bindings silently; diverging overrides produce a build
 # that neither binding tests in isolation. Both bindings inherit decibri's
 # default features (capture, output, vad, denoise, gain, ort-load-dynamic).
-decibri = { version = "3.3.0", path = "../../crates/decibri" }
+decibri = { version = "3.3.1", path = "../../crates/decibri" }
 
 # PyO3 0.28 is the first MSRV-1.83 release line with the attach / detach /
 # initialize API renames; aligns with workspace MSRV 1.88 (headroom preserved).

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -31,9 +31,9 @@ def test_version_returns_version_info() -> None:
 
 def test_version_decibri_matches_rust_core() -> None:
     # Literal equality per Phase 1 plan. When the Rust workspace bumps past
-    # 3.3.0 this assertion breaks deliberately: force a conscious update of
+    # 3.3.1 this assertion breaks deliberately: force a conscious update of
     # the Python test expectation alongside the Rust version bump.
-    assert decibri.DecibriBridge.version().decibri == "3.3.0"
+    assert decibri.DecibriBridge.version().decibri == "3.3.1"
 
 
 def test_version_portaudio_matches_node_binding() -> None:
@@ -46,7 +46,7 @@ def test_version_portaudio_matches_node_binding() -> None:
 def test_version_info_repr() -> None:
     info = decibri.DecibriBridge.version()
     rep = repr(info)
-    assert rep == "VersionInfo(decibri='3.3.0', portaudio='cpal 0.17')"
+    assert rep == "VersionInfo(decibri='3.3.1', portaudio='cpal 0.17')"
 
 
 def test_version_info_is_frozen() -> None:

--- a/crates/decibri/src/error.rs
+++ b/crates/decibri/src/error.rs
@@ -2,6 +2,26 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 
+// Per-platform guidance for `PermissionDenied`. Attribute-gated so each
+// platform's binary embeds only its own hint string. The attribute-gated
+// pattern matches the crate's existing conditional-compilation idiom: 52
+// `#[cfg(...)]` attribute sites across the crate (all feature-predicates),
+// 0 `cfg!()` macro sites. The `not(any(...))` fallback covers BSDs and
+// any future target-os values uncategorized at compile time.
+
+#[cfg(target_os = "macos")]
+const PERMISSION_HINT: &str = "Enable in System Preferences > Security & Privacy > Microphone.";
+
+#[cfg(target_os = "windows")]
+const PERMISSION_HINT: &str = "Enable in Settings > Privacy & Security > Microphone.";
+
+#[cfg(target_os = "linux")]
+const PERMISSION_HINT: &str =
+    "Check your distribution's audio permissions (PulseAudio / PipeWire).";
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+const PERMISSION_HINT: &str = "Check your system audio permissions.";
+
 /// Errors produced by decibri operations.
 ///
 /// This enum is `#[non_exhaustive]`: consumers pattern-matching on it must
@@ -11,13 +31,13 @@ use thiserror::Error;
 #[non_exhaustive]
 pub enum DecibriError {
     // ── Config validation ──────────────────────────────────────────────
-    #[error("sampleRate must be between 1000 and 384000")]
+    #[error("sample rate must be between 1000 and 384000")]
     SampleRateOutOfRange,
 
     #[error("channels must be between 1 and 32")]
     ChannelsOutOfRange,
 
-    #[error("framesPerBuffer must be between 64 and 65536")]
+    #[error("frames per buffer must be between 64 and 65536")]
     FramesPerBufferOutOfRange,
 
     #[error("format must be 'int16' or 'float32'")]
@@ -55,7 +75,7 @@ pub enum DecibriError {
     DeviceEnumerationFailed(String),
 
     // ── Stream errors ──────────────────────────────────────────────────
-    #[error("Decibri is already running. Call stop() first.")]
+    #[error("audio stream is already running. Call stop() first.")]
     AlreadyRunning,
 
     #[error("Failed to open audio stream: {0}")]
@@ -64,7 +84,7 @@ pub enum DecibriError {
     #[error("Failed to start audio stream: {0}")]
     StreamStartFailed(String),
 
-    #[error("Microphone permission denied. Enable in System Preferences > Security & Privacy.")]
+    #[error("Microphone permission denied. {}", PERMISSION_HINT)]
     PermissionDenied,
 
     /// Capture stream has closed (stopped explicitly or by driver error).
@@ -97,9 +117,9 @@ pub enum DecibriError {
     // `String`) so consumers retain path semantics without re-parsing.
     #[error(
         "decibri: failed to initialize ONNX Runtime: {source}. \
-         Either pass ort_library_path in VadConfig, set ORT_DYLIB_PATH to \
-         point to a valid ONNX Runtime library, or enable the \
-         `ort-download-binaries` feature for zero-config builds."
+         Either pass ort_library_path when constructing the VAD, set \
+         ORT_DYLIB_PATH to point to a valid ONNX Runtime library, or \
+         enable the `ort-download-binaries` feature for zero-config builds."
     )]
     OrtInitFailed {
         #[source]
@@ -109,8 +129,8 @@ pub enum DecibriError {
     #[error(
         "decibri: failed to load ONNX Runtime from {}: {source}. \
          If ORT_DYLIB_PATH is set, verify it points to a valid ONNX Runtime \
-         library for your platform. Otherwise the bundled ORT may be missing \
-         from your platform package. Try reinstalling decibri.",
+         library for your platform. Otherwise the bundled ONNX Runtime may \
+         be missing from your installation. Try reinstalling decibri.",
         path.display()
     )]
     OrtLoadFailed {
@@ -135,8 +155,8 @@ pub enum DecibriError {
     #[error(
         "decibri: failed to load ONNX Runtime from {}: {reason}. \
          If ORT_DYLIB_PATH is set, verify it points to a valid ONNX Runtime \
-         library for your platform. Otherwise the bundled ORT may be missing \
-         from your platform package. Try reinstalling decibri.",
+         library for your platform. Otherwise the bundled ONNX Runtime may \
+         be missing from your installation. Try reinstalling decibri.",
         path.display()
     )]
     OrtPathInvalid { path: PathBuf, reason: &'static str },

--- a/npm/decibri/package.json
+++ b/npm/decibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decibri",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Cross-platform audio capture, output, and processing for Node.js and browsers",
   "main": "src/decibri.js",
   "types": "src/decibri.d.ts",
@@ -69,10 +69,10 @@
     "README.md"
   ],
   "optionalDependencies": {
-    "@decibri/decibri-win32-x64-msvc": "3.3.0",
-    "@decibri/decibri-darwin-arm64": "3.3.0",
-    "@decibri/decibri-linux-x64-gnu": "3.3.0",
-    "@decibri/decibri-linux-arm64-gnu": "3.3.0"
+    "@decibri/decibri-win32-x64-msvc": "3.3.1",
+    "@decibri/decibri-darwin-arm64": "3.3.1",
+    "@decibri/decibri-linux-x64-gnu": "3.3.1",
+    "@decibri/decibri-linux-arm64-gnu": "3.3.1"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.0.0"

--- a/npm/decibri/src/browser/decibri-browser.js
+++ b/npm/decibri/src/browser/decibri-browser.js
@@ -53,13 +53,13 @@ class Decibri extends Emitter {
 
     // ── Validate ──────────────────────────────────────────────────────────
     if (this._sampleRate < 1000 || this._sampleRate > 384000) {
-      throw new TypeError(`sampleRate must be between 1000 and 384000, got ${this._sampleRate}`);
+      throw new TypeError(`sample rate must be between 1000 and 384000, got ${this._sampleRate}`);
     }
     if (this._channels < 1 || this._channels > 32) {
       throw new TypeError(`channels must be between 1 and 32, got ${this._channels}`);
     }
     if (this._framesPerBuffer < 64 || this._framesPerBuffer > 65536) {
-      throw new TypeError(`framesPerBuffer must be between 64 and 65536, got ${this._framesPerBuffer}`);
+      throw new TypeError(`frames per buffer must be between 64 and 65536, got ${this._framesPerBuffer}`);
     }
     if (this._format !== 'int16' && this._format !== 'float32') {
       throw new TypeError("format must be 'int16' or 'float32'");

--- a/npm/decibri/src/decibri-output.js
+++ b/npm/decibri/src/decibri-output.js
@@ -17,7 +17,7 @@ class DecibriOutput extends Writable {
 
     const sampleRate = options.sampleRate ?? 16000;
     if (sampleRate < 1000 || sampleRate > 384000) {
-      throw new RangeError('sampleRate must be between 1000 and 384000');
+      throw new RangeError('sample rate must be between 1000 and 384000');
     }
 
     const channels = options.channels ?? 1;

--- a/npm/decibri/src/decibri.js
+++ b/npm/decibri/src/decibri.js
@@ -93,7 +93,7 @@ class Decibri extends Readable {
 
     const sampleRate = options.sampleRate ?? 16000;
     if (sampleRate < 1000 || sampleRate > 384000) {
-      throw new RangeError('sampleRate must be between 1000 and 384000');
+      throw new RangeError('sample rate must be between 1000 and 384000');
     }
 
     const channels = options.channels ?? 1;
@@ -103,7 +103,7 @@ class Decibri extends Readable {
 
     const framesPerBuffer = options.framesPerBuffer ?? 1600;
     if (framesPerBuffer < 64 || framesPerBuffer > 65536) {
-      throw new RangeError('framesPerBuffer must be between 64 and 65536');
+      throw new RangeError('frames per buffer must be between 64 and 65536');
     }
 
     const format = options.format ?? 'int16';

--- a/npm/decibri/src/errors.js
+++ b/npm/decibri/src/errors.js
@@ -24,9 +24,9 @@ function wrapNativeError(err) {
 
   const msg = err.message;
   const isRange =
-    msg.startsWith('sampleRate must be between') ||
+    msg.startsWith('sample rate must be between') ||
     msg.startsWith('channels must be between') ||
-    msg.startsWith('framesPerBuffer must be between') ||
+    msg.startsWith('frames per buffer must be between') ||
     msg.startsWith('Silero VAD only supports') ||
     msg.startsWith('VAD threshold must be between') ||
     msg.startsWith('device index out of range');

--- a/npm/platform-darwin-arm64/package.json
+++ b/npm/platform-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-darwin-arm64",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "os": ["darwin"],
   "cpu": ["arm64"],
   "main": "decibri.darwin-arm64.node",

--- a/npm/platform-linux-arm64-gnu/package.json
+++ b/npm/platform-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-arm64-gnu",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "os": ["linux"],
   "cpu": ["arm64"],
   "main": "decibri.linux-arm64-gnu.node",

--- a/npm/platform-linux-x64-gnu/package.json
+++ b/npm/platform-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-x64-gnu",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "os": ["linux"],
   "cpu": ["x64"],
   "main": "decibri.linux-x64-gnu.node",

--- a/npm/platform-win32-x64-msvc/package.json
+++ b/npm/platform-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-win32-x64-msvc",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "os": ["win32"],
   "cpu": ["x64"],
   "main": "decibri.win32-x64-msvc.node",

--- a/tests/browser/decibri-browser.test.js
+++ b/tests/browser/decibri-browser.test.js
@@ -127,13 +127,13 @@ describe('Decibri constructor', () => {
 
 describe('Decibri constructor validation', () => {
   it('throws on invalid sampleRate', () => {
-    expect(() => new Decibri({ sampleRate: 0 })).toThrow('sampleRate');
-    expect(() => new Decibri({ sampleRate: 500000 })).toThrow('sampleRate');
+    expect(() => new Decibri({ sampleRate: 0 })).toThrow('sample rate');
+    expect(() => new Decibri({ sampleRate: 500000 })).toThrow('sample rate');
   });
 
   it('throws on invalid framesPerBuffer', () => {
-    expect(() => new Decibri({ framesPerBuffer: 0 })).toThrow('framesPerBuffer');
-    expect(() => new Decibri({ framesPerBuffer: 100000 })).toThrow('framesPerBuffer');
+    expect(() => new Decibri({ framesPerBuffer: 0 })).toThrow('frames per buffer');
+    expect(() => new Decibri({ framesPerBuffer: 100000 })).toThrow('frames per buffer');
   });
 
   it('throws on invalid channels', () => {

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -64,17 +64,17 @@ async function testErrors() {
   console.log('--- Group 1: Error messages ---');
 
   // sampleRate
-  assertThrows(() => new Decibri({ sampleRate: 0 }), RangeError, 'sampleRate must be between 1000 and 384000');
-  assertThrows(() => new Decibri({ sampleRate: 999 }), RangeError, 'sampleRate must be between 1000 and 384000');
-  assertThrows(() => new Decibri({ sampleRate: 384001 }), RangeError, 'sampleRate must be between 1000 and 384000');
+  assertThrows(() => new Decibri({ sampleRate: 0 }), RangeError, 'sample rate must be between 1000 and 384000');
+  assertThrows(() => new Decibri({ sampleRate: 999 }), RangeError, 'sample rate must be between 1000 and 384000');
+  assertThrows(() => new Decibri({ sampleRate: 384001 }), RangeError, 'sample rate must be between 1000 and 384000');
 
   // channels
   assertThrows(() => new Decibri({ channels: 0 }), RangeError, 'channels must be between 1 and 32');
   assertThrows(() => new Decibri({ channels: 33 }), RangeError, 'channels must be between 1 and 32');
 
   // framesPerBuffer
-  assertThrows(() => new Decibri({ framesPerBuffer: 63 }), RangeError, 'framesPerBuffer must be between 64 and 65536');
-  assertThrows(() => new Decibri({ framesPerBuffer: 65537 }), RangeError, 'framesPerBuffer must be between 64 and 65536');
+  assertThrows(() => new Decibri({ framesPerBuffer: 63 }), RangeError, 'frames per buffer must be between 64 and 65536');
+  assertThrows(() => new Decibri({ framesPerBuffer: 65537 }), RangeError, 'frames per buffer must be between 64 and 65536');
 
   // format
   assertThrows(() => new Decibri({ format: 'wav' }), TypeError, "format must be 'int16' or 'float32'");

--- a/tests/test-ci.js
+++ b/tests/test-ci.js
@@ -51,17 +51,17 @@ function assert(condition, label) {
 console.log('--- Group 1: Decibri error messages ---');
 
 // sampleRate
-assertThrows(() => new Decibri({ sampleRate: 0 }), RangeError, 'sampleRate must be between 1000 and 384000');
-assertThrows(() => new Decibri({ sampleRate: 999 }), RangeError, 'sampleRate must be between 1000 and 384000');
-assertThrows(() => new Decibri({ sampleRate: 384001 }), RangeError, 'sampleRate must be between 1000 and 384000');
+assertThrows(() => new Decibri({ sampleRate: 0 }), RangeError, 'sample rate must be between 1000 and 384000');
+assertThrows(() => new Decibri({ sampleRate: 999 }), RangeError, 'sample rate must be between 1000 and 384000');
+assertThrows(() => new Decibri({ sampleRate: 384001 }), RangeError, 'sample rate must be between 1000 and 384000');
 
 // channels
 assertThrows(() => new Decibri({ channels: 0 }), RangeError, 'channels must be between 1 and 32');
 assertThrows(() => new Decibri({ channels: 33 }), RangeError, 'channels must be between 1 and 32');
 
 // framesPerBuffer
-assertThrows(() => new Decibri({ framesPerBuffer: 63 }), RangeError, 'framesPerBuffer must be between 64 and 65536');
-assertThrows(() => new Decibri({ framesPerBuffer: 65537 }), RangeError, 'framesPerBuffer must be between 64 and 65536');
+assertThrows(() => new Decibri({ framesPerBuffer: 63 }), RangeError, 'frames per buffer must be between 64 and 65536');
+assertThrows(() => new Decibri({ framesPerBuffer: 65537 }), RangeError, 'frames per buffer must be between 64 and 65536');
 
 // format
 assertThrows(() => new Decibri({ format: 'wav' }), TypeError, "format must be 'int16' or 'float32'");
@@ -143,8 +143,8 @@ console.log('  Group 2 done\n');
 
 console.log('--- Group 3: DecibriOutput error messages ---');
 
-assertThrows(() => new DecibriOutput({ sampleRate: 0 }), RangeError, 'sampleRate must be between 1000 and 384000');
-assertThrows(() => new DecibriOutput({ sampleRate: 384001 }), RangeError, 'sampleRate must be between 1000 and 384000');
+assertThrows(() => new DecibriOutput({ sampleRate: 0 }), RangeError, 'sample rate must be between 1000 and 384000');
+assertThrows(() => new DecibriOutput({ sampleRate: 384001 }), RangeError, 'sample rate must be between 1000 and 384000');
 assertThrows(() => new DecibriOutput({ channels: 0 }), RangeError, 'channels must be between 1 and 32');
 assertThrows(() => new DecibriOutput({ channels: 33 }), RangeError, 'channels must be between 1 and 32');
 assertThrows(() => new DecibriOutput({ format: 'wav' }), TypeError, "format must be 'int16' or 'float32'");

--- a/tests/test-output.js
+++ b/tests/test-output.js
@@ -75,9 +75,9 @@ async function testErrors() {
   console.log('--- Group 1: Error messages ---');
 
   // sampleRate
-  assertThrows(() => new DecibriOutput({ sampleRate: 0 }), RangeError, 'sampleRate must be between 1000 and 384000');
-  assertThrows(() => new DecibriOutput({ sampleRate: 999 }), RangeError, 'sampleRate must be between 1000 and 384000');
-  assertThrows(() => new DecibriOutput({ sampleRate: 384001 }), RangeError, 'sampleRate must be between 1000 and 384000');
+  assertThrows(() => new DecibriOutput({ sampleRate: 0 }), RangeError, 'sample rate must be between 1000 and 384000');
+  assertThrows(() => new DecibriOutput({ sampleRate: 999 }), RangeError, 'sample rate must be between 1000 and 384000');
+  assertThrows(() => new DecibriOutput({ sampleRate: 384001 }), RangeError, 'sample rate must be between 1000 and 384000');
 
   // channels
   assertThrows(() => new DecibriOutput({ channels: 0 }), RangeError, 'channels must be between 1 and 32');


### PR DESCRIPTION
## Summary

Audience-neutral error message refinement pass on `crates/decibri/src/error.rs`, with lockstep updates to all consuming bindings and tests. Strict patch release; no `DecibriError` variant identity, layout, or count change; no public API surface change.

## Five message changes

- **`SampleRateOutOfRange`**: `"sampleRate must be between 1000 and 384000"` → `"sample rate must be between 1000 and 384000"`. Removes camelCase parameter name that was the only place in the entire `crates/decibri/` tree using camelCase for this field (rest of the crate uses snake_case fields and natural-language rustdoc voice).

- **`FramesPerBufferOutOfRange`**: `"framesPerBuffer must be between 64 and 65536"` → `"frames per buffer must be between 64 and 65536"`. Same rationale.

- **`AlreadyRunning`**: `"Decibri is already running. Call stop() first."` → `"audio stream is already running. Call stop() first."`. Removes hardcoded `Decibri` class name that was misleading when raised from `DecibriOutput`. New wording matches existing `error.rs` vocabulary ("capture stream", "output stream", "audio stream").

- **`OrtInitFailed`**: `"Either pass ort_library_path in VadConfig, ..."` → `"Either pass ort_library_path when constructing the VAD, ..."`. Drops Rust-internal `VadConfig` type reference; phrasing now correct for Node, Python, and direct-Rust crate consumers alike.

- **`OrtLoadFailed` and `OrtPathInvalid`**: `"the bundled ORT may be missing from your platform package"` → `"the bundled ONNX Runtime may be missing from your installation"`. Drops npm-internal "platform package" phrasing; "installation" works for npm platform packages, Python wheels, and direct-Rust crate use.

- **`PermissionDenied`**: macOS-specific `"Enable in System Preferences > Security & Privacy."` replaced with attribute-gated per-platform guidance (`PERMISSION_HINT` constants):
  - macOS: `"Enable in System Preferences > Security & Privacy > Microphone."`
  - Windows: `"Enable in Settings > Privacy & Security > Microphone."`
  - Linux: `"Check your distribution's audio permissions (PulseAudio / PipeWire)."`
  - Fallback: `"Check your system audio permissions."`

## Lockstep updates

- `bindings/node/src/lib.rs`: 1 message in the napi `start()` pre-running check.
- `npm/decibri/src/errors.js`: 2 prefix-match strings in the typed-error shim.
- `npm/decibri/src/decibri.js`: 2 thrown messages in client-side validation (`channels` unchanged because already natural-language).
- `npm/decibri/src/decibri-output.js`: 1 thrown message.
- `npm/decibri/src/browser/decibri-browser.js`: 2 template-literal messages in browser-side validation.
- `tests/test-ci.js`, `tests/test-api.js`, `tests/test-output.js`: 15 hardcoded message-substring assertions.
- `tests/browser/decibri-browser.test.js`: 4 parameter-name-only `toThrow()` substring assertions (caught by CI Browser Tests workflow on the first push; landed in fix-up commit).

## Version bumps

`3.3.0` → `3.3.1` across:
- Workspace `Cargo.toml`
- `bindings/python/Cargo.toml` dual `path + version` dep on the core crate
- `npm/decibri/package.json` (version + 4 `optionalDependencies` exact-pins)
- 4 npm platform `package.json` files
- `bindings/python/tests/test_smoke.py` (3 sites: comment + 2 literal assertions; intentional churn per Phase 1 plan §3.7)
- `Cargo.lock` (auto-regenerated; gitignored)

`CHANGELOG.md` `[3.3.1] - 2026-04-25` entry.

## Migration notes for consumers

Error message wording on shipped `DecibriError` variants has historically been stable across the 3.x line. 3.3.1 is the consolidation point for audience-neutral messages; future releases re-establish wording stability.

- **Direct Rust crate consumers** asserting on `DecibriError::Display` strings should update assertions for the five refined messages. Type-level matching on `DecibriError` variants is unaffected.
- **Node consumers** using `e.message.includes(prefix)` or `e.message.startsWith(prefix)` patterns should update for `sampleRate` → `sample rate`, `framesPerBuffer` → `frames per buffer`, and the `AlreadyRunning` message text. Type-level matching on `RangeError` / `TypeError` is unaffected.
- **Python consumers**: P3 Phase 2's first wheel (still pre-release) consumes `decibri@3.3.1`, so the messages it sees are the corrected forms from day one. No migration needed.

## Validation

3 commits on `development`, all gates green per commit:

- Commit 1 `9d84b09` — `fix(error): audience-neutralize five DecibriError messages`
- Commit 1 fix-up `8a3ff7a` — `fix(error): update browser test assertions for refined messages`
- Commit 2 `47d0d1b` — `chore(release): bump to 3.3.1`

CI green across all workflows (`python-ci.yml`, `ci.yml`, Browser Tests).

Phase-level audit (8 sections): GO verdict, zero Blocking, zero Significant, 4 Minor findings (all pre-existing patterns, no action).

## Reference

Patch plan: `decibri-3-3-1-patch-error-message-refinement.md` (working document, not in repo).