### PR TITLE
Patch 3.3.2: build.rs hardening + cargo publish --dry-run coverage

### DIFF
--- a/.github/workflows/release-dryrun.yml
+++ b/.github/workflows/release-dryrun.yml
@@ -327,3 +327,28 @@ jobs:
             exit 1
           fi
           echo "All 5 packages pass verification."
+
+  cargo-publish-dryrun:
+    name: Cargo publish --dry-run (crates.io path verification)
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install ALSA dev headers
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - name: Run cargo publish --dry-run against crates/decibri
+        # --dry-run runs package + verify locally without uploading. Catches
+        # build.rs failures, missing files, manifest issues, and any other
+        # publish-time problems that the npm-side dryrun cannot see. No
+        # crates.io credentials required (--dry-run stops before upload).
+        # Mirrors release.yml's `cargo publish -p decibri` step at line 455.
+        #
+        # No --allow-dirty flag here: CI checks out a clean tree.
+        # --allow-dirty is for local invocation when Ross's working tree has
+        # uncommitted changes mid-development.
+        #
+        # No rust-cache step: matches existing release-dryrun.yml + release.yml
+        # convention of building release-validation jobs from clean state.
+        # Cache might mask the very issues --dry-run is meant to catch.
+        run: cargo publish -p decibri --dry-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.3.2] - Unreleased
+## [3.3.2] - 2026-04-26
 
 ### Changed
 
 - **`crates/decibri/build.rs` rewrite to use Cargo.toml as primary source.** The previous build script (introduced in 3.3.1 to source the cpal version from a single point of truth) read the workspace `Cargo.lock` via a path traversal that worked in workspace builds but panicked in `cargo publish` verify because the published tarball is flat (`decibri-X.Y.Z/Cargo.toml` and `decibri-X.Y.Z/Cargo.lock` are siblings, not in workspace structure). The traversal landed at `target/Cargo.lock` (nonexistent) and aborted the build. **3.3.1's crates.io publish failed on this defect; 3.3.1 shipped to npm but not to crates.io.** 3.3.2 fixes the build.rs to read `CARGO_MANIFEST_DIR / Cargo.toml` directly, with belt-and-suspenders fallbacks: env-var override (`DECIBRI_CPAL_VERSION`), workspace `Cargo.toml` fallback for `{ workspace = true }` inherit form, hardcoded `"0.17"` constant fallback (with `cargo:warning=`) for unforeseen build contexts. Cargo.toml is unambiguously present in every build context because cargo guarantees `CARGO_MANIFEST_DIR` always points at the manifest's directory.
 - **No functional change to user-visible API or error messages.** All 5 message refinements from 3.3.1 (`SampleRateOutOfRange`, `FramesPerBufferOutOfRange`, `AlreadyRunning`, `OrtInitFailed`, `OrtLoadFailed` / `OrtPathInvalid`, `PermissionDenied`) are preserved unchanged.
 - **`decibri::CPAL_VERSION` byte-identity preserved across all four cargo-emitted dep forms.** Verified 2026-04-26 by walking through `find_cpal_in_dependencies` + `truncate_to_major_minor` against on-disk Cargo.toml content: Form 1 (`cpal = "0.17"` workspace.dependencies) -> `"0.17"`; Form 2 (`cpal = { version = "0.17", optional = true }` hypothetical inline-table) -> `"0.17"`; Form 3 (`cpal = { workspace = true, optional = true }` source crate) -> workspace fallback -> `"0.17"`; Form 4 (`[dependencies.cpal] version = "0.17"` published normalized) -> `"0.17"`. All four forms produce identical output to the v3.3.1 build.rs's Cargo.lock-resolved truncation because the workspace pin is at major.minor granularity already (`cpal = "0.17"` in `[workspace.dependencies]`).
+- **`release-dryrun.yml` extended to exercise `cargo publish -p decibri --dry-run`.** The previous dryrun workflow ran the npm-side build matrix and `verify_pack` packaging gate but had no crates.io publish path coverage. The new step catches build.rs failures and any other publish-time issues that affect the Rust crate publish but not the npm packaging. Closes the procedural gap that allowed 3.3.1's defect to ship through CI green.
 
 ### Migration notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.2] - Unreleased
+
+### Changed
+
+- **`crates/decibri/build.rs` rewrite to use Cargo.toml as primary source.** The previous build script (introduced in 3.3.1 to source the cpal version from a single point of truth) read the workspace `Cargo.lock` via a path traversal that worked in workspace builds but panicked in `cargo publish` verify because the published tarball is flat (`decibri-X.Y.Z/Cargo.toml` and `decibri-X.Y.Z/Cargo.lock` are siblings, not in workspace structure). The traversal landed at `target/Cargo.lock` (nonexistent) and aborted the build. **3.3.1's crates.io publish failed on this defect; 3.3.1 shipped to npm but not to crates.io.** 3.3.2 fixes the build.rs to read `CARGO_MANIFEST_DIR / Cargo.toml` directly, with belt-and-suspenders fallbacks: env-var override (`DECIBRI_CPAL_VERSION`), workspace `Cargo.toml` fallback for `{ workspace = true }` inherit form, hardcoded `"0.17"` constant fallback (with `cargo:warning=`) for unforeseen build contexts. Cargo.toml is unambiguously present in every build context because cargo guarantees `CARGO_MANIFEST_DIR` always points at the manifest's directory.
+- **No functional change to user-visible API or error messages.** All 5 message refinements from 3.3.1 (`SampleRateOutOfRange`, `FramesPerBufferOutOfRange`, `AlreadyRunning`, `OrtInitFailed`, `OrtLoadFailed` / `OrtPathInvalid`, `PermissionDenied`) are preserved unchanged.
+- **`decibri::CPAL_VERSION` byte-identity preserved across all four cargo-emitted dep forms.** Verified 2026-04-26 by walking through `find_cpal_in_dependencies` + `truncate_to_major_minor` against on-disk Cargo.toml content: Form 1 (`cpal = "0.17"` workspace.dependencies) -> `"0.17"`; Form 2 (`cpal = { version = "0.17", optional = true }` hypothetical inline-table) -> `"0.17"`; Form 3 (`cpal = { workspace = true, optional = true }` source crate) -> workspace fallback -> `"0.17"`; Form 4 (`[dependencies.cpal] version = "0.17"` published normalized) -> `"0.17"`. All four forms produce identical output to the v3.3.1 build.rs's Cargo.lock-resolved truncation because the workspace pin is at major.minor granularity already (`cpal = "0.17"` in `[workspace.dependencies]`).
+
+### Migration notes
+
+- **Direct Rust crate consumers** of decibri: 3.3.1 was never published to crates.io. crates.io's decibri version history is 3.3.0 -> 3.3.2; 3.3.1 is skipped entirely on this registry. **npm consumers** see the standard 3.3.0 -> 3.3.1 -> 3.3.2 progression (3.3.1 shipped successfully on npm; only the cargo publish step in `release.yml` failed). The asymmetry is documented here for archaeological clarity.
+- All 3.3.1 message refinements (per `[3.3.1]` entry above) are preserved in 3.3.2. Consumer-side migration from 3.3.0 to 3.3.2 is the same as 3.3.0 to 3.3.1 from the user-visible API perspective.
+- **No npm migration required** for 3.3.1 -> 3.3.2. 3.3.2 publishes a new wheel set with the same user-visible behavior; bump-and-rebuild is sufficient.
+
 ## [3.3.1] - 2026-04-25
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.3.1"
+version = "3.3.2"
 edition = "2021"
 # MSRV empirically verified 2026-04-22: rustc 1.88 is the minimum version
 # that compiles the workspace. Floors: ort 2.0.0-rc.12 declares

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -28,7 +28,7 @@ crate-type = ["cdylib"]
 # features across both bindings silently; diverging overrides produce a build
 # that neither binding tests in isolation. Both bindings inherit decibri's
 # default features (capture, output, vad, denoise, gain, ort-load-dynamic).
-decibri = { version = "3.3.1", path = "../../crates/decibri" }
+decibri = { version = "3.3.2", path = "../../crates/decibri" }
 
 # PyO3 0.28 is the first MSRV-1.83 release line with the attach / detach /
 # initialize API renames; aligns with workspace MSRV 1.88 (headroom preserved).

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -31,9 +31,9 @@ def test_version_returns_version_info() -> None:
 
 def test_version_decibri_matches_rust_core() -> None:
     # Literal equality per Phase 1 plan. When the Rust workspace bumps past
-    # 3.3.1 this assertion breaks deliberately: force a conscious update of
+    # 3.3.2 this assertion breaks deliberately: force a conscious update of
     # the Python test expectation alongside the Rust version bump.
-    assert decibri.DecibriBridge.version().decibri == "3.3.1"
+    assert decibri.DecibriBridge.version().decibri == "3.3.2"
 
 
 def test_version_portaudio_matches_node_binding() -> None:
@@ -46,7 +46,7 @@ def test_version_portaudio_matches_node_binding() -> None:
 def test_version_info_repr() -> None:
     info = decibri.DecibriBridge.version()
     rep = repr(info)
-    assert rep == "VersionInfo(decibri='3.3.1', portaudio='cpal 0.17')"
+    assert rep == "VersionInfo(decibri='3.3.2', portaudio='cpal 0.17')"
 
 
 def test_version_info_is_frozen() -> None:

--- a/crates/decibri/build.rs
+++ b/crates/decibri/build.rs
@@ -1,6 +1,5 @@
-//! Build script: extracts the resolved cpal version from the workspace
-//! Cargo.lock and exposes it to crate code via the `DECIBRI_CPAL_VERSION`
-//! environment variable.
+//! Build script: extracts the resolved cpal version and exposes it to crate
+//! code via the `DECIBRI_CPAL_VERSION` environment variable.
 //!
 //! This is the single-source-of-truth mechanism for the `CPAL_VERSION` const
 //! in `lib.rs`. Previously, the cpal version string was hardcoded in the
@@ -8,8 +7,43 @@
 //! places): duplicated state that would silently drift when the workspace
 //! bumped cpal. By reading the resolved version here and emitting a
 //! build-time env var, every binding pulls `decibri::CPAL_VERSION` from one
-//! place. When the workspace bumps cpal, Cargo.lock updates, this script
+//! place. When the workspace bumps cpal, Cargo.toml updates, this script
 //! re-runs, and all downstream consumers see the new value automatically.
+//!
+//! # Resolution strategy (belt-and-suspenders, in priority order)
+//!
+//! 1. **`DECIBRI_CPAL_VERSION` env var override.** If set, used verbatim and
+//!    no parsing occurs. Provides an escape hatch for unforeseen build
+//!    contexts and supports release-pipeline injection if ever needed.
+//! 2. **Cargo.toml at `CARGO_MANIFEST_DIR`.** Always present in any build
+//!    context (workspace, `cargo publish` verify, `cargo install` consumer).
+//!    Parses the cpal dependency entry; handles the four cargo-emitted
+//!    forms (literal string, inline table with `version = "..."`, workspace
+//!    inherit, and dedicated `[dependencies.cpal]` table).
+//! 3. **Workspace `Cargo.toml` fallback** (in-workspace builds only). When
+//!    the manifest's cpal entry is `{ workspace = true, ... }`, the version
+//!    lives in the workspace `[workspace.dependencies]` block at
+//!    `../../Cargo.toml`. Read and parse from there.
+//! 4. **Hardcoded `"0.17"` constant fallback** with `cargo:warning=`
+//!    visibility. Belt-and-suspenders for unforeseen build contexts where
+//!    none of the above paths succeed. Prevents a build failure but emits
+//!    a loud warning so the fallback is visible in build output.
+//!
+//! # Why Cargo.toml is the primary source (changed from Cargo.lock in v3.3.2)
+//!
+//! Previous build.rs (v3.3.0 - v3.3.1) read the workspace `Cargo.lock` via
+//! `..\..\Cargo.lock` traversal from `CARGO_MANIFEST_DIR`. This worked in
+//! workspace builds but panicked in `cargo publish` verify because the
+//! published tarball is flat (`decibri-X.Y.Z/Cargo.toml` and
+//! `decibri-X.Y.Z/Cargo.lock` are siblings, not in workspace structure);
+//! the traversal landed at `target/Cargo.lock` (nonexistent). The v3.3.1
+//! crates.io publish failed on this defect.
+//!
+//! Cargo.toml is unambiguously present in every build context because cargo
+//! guarantees `CARGO_MANIFEST_DIR` points at the manifest's directory.
+//! Cargo's publish-time normalization fully resolves `{ workspace = true }`
+//! to literal versions in the published Cargo.toml, so workspace-fallback
+//! is only needed for in-workspace builds.
 //!
 //! Output format: major.minor only (`"0.17"`, not `"0.17.0"`). Preserves
 //! byte-identical output with the pre-refactor hardcoded string. If a
@@ -17,73 +51,211 @@
 //! `truncate_to_major_minor` to return the unmodified string.
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+const FALLBACK_VERSION: &str = "0.17";
 
 fn main() {
-    // crates/decibri -> crates -> workspace root
     let manifest_dir = PathBuf::from(
         std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set by cargo"),
     );
-    let workspace_lock = manifest_dir
-        .parent()
-        .and_then(|p| p.parent())
-        .map(|p| p.join("Cargo.lock"))
-        .expect("workspace root must be reachable from crates/decibri");
+    let manifest_toml = manifest_dir.join("Cargo.toml");
 
-    // Re-run only when Cargo.lock or this build script changes. Without
-    // these directives, cargo re-runs build.rs on every rebuild, defeating
-    // incremental compilation caches.
-    println!("cargo:rerun-if-changed={}", workspace_lock.display());
+    println!("cargo:rerun-if-env-changed=DECIBRI_CPAL_VERSION");
+    println!("cargo:rerun-if-changed={}", manifest_toml.display());
     println!("cargo:rerun-if-changed=build.rs");
 
-    let lock_content = fs::read_to_string(&workspace_lock)
-        .unwrap_or_else(|e| panic!("failed to read {}: {}", workspace_lock.display(), e));
+    // Layer 1: env var override.
+    if let Ok(v) = std::env::var("DECIBRI_CPAL_VERSION") {
+        if !v.is_empty() {
+            emit(&v);
+            return;
+        }
+    }
 
-    let cpal_version = extract_cpal_version(&lock_content).unwrap_or_else(|| {
-        panic!(
-            "expected a [[package]] entry for `cpal` in {}; Cargo.lock is \
-             malformed or cpal has been removed from the dep graph",
-            workspace_lock.display()
-        )
-    });
+    // Layer 2: read CARGO_MANIFEST_DIR / Cargo.toml.
+    match fs::read_to_string(&manifest_toml) {
+        Ok(content) => match resolve_cpal_version(&content, &manifest_dir) {
+            Some(v) => {
+                emit(&v);
+                return;
+            }
+            None => {
+                println!(
+                    "cargo:warning=decibri build.rs: cpal version not found in {}; \
+                     falling back to hardcoded \"{}\"",
+                    manifest_toml.display(),
+                    FALLBACK_VERSION
+                );
+            }
+        },
+        Err(e) => {
+            println!(
+                "cargo:warning=decibri build.rs: failed to read {}: {}; \
+                 falling back to hardcoded \"{}\"",
+                manifest_toml.display(),
+                e,
+                FALLBACK_VERSION
+            );
+        }
+    }
 
-    let major_minor = truncate_to_major_minor(&cpal_version);
+    // Layer 4: hardcoded fallback.
+    emit(FALLBACK_VERSION);
+}
+
+fn emit(version: &str) {
+    let major_minor = truncate_to_major_minor(version);
     println!("cargo:rustc-env=DECIBRI_CPAL_VERSION={}", major_minor);
 }
 
-/// Finds the `cpal` package's `version` line in a Cargo.lock file.
+/// Resolve cpal version from a manifest's content, with workspace fallback.
 ///
-/// Cargo.lock format is stable since Cargo 1.0:
+/// Handles all four cargo-emitted forms of the cpal dep:
+/// - `cpal = "0.17"` (Form 1: inline string)
+/// - `cpal = { version = "0.17", optional = true }` (Form 2: inline table)
+/// - `cpal = { workspace = true, optional = true }` (Form 3: workspace inherit)
+/// - `[dependencies.cpal]\nversion = "0.17"\n...` (Form 4: dedicated table)
 ///
-/// ```text
-/// [[package]]
-/// name = "cpal"
-/// version = "0.17.3"
-/// source = "registry+..."
-/// ```
-///
-/// Walks the file in order, tracking whether we're inside a `[[package]]`
-/// block, whether that block's `name` is `cpal`, and whether we've seen
-/// `version` for that block. Returns the first match; the workspace
-/// currently has exactly one cpal entry.
-fn extract_cpal_version(lock_content: &str) -> Option<String> {
-    let mut in_package = false;
-    let mut is_cpal = false;
-    for line in lock_content.lines() {
+/// Forms 1, 2, 4 are self-contained: version returned directly.
+/// Form 3 triggers a workspace-fallback read of `../../Cargo.toml`'s
+/// `[workspace.dependencies] cpal` entry, which is always Form 1 or Form 2.
+fn resolve_cpal_version(manifest_content: &str, manifest_dir: &Path) -> Option<String> {
+    if let Some(form) = find_cpal_in_dependencies(manifest_content) {
+        match form {
+            CpalEntry::Literal(v) => return Some(v),
+            CpalEntry::WorkspaceInherit => {
+                // Form 3: walk up to workspace Cargo.toml.
+                let workspace_toml = manifest_dir.parent()?.parent()?.join("Cargo.toml");
+                let ws_content = fs::read_to_string(&workspace_toml).ok()?;
+                if let Some(CpalEntry::Literal(v)) =
+                    find_cpal_in_workspace_dependencies(&ws_content)
+                {
+                    return Some(v);
+                }
+                return None;
+            }
+        }
+    }
+    None
+}
+
+#[derive(Debug)]
+enum CpalEntry {
+    Literal(String),
+    WorkspaceInherit,
+}
+
+/// Search a manifest's `[dependencies]` block (inline forms 1-3) and any
+/// `[dependencies.cpal]` table (form 4) for the cpal entry.
+fn find_cpal_in_dependencies(content: &str) -> Option<CpalEntry> {
+    // Form 4: `[dependencies.cpal]` dedicated table.
+    if let Some(v) = extract_version_after_section(content, "[dependencies.cpal]") {
+        return Some(CpalEntry::Literal(v));
+    }
+    // Forms 1-3: inline within `[dependencies]` block.
+    extract_inline_cpal_in_section(content, "[dependencies]")
+}
+
+/// Search a workspace manifest's `[workspace.dependencies]` block.
+/// Workspace deps are always Form 1 or Form 2 (workspace-inherit doesn't
+/// nest); WorkspaceInherit is not a valid CpalEntry here.
+fn find_cpal_in_workspace_dependencies(content: &str) -> Option<CpalEntry> {
+    if let Some(v) = extract_version_after_section(content, "[workspace.dependencies.cpal]") {
+        return Some(CpalEntry::Literal(v));
+    }
+    extract_inline_cpal_in_section(content, "[workspace.dependencies]")
+}
+
+/// For a `[section.cpal]` dedicated-table form, walk forward from the
+/// section header to the next `[` line, finding `version = "..."`.
+fn extract_version_after_section(content: &str, section_header: &str) -> Option<String> {
+    let mut in_section = false;
+    for line in content.lines() {
         let trimmed = line.trim();
-        if trimmed == "[[package]]" {
-            in_package = true;
-            is_cpal = false;
+        if trimmed == section_header {
+            in_section = true;
             continue;
         }
-        if in_package && trimmed == "name = \"cpal\"" {
-            is_cpal = true;
+        if in_section {
+            // Next section header ends this table.
+            if trimmed.starts_with('[') && trimmed != section_header {
+                return None;
+            }
+            if let Some(rest) = trimmed.strip_prefix("version") {
+                let after_eq = rest.trim_start().strip_prefix('=')?.trim_start();
+                if let Some(stripped) = after_eq.strip_prefix('"') {
+                    if let Some(v) = stripped.strip_suffix('"') {
+                        return Some(v.to_string());
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// For an inline `cpal = ...` line within a `[section]` block, parse:
+///   - `cpal = "0.17"` -> Literal("0.17")
+///   - `cpal = { version = "0.17", ... }` -> Literal("0.17")
+///   - `cpal = { workspace = true, ... }` -> WorkspaceInherit
+///
+/// Walks lines from `[section]` header until the next `[` section starts.
+/// Returns the first cpal line found.
+fn extract_inline_cpal_in_section(content: &str, section_header: &str) -> Option<CpalEntry> {
+    let mut in_section = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed == section_header {
+            in_section = true;
             continue;
         }
-        if in_package && is_cpal {
-            if let Some(rest) = trimmed.strip_prefix("version = \"") {
-                if let Some(v) = rest.strip_suffix('"') {
-                    return Some(v.to_string());
+        if in_section {
+            if trimmed.starts_with('[') && trimmed != section_header {
+                return None;
+            }
+            if let Some(value_part) = trimmed.strip_prefix("cpal") {
+                let after_eq = value_part.trim_start().strip_prefix('=')?.trim_start();
+                return parse_inline_value(after_eq);
+            }
+        }
+    }
+    None
+}
+
+/// Parse the value side of a `cpal = ...` inline declaration:
+///   `"0.17"` -> Literal("0.17")
+///   `{ version = "0.17", ... }` -> Literal("0.17")
+///   `{ workspace = true, ... }` -> WorkspaceInherit
+fn parse_inline_value(value: &str) -> Option<CpalEntry> {
+    let trimmed = value.trim();
+    // Form 1: bare quoted string.
+    if let Some(stripped) = trimmed.strip_prefix('"') {
+        if let Some(v) = stripped.split('"').next() {
+            return Some(CpalEntry::Literal(v.to_string()));
+        }
+    }
+    // Forms 2/3: inline table.
+    if let Some(inner) = trimmed.strip_prefix('{').and_then(|s| s.strip_suffix('}')) {
+        // Look for `workspace = true` first (Form 3).
+        for part in inner.split(',') {
+            let part = part.trim();
+            if part.starts_with("workspace") {
+                let after_eq = part.split('=').nth(1)?.trim();
+                if after_eq == "true" {
+                    return Some(CpalEntry::WorkspaceInherit);
+                }
+            }
+        }
+        // Otherwise look for `version = "..."` (Form 2).
+        for part in inner.split(',') {
+            let part = part.trim();
+            if let Some(rest) = part.strip_prefix("version") {
+                let after_eq = rest.trim_start().strip_prefix('=')?.trim_start();
+                if let Some(stripped) = after_eq.strip_prefix('"') {
+                    if let Some(v) = stripped.split('"').next() {
+                        return Some(CpalEntry::Literal(v.to_string()));
+                    }
                 }
             }
         }

--- a/crates/decibri/src/lib.rs
+++ b/crates/decibri/src/lib.rs
@@ -150,10 +150,11 @@ pub mod error;
 pub mod sample;
 
 /// Resolved cpal version (major.minor) extracted at build time from the
-/// workspace `Cargo.lock`.
+/// crate's `Cargo.toml`.
 ///
-/// Populated by `build.rs` scanning Cargo.lock for the `cpal` package entry
-/// and truncating the resolved version to major.minor. Used by binding
+/// Populated by `build.rs` parsing the cpal entry from the crate's
+/// `Cargo.toml` (with workspace fallback for `{ workspace = true }`
+/// inherits) and truncating to major.minor. Used by binding
 /// layers (Node, Python) as the value of the `portaudio` field in their
 /// version-info responses:
 ///
@@ -163,9 +164,9 @@ pub mod sample;
 /// ```
 ///
 /// Single source of truth: bumping cpal in the workspace `Cargo.toml`
-/// regenerates `Cargo.lock`, which re-triggers the build script, which
-/// updates this constant, which updates every binding that reads it. No
-/// manual sync required across crates.
+/// re-triggers the build script (via `cargo:rerun-if-changed=Cargo.toml`),
+/// which updates this constant, which updates every binding that reads it.
+/// No manual sync required across crates.
 ///
 /// Format: `"0.17"`. Bindings prefix with `"cpal "` when reporting to users.
 /// If future work wants finer granularity (e.g. full `"0.17.3"`), update

--- a/npm/decibri/package.json
+++ b/npm/decibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decibri",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Cross-platform audio capture, output, and processing for Node.js and browsers",
   "main": "src/decibri.js",
   "types": "src/decibri.d.ts",
@@ -69,10 +69,10 @@
     "README.md"
   ],
   "optionalDependencies": {
-    "@decibri/decibri-win32-x64-msvc": "3.3.1",
-    "@decibri/decibri-darwin-arm64": "3.3.1",
-    "@decibri/decibri-linux-x64-gnu": "3.3.1",
-    "@decibri/decibri-linux-arm64-gnu": "3.3.1"
+    "@decibri/decibri-win32-x64-msvc": "3.3.2",
+    "@decibri/decibri-darwin-arm64": "3.3.2",
+    "@decibri/decibri-linux-x64-gnu": "3.3.2",
+    "@decibri/decibri-linux-arm64-gnu": "3.3.2"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.0.0"

--- a/npm/platform-darwin-arm64/package.json
+++ b/npm/platform-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-darwin-arm64",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "os": ["darwin"],
   "cpu": ["arm64"],
   "main": "decibri.darwin-arm64.node",

--- a/npm/platform-linux-arm64-gnu/package.json
+++ b/npm/platform-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-arm64-gnu",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "os": ["linux"],
   "cpu": ["arm64"],
   "main": "decibri.linux-arm64-gnu.node",

--- a/npm/platform-linux-x64-gnu/package.json
+++ b/npm/platform-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-x64-gnu",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "os": ["linux"],
   "cpu": ["x64"],
   "main": "decibri.linux-x64-gnu.node",

--- a/npm/platform-win32-x64-msvc/package.json
+++ b/npm/platform-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-win32-x64-msvc",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "os": ["win32"],
   "cpu": ["x64"],
   "main": "decibri.win32-x64-msvc.node",


### PR DESCRIPTION
## Summary

Recovery release for v3.3.1's split-state ship. v3.3.1 published successfully to npm (main package + 4 platform packages on 2026-04-25) but failed on `cargo publish -p decibri` at the verify step due to a structural defect in `crates/decibri/build.rs` introduced in Phase 1 Commit 1a. The defect was dormant because v3.3.0 predated the build.rs entirely; v3.3.1 was the first release attempt that exercised the cargo publish path with build.rs in tree, and it broke on first contact.

3.3.2 ships the fix to both registries plus a procedural-gap-closure that prevents recurrence.

## What changed

### build.rs hardening (Commit 1)

Rewrote `crates/decibri/build.rs` to use Cargo.toml as primary source for the cpal version instead of workspace Cargo.lock. Cargo.toml is unambiguously present in any build context (workspace, `cargo publish` verify, `cargo install` consumer); cargo guarantees `CARGO_MANIFEST_DIR` always points at the manifest's directory. The previous Cargo.lock traversal worked in workspace builds but panicked in publish-verify because the published tarball is flat (`decibri-X.Y.Z/Cargo.toml` and `decibri-X.Y.Z/Cargo.lock` are siblings, not in workspace structure); the `../../Cargo.lock` traversal landed at `target/Cargo.lock` (nonexistent).

Belt-and-suspenders structure:

1. `DECIBRI_CPAL_VERSION` env var override (escape hatch for unforeseen contexts).
2. Cargo.toml parse from `CARGO_MANIFEST_DIR` (handles 4 cargo-emitted dep forms: literal string, inline table, workspace inherit, dedicated `[dependencies.cpal]` table).
3. Workspace `Cargo.toml` fallback for `{ workspace = true }` inherit form (in-workspace builds only; cargo normalizes inherits to literal versions in published Cargo.toml).
4. Hardcoded `"0.17"` constant fallback with `cargo:warning=` for visibility into unforeseen contexts.

Hand-rolled parser (no `toml` crate dep added; matches existing build.rs string-walking style).

`crates/decibri/src/lib.rs:152-178` rustdoc on `CPAL_VERSION` updated to reflect the new mechanism (mechanism-specific lines updated; rationale-flavored content preserved verbatim).

`decibri::CPAL_VERSION` byte-identity preserved across all four cargo-emitted dep forms — verified by walking through `find_cpal_in_dependencies` + `truncate_to_major_minor` against on-disk content. All four forms produce `"0.17"` identically because the workspace pin is at major.minor granularity.

### Procedural-gap-closure (Commit 2)

Extended `release-dryrun.yml` with a new `cargo-publish-dryrun` job that runs `cargo publish -p decibri --dry-run` on ubuntu-latest after the build matrix succeeds. The previous dryrun workflow ran the npm-side build matrix and `verify_pack` packaging gate but had no crates.io publish path coverage. The new job catches build.rs failures and any other publish-time issues that affect the Rust crate publish but not the npm packaging.

No `--allow-dirty` flag (CI checks out a clean tree); no rust-cache step (matches release-validation convention of building from clean state to avoid cache masking the issues `--dry-run` is meant to catch). Action references use the same floating-tag convention as the rest of release-dryrun.yml (SHA-pin audit deferred to Phase 5).

### Version bumps (Commit 3)

`3.3.1` → `3.3.2` across:
- Workspace `Cargo.toml`
- `bindings/python/Cargo.toml` dual `path + version` dep on the core crate
- `npm/decibri/package.json` (version + 4 `optionalDependencies` exact-pins)
- 4 npm platform `package.json` files
- `bindings/python/tests/test_smoke.py` (3 sites: comment + 2 literal assertions per Phase 1 plan §3.7 intentional-churn pattern)
- `Cargo.lock` (auto-regenerated; gitignored)

`CHANGELOG.md` `[3.3.2] - 2026-04-26` entry with the dryrun-extension bullet appended.

## Version-skew documentation

**npm:** 3.3.0 → 3.3.1 → 3.3.2 (standard progression).
**crates.io:** 3.3.0 → 3.3.2 (3.3.1 skipped entirely).

Consumers asking "why is there no decibri 3.3.1 on crates.io?" find the answer in:
- The `CHANGELOG.md` `[3.3.2]` entry's preamble.
- The `decibri-3-3-2-patch-build-rs-hardening.md` plan file.
- Future master plan `v2_6_1` covering the recovery window.

## Migration notes

- **Direct Rust crate consumers** of decibri: 3.3.1 was never published to crates.io. crates.io's decibri version history is 3.3.0 → 3.3.2; 3.3.1 is skipped entirely on this registry.
- **npm consumers** see the standard 3.3.0 → 3.3.1 → 3.3.2 progression. 3.3.1 shipped successfully on npm; only the cargo publish step in `release.yml` failed.
- All 3.3.1 message refinements (per `[3.3.1]` entry) are preserved unchanged in 3.3.2. Consumer-side migration from 3.3.0 to 3.3.2 is the same as 3.3.0 to 3.3.1 from the user-visible API perspective.
- **No npm migration required** for 3.3.1 → 3.3.2. 3.3.2 publishes a new wheel set with the same user-visible behavior; bump-and-rebuild is sufficient.

## Validation

3 commits on `development`, all gates green per commit:

- Commit 1 `8336c98` — `fix(build): switch build.rs to Cargo.toml as primary source for cpal version`
- Commit 2 `a63cee5` — `ci: add cargo-publish-dryrun job to release-dryrun.yml`
- Commit 3 `823d0e7` — `chore(release): bump to 3.3.2`

CI green across all workflows: 5 ci.yml status checks (Lint, Security Audit, Rust Tests, Node.js Tests, Browser Tests) on every push; Python CI fired on Commits 1 and 3 (paths filter matched), correctly skipped on Commit 2 (workflow-only change). Total 16 status checks across the 3 pushes.

Plus Gate 7 publish-flow validation on Commits 1 and 3: `cargo publish -p decibri --dry-run --allow-dirty` reaches the upload prompt without panic — the integration-test signal that the build.rs fix actually resolves the v3.3.1 defect.

Phase-level audit (8 sections): GO verdict, zero Blocking, zero Significant, 6 Minor findings (3 plan-doc cleanup items, 2 Phase 5 deferrals, 1 FYI). Pattern-consistent with the 3.3.1 audit precedent.

## Pre-merge gate

`release-dryrun.yml` will be manually dispatched against `development` after this PR opens to verify the new `cargo-publish-dryrun` job passes in CI before merge. This is the procedural-gap-closure verification — closes the gap that allowed 3.3.1 to ship to npm with a broken cargo publish path.

## Reference

Patch plan: `decibri-3-3-2-patch-build-rs-hardening.md` (working document, not in repo).