### PR TITLE
Fix check-upstream.yml: replace curl+python with cargo search

### DIFF
--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -30,7 +30,11 @@ jobs:
           # Use cargo search instead of curl+python: avoids crates.io
           # User-Agent enforcement issues from GitHub Actions runner IPs,
           # and uses the cargo toolchain's own crates.io client.
-          VERSION=$(cargo search cpal --limit 1 | head -1 | grep -oP '"\K[^"]+')
+          # Parser splits on '"' and takes field 2 (the version string).
+          # Earlier attempt used grep -oP '"\K[^"]+', but PCRE \K matches
+          # twice on a line like `cpal = "0.17.3"    # description`,
+          # producing two output lines and corrupting $GITHUB_OUTPUT.
+          VERSION=$(cargo search cpal --limit 1 | head -1 | awk -F'"' '{print $2}')
           if [ -z "$VERSION" ]; then
             echo "ERROR: could not extract cpal version from cargo search output"
             cargo search cpal --limit 1
@@ -78,7 +82,9 @@ jobs:
           # Use cargo search instead of curl+python: avoids crates.io
           # User-Agent enforcement issues from GitHub Actions runner IPs,
           # and uses the cargo toolchain's own crates.io client.
-          VERSION=$(cargo search ort --limit 1 | head -1 | grep -oP '"\K[^"]+')
+          # See check-cpal for parser rationale; awk -F'"' is robust and
+          # preserves RC suffixes like 2.0.0-rc.12.
+          VERSION=$(cargo search ort --limit 1 | head -1 | awk -F'"' '{print $2}')
           if [ -z "$VERSION" ]; then
             echo "ERROR: could not extract ort version from cargo search output"
             cargo search ort --limit 1

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -27,7 +27,15 @@ jobs:
       - name: Get latest version
         id: latest
         run: |
-          VERSION=$(curl -s https://crates.io/api/v1/crates/cpal | python3 -c "import sys,json; print(json.load(sys.stdin)['crate']['max_version'])")
+          # Use cargo search instead of curl+python: avoids crates.io
+          # User-Agent enforcement issues from GitHub Actions runner IPs,
+          # and uses the cargo toolchain's own crates.io client.
+          VERSION=$(cargo search cpal --limit 1 | head -1 | grep -oP '"\K[^"]+')
+          if [ -z "$VERSION" ]; then
+            echo "ERROR: could not extract cpal version from cargo search output"
+            cargo search cpal --limit 1
+            exit 1
+          fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Create issue if behind
@@ -67,7 +75,15 @@ jobs:
       - name: Get latest version
         id: latest
         run: |
-          VERSION=$(curl -s https://crates.io/api/v1/crates/ort | python3 -c "import sys,json; print(json.load(sys.stdin)['crate']['max_version'])")
+          # Use cargo search instead of curl+python: avoids crates.io
+          # User-Agent enforcement issues from GitHub Actions runner IPs,
+          # and uses the cargo toolchain's own crates.io client.
+          VERSION=$(cargo search ort --limit 1 | head -1 | grep -oP '"\K[^"]+')
+          if [ -z "$VERSION" ]; then
+            echo "ERROR: could not extract ort version from cargo search output"
+            cargo search ort --limit 1
+            exit 1
+          fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Create issue if behind


### PR DESCRIPTION
The check-cpal and check-ort jobs were failing in CI with KeyError: 'crate' when curl piped a non-crate response from crates.io into Python (likely crates.io's User-Agent enforcement on GitHub Actions runner IPs).

Replaces the broken curl+python pipeline with `cargo search`, which uses the cargo toolchain's own crates.io client. Bug-bug-fix sequence:

1. First commit: replaced curl+python with `cargo search` + `grep -oP '"\K[^"]+'`. This passed local validation but failed in CI because PCRE `\K` reset the match, capturing both the version and the trailing description text per line. head -1 filtered cargo's output, not grep's, so $VERSION ended up multi-line and broke $GITHUB_OUTPUT's key=value format.

2. Second commit: switched to `awk -F'"' '{print $2}'`. Single-output, unambiguous, robust against any description content. Workflow now passes in CI on the development branch.

The check-onnxruntime job uses gh api (different code path) and was unaffected; left unchanged.

Verified: workflow_dispatch run on development passed all three jobs.