### PR TITLE
Phase 3: Bundle ONNX Runtime dylib in Python wheels

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -327,6 +327,7 @@ jobs:
 
       - name: Build release wheel (smoke; not uploaded)
         working-directory: bindings/python
+        shell: bash
         # Validates the release-profile abi3 wheel builds end-to-end,
         # separate from the dev-profile `maturin develop` above. Catches
         # release-only issues (lto, strip, codegen-units = 1) before they'd

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -305,9 +305,14 @@ jobs:
       - name: Run pytest
         working-directory: bindings/python
         # GitHub Actions sets CI=true automatically; conftest.py auto-skips
-        # the requires_audio_input / requires_audio_output / requires_bundled_ort
-        # markers under that signal. CI runs only the no-hardware subset
-        # (~84 tests of the 107 in the suite).
+        # the audio hardware markers (requires_audio_input,
+        # requires_audio_output) under that signal because runners have no
+        # real audio devices. The requires_bundled_ort marker uses a
+        # separate auto-skip policy keyed on whether
+        # bindings/python/python/decibri/_ort/ contains a platform dylib;
+        # that directory is populated by the "Download and extract ONNX
+        # Runtime" step earlier in this job, so bundled-ORT tests run
+        # here rather than skip.
         run: uv run pytest -v
 
       - name: Run mypy --strict (Linux only)
@@ -329,3 +334,50 @@ jobs:
         # entry; acceptable cost for the pre-publish insurance. Artifact
         # not uploaded; Phase 3 adds the cross-platform wheel upload matrix.
         run: uv run maturin build --release
+
+      - name: Wheel install-test (Phase 3 acceptance gate)
+        working-directory: bindings/python
+        shell: bash
+        # Catches the original Phase 2 gap: "wheel built fine, but breaks
+        # on user install". A clean venv installs the just-built wheel
+        # path-based (NOT from any registry) and runs the ORT bundling
+        # test suite against it. No editable install in this venv, so
+        # `import decibri` resolves to the wheel's installed layout
+        # exactly as a user's `pip install decibri` would. The
+        # requires_bundled_ort tests must RUN (not skip) here; if they
+        # skip, the wheel is missing the bundled _ort/ and the gate fails.
+        #
+        # uv venv creates Scripts/python.exe on Windows and bin/python on
+        # Unix; we resolve the platform-specific path explicitly to keep
+        # the rest of the step OS-neutral. set -euo pipefail surfaces any
+        # missing wheel as a hard failure rather than a silent no-op.
+        run: |
+          set -euo pipefail
+          WHEEL=$(ls target/wheels/decibri-*.whl | head -1)
+          if [ -z "$WHEEL" ]; then
+            echo "ERROR: no wheel found in target/wheels/"
+            exit 1
+          fi
+          echo "Install-test target: $WHEEL"
+
+          # Wheel size soft alarm (Decision: 150 MB). Bundled wheels are
+          # expected at 30 to 50 MB; alert if anything triples that.
+          SIZE=$(wc -c < "$WHEEL")
+          echo "Wheel size: $((SIZE / 1024 / 1024)) MB ($SIZE bytes)"
+          if [ "$SIZE" -gt 157286400 ]; then
+            echo "WARNING: wheel exceeds 150 MB soft cap; investigate before merge."
+          fi
+
+          uv venv .install-test
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            VENV_PY=".install-test/Scripts/python.exe"
+          else
+            VENV_PY=".install-test/bin/python"
+          fi
+          uv pip install --python "$VENV_PY" "$WHEEL" pytest
+
+          # Run the install-test pytest from the source tree but with the
+          # clean venv's python; pytest finds tests/test_ort_bundling.py
+          # under the source layout, while `import decibri` resolves to
+          # the wheel-installed package (no editable install in this venv).
+          "$VENV_PY" -m pytest tests/test_ort_bundling.py -v

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -353,9 +353,15 @@ jobs:
         # missing wheel as a hard failure rather than a silent no-op.
         run: |
           set -euo pipefail
-          WHEEL=$(ls target/wheels/decibri-*.whl | head -1)
+          # Wheel path: maturin writes to the cargo workspace root's
+          # target/wheels/ regardless of where it was invoked from, because
+          # bindings/python is a workspace member. The install-test step's
+          # working-directory is bindings/python (so pytest finds tests/),
+          # so we resolve the wheel via $GITHUB_WORKSPACE rather than a
+          # relative path that depends on cwd.
+          WHEEL=$(ls "${GITHUB_WORKSPACE}/target/wheels/decibri-"*.whl | head -1)
           if [ -z "$WHEEL" ]; then
-            echo "ERROR: no wheel found in target/wheels/"
+            echo "ERROR: no wheel found in ${GITHUB_WORKSPACE}/target/wheels/"
             exit 1
           fi
           echo "Install-test target: $WHEEL"

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -42,6 +42,14 @@ env:
   # to every matrix entry; it is a no-op on Python 3.10 through 3.13 build
   # hosts and only takes effect for the 3.14 entries.
   PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+  # Single source of truth for the bundled ONNX Runtime version, mirroring
+  # release.yml's pattern (release.yml line 20). Read by the per-platform
+  # preflight + download steps below. Also parsed by check-upstream.yml's
+  # ONNX Runtime drift check (the workflow greps release.yml for
+  # ORT_VERSION; the Python wheel pipeline pins to the same value here).
+  # Update in lockstep with release.yml at every ort-crate upgrade per the
+  # workspace Cargo.toml maintainer comment (steps 2 and 3 of that comment).
+  ORT_VERSION: 1.24.4
 
 jobs:
   python-ci:
@@ -157,6 +165,137 @@ jobs:
         # rather than silently regenerating. Local devs use plain
         # `uv sync --dev` (no --locked) per CLAUDE.md Gate 6.
         run: uv sync --dev --locked
+
+      - name: Compute ORT platform metadata
+        id: ort-meta
+        shell: bash
+        # Maps RUNNER_OS + RUNNER_ARCH to the upstream ONNX Runtime
+        # tarball naming convention. The four expected combinations
+        # mirror release.yml's per-job matrix.ort_platform_slug values:
+        # win-x64, osx-arm64, linux-x64, linux-aarch64. python-ci.yml's
+        # matrix is conditional (sized by trigger) so the slug cannot be
+        # carried as a matrix dimension; computing it here keeps a single
+        # source of truth and lets the preflight + download steps below
+        # share one URL.
+        run: |
+          case "${RUNNER_OS}-${RUNNER_ARCH}" in
+            Linux-X64)    SLUG="linux-x64";     EXT="tgz" ;;
+            Linux-ARM64)  SLUG="linux-aarch64"; EXT="tgz" ;;
+            macOS-ARM64)  SLUG="osx-arm64";     EXT="tgz" ;;
+            Windows-X64)  SLUG="win-x64";       EXT="zip" ;;
+            *)
+              echo "ERROR: unsupported runner OS+arch combination: ${RUNNER_OS}-${RUNNER_ARCH}"
+              exit 1
+              ;;
+          esac
+          URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-${SLUG}-${ORT_VERSION}.${EXT}"
+          echo "slug=${SLUG}" >> "$GITHUB_OUTPUT"
+          echo "ext=${EXT}" >> "$GITHUB_OUTPUT"
+          echo "url=${URL}" >> "$GITHUB_OUTPUT"
+          echo "Resolved: ${URL}"
+
+      - name: Verify ONNX Runtime tarball availability
+        shell: bash
+        # Mirrors release.yml lines 131-143: HEAD-check the URL before
+        # the heavier download runs, so a Microsoft asset rename or yank
+        # surfaces immediately with a clear error message rather than as
+        # an opaque mid-build failure. Same pattern in production for the
+        # Node release pipeline since 3.0.
+        run: |
+          URL="${{ steps.ort-meta.outputs.url }}"
+          echo "Verifying: $URL"
+          if ! curl -sIfL --retry 3 --retry-delay 2 -o /dev/null "$URL"; then
+            echo "ERROR: expected ONNX Runtime tarball not available at $URL"
+            echo "This may mean Microsoft renamed release assets, delayed a release,"
+            echo "or the pinned ORT_VERSION no longer exists upstream."
+            echo "Check: https://github.com/microsoft/onnxruntime/releases/tag/v${ORT_VERSION}"
+            exit 1
+          fi
+          echo "OK: tarball is available"
+
+      - name: Download and extract ONNX Runtime (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        # Mirrors release.yml lines 145-155. cp -L dereferences the
+        # symlink chain (libonnxruntime.dylib -> libonnxruntime.<ver>.dylib)
+        # so the bundled file is a real signed dylib, not a dangling link
+        # post-pip-install. Renamed to unversioned to match what the Python
+        # resolver looks for under python/decibri/_ort/.
+        run: |
+          SLUG="${{ steps.ort-meta.outputs.slug }}"
+          URL="${{ steps.ort-meta.outputs.url }}"
+          mkdir -p bindings/python/python/decibri/_ort
+          curl -sL --retry 3 --retry-delay 2 -o ort.tgz "$URL"
+          tar -xzf ort.tgz
+          SRC="onnxruntime-${SLUG}-${ORT_VERSION}"
+          cp -L "$SRC/lib/libonnxruntime.${ORT_VERSION}.dylib" bindings/python/python/decibri/_ort/libonnxruntime.dylib
+
+      - name: Verify libonnxruntime.dylib codesign (macOS, diagnostic)
+        if: runner.os == 'macOS'
+        continue-on-error: true
+        # Non-gating mirror of release.yml lines 157-167: cp -L on a real
+        # file preserves signed bytes but does not preserve the original
+        # filename the signature may be scoped to. Microsoft's upstream
+        # dylib is signed; this surfaces whether the rename invalidates
+        # the signature. On failure the step is marked red but the
+        # workflow proceeds.
+        run: codesign -v --verbose=2 bindings/python/python/decibri/_ort/libonnxruntime.dylib
+
+      - name: Download and extract ONNX Runtime (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        # Mirrors release.yml lines 169-183. Two files copied: the main
+        # dylib (symlink-resolved) and libonnxruntime_providers_shared.so
+        # (kept under its exact upstream name). The main dylib dlopens
+        # the providers solib by basename via $ORIGIN RUNPATH at session
+        # creation; without it Linux SileroVad fails to load.
+        run: |
+          SLUG="${{ steps.ort-meta.outputs.slug }}"
+          URL="${{ steps.ort-meta.outputs.url }}"
+          mkdir -p bindings/python/python/decibri/_ort
+          curl -sL --retry 3 --retry-delay 2 -o ort.tgz "$URL"
+          tar -xzf ort.tgz
+          SRC="onnxruntime-${SLUG}-${ORT_VERSION}"
+          cp -L "$SRC/lib/libonnxruntime.so" bindings/python/python/decibri/_ort/libonnxruntime.so
+          cp "$SRC/lib/libonnxruntime_providers_shared.so" bindings/python/python/decibri/_ort/
+
+      - name: Download and extract ONNX Runtime (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        # Mirrors release.yml lines 185-195. The Windows zip ships
+        # onnxruntime.dll (no rename needed; upstream name matches what
+        # the Python resolver looks for) and onnxruntime_providers_shared.dll;
+        # we bundle only the main DLL, matching release.yml's proven Node
+        # distribution. CPU EP (the only path Phase 3 uses per master-plan
+        # Decision 1) does not load providers_shared on Windows. If a
+        # future GPU EP integration needs it, revisit.
+        run: |
+          $ProgressPreference = 'SilentlyContinue'
+          $url = "${{ steps.ort-meta.outputs.url }}"
+          New-Item -ItemType Directory -Force -Path bindings/python/python/decibri/_ort | Out-Null
+          Invoke-WebRequest -Uri $url -OutFile ort.zip -MaximumRetryCount 3 -RetryIntervalSec 2
+          Expand-Archive -Path ort.zip -DestinationPath .
+          $src = "onnxruntime-${{ steps.ort-meta.outputs.slug }}-$env:ORT_VERSION"
+          Copy-Item "$src/lib/onnxruntime.dll" bindings/python/python/decibri/_ort/
+
+      - name: Inspect onnxruntime.dll imports (Windows, diagnostic)
+        if: runner.os == 'Windows'
+        continue-on-error: true
+        shell: pwsh
+        # Non-gating mirror of release.yml lines 197-217. dumpbin ships
+        # under VS install path and is not on default PATH on
+        # windows-latest runners. Output (the DLL's import table) goes to
+        # the log so unexpected dependencies (odd MSVC runtime, Windows
+        # SDK DLLs, etc.) surface before users hit "cannot find library
+        # X" at runtime.
+        run: |
+          $dumpbin = Get-ChildItem "C:\Program Files*\Microsoft Visual Studio\*\*\VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $dumpbin) {
+            Write-Host "dumpbin.exe not found under the Visual Studio install path"
+            exit 1
+          }
+          Write-Host "Using dumpbin: $($dumpbin.FullName)"
+          & $dumpbin.FullName /imports bindings/python/python/decibri/_ort/onnxruntime.dll
 
       - name: Build extension (maturin develop, dev profile)
         working-directory: bindings/python

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -333,7 +333,22 @@ jobs:
         # surface during Phase 5 TestPyPI publish. Adds ~30s per matrix
         # entry; acceptable cost for the pre-publish insurance. Artifact
         # not uploaded; Phase 3 adds the cross-platform wheel upload matrix.
-        run: uv run maturin build --release
+        #
+        # Clean target/wheels/ before invoking maturin. Swatinem/rust-cache
+        # caches the entire target/ tree, including target/wheels/. When a
+        # cache key matches across runs (e.g. neither dependencies nor
+        # toolchain changed), restoration brings back stale .whl files from
+        # earlier builds. The install-test step's
+        # `ls target/wheels/decibri-*.whl | head -1` picks alphabetically,
+        # which can select a stale linux_x86_64 wheel over the freshly
+        # built manylinux_2_38_x86_64 wheel. Wiping target/wheels/ here
+        # leaves only the current build's output for downstream steps to
+        # find. The Rust build cache in target/release/ and target/debug/
+        # is preserved (we only delete target/wheels/), so build times
+        # are unaffected.
+        run: |
+          rm -rf "${GITHUB_WORKSPACE}/target/wheels/"
+          uv run maturin build --release
 
       - name: Wheel install-test (Phase 3 acceptance gate)
         working-directory: bindings/python

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -52,6 +52,14 @@ module-name = "decibri._decibri"
 bindings = "pyo3"
 include = [
     { path = "python/decibri/models/silero_vad.onnx", format = ["sdist", "wheel"] },
+    # Per-platform ONNX Runtime dynamic library bundled by python-ci.yml's
+    # download/extract step before maturin runs. Wheel-only: the dylib is
+    # platform-specific and source distributions must not embed prebuilt
+    # binaries. The directory is empty on dev installs (no manual ORT
+    # download); tests gated by the requires_bundled_ort marker auto-skip
+    # in that case. Glob pattern tolerates auditwheel/delocate hash-suffix
+    # renaming applied at wheel-repair time.
+    { path = "python/decibri/_ort/*", format = ["wheel"] },
 ]
 
 [tool.pytest.ini_options]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -32,6 +32,16 @@ classifiers = [
     "Topic :: Multimedia :: Sound/Audio :: Capture/Recording",
 ]
 
+# Runtime dependencies. typing_extensions is required because
+# python/decibri/_classes.py imports `Self` from it for compatibility with
+# Python 3.10 (the abi3 floor); typing.Self only exists in 3.11+. The dev
+# group below pins the same package for the development environment, but
+# that group does not propagate into wheel metadata, so the runtime
+# declaration is the one that reaches end users via `pip install decibri`.
+dependencies = [
+    "typing-extensions>=4.15",
+]
+
 [project.urls]
 Homepage = "https://github.com/decibri/decibri"
 Repository = "https://github.com/decibri/decibri"

--- a/bindings/python/python/decibri/_classes.py
+++ b/bindings/python/python/decibri/_classes.py
@@ -229,6 +229,52 @@ class Decibri:
         numpy: bool = False,
         ort_library_path: str | Path | None = None,
     ) -> None:
+        """Construct a Decibri audio capture instance.
+
+        Most parameters control capture behaviour and are documented at
+        the class level. The argument that benefits from per-arg detail
+        is ``ort_library_path``, since its resolution involves a
+        priority chain that is invisible at the call site.
+
+        Parameters
+        ----------
+        ort_library_path : str | Path | None, optional
+            Path to the ONNX Runtime dynamic library used by Silero VAD.
+            Only consulted when ``vad=True`` and ``vad_mode='silero'``;
+            energy-mode VAD and ``vad=False`` do not load ORT.
+
+            If ``None`` (the default), decibri resolves the dylib via
+            this priority order, first match wins:
+
+            1. This constructor argument, if you pass an explicit path.
+            2. The ``DECIBRI_ORT_DYLIB_PATH`` environment variable,
+               for per-deployment overrides without code changes.
+            3. The ``ORT_DYLIB_PATH`` environment variable, the upstream
+               ``ort`` crate's standard convention, respected here so
+               existing bare-ort deployments keep working.
+            4. The dylib bundled with the wheel under ``decibri/_ort/``,
+               which is the default ``pip install decibri`` experience.
+
+            If none of the above resolve to a real file, ORT's default
+            loader is used. That loader itself respects ``ORT_DYLIB_PATH``
+            if you set it after decibri import, so a late environment
+            change still works as a last-resort fallback.
+
+            Path validity is enforced by the Rust core, not the resolver.
+            An invalid path (missing file, directory, etc.) raises
+            ``OrtPathInvalid`` from the bridge layer with the path and
+            reason attached.
+
+            Note: ORT initialization is process-global. Once any Decibri
+            instance constructs with a specific dylib path, subsequent
+            Decibri instances inherit that initialization regardless of
+            their own ``ort_library_path`` argument. The first Decibri
+            construction in a process determines the dylib for the
+            entire process lifetime.
+
+        Other parameters are summarised at the class docstring; refer to
+        ``help(Decibri)`` for the capture-side surface.
+        """
         if format not in _VALID_FORMATS:
             raise exceptions.InvalidFormat(
                 f"format must be 'int16' or 'float32'; got {format!r}"
@@ -285,8 +331,20 @@ class Decibri:
                     "installation, or pass model_path explicitly."
                 ) from exc
 
+        # Resolve the ORT dylib path via the four-arm priority order in
+        # _ort_resolver. Only consulted when Silero VAD is enabled; energy
+        # mode and vad=False never load ORT, so the resolver call (and its
+        # bundled-dylib lookup) is skipped to avoid the import-time cost.
+        # See _ort_resolver.resolve_ort_dylib_path for the priority order.
         resolved_ort_path: str | None = None
-        if ort_library_path is not None:
+        if vad and vad_mode == "silero":
+            from decibri._ort_resolver import resolve_ort_dylib_path
+
+            resolved_ort_path = resolve_ort_dylib_path(ort_library_path)
+        elif ort_library_path is not None:
+            # Preserve passthrough for explicit caller paths even when ORT
+            # is not loaded, so tests and tooling that introspect the
+            # bridge state see the user's intent.
             resolved_ort_path = str(Path(ort_library_path))
 
         self._bridge = _decibri.DecibriBridge(

--- a/bindings/python/python/decibri/_ort_resolver.py
+++ b/bindings/python/python/decibri/_ort_resolver.py
@@ -1,0 +1,125 @@
+"""ONNX Runtime dynamic library path resolver for the Python wheel.
+
+The Phase 2 wheel build leaves ORT loading to the user (manual
+``ORT_DYLIB_PATH``, or a separate ``pip install onnxruntime``), which is
+incompatible with the premium-quality remit. Phase 3 closes that gap by
+bundling the per-platform dylib into ``decibri/_ort/`` at CI build time and
+resolving its path at first VAD use through this module.
+
+The resolver implements a four-arm priority order so that:
+
+1. Power users can override at the call site (constructor argument).
+2. Operators can override per-deployment via a decibri-namespaced env var
+   without touching code.
+3. Existing users of the upstream ``ort`` crate convention
+   (``ORT_DYLIB_PATH``) keep working.
+4. Default ``pip install decibri`` users get the bundled dylib for free.
+
+The module is intentionally policy-only. It never touches ORT itself, never
+loads a dylib, and never raises on a missing or invalid path. Path validity
+is the Rust core's responsibility (``init_ort_once`` in
+``crates/decibri/src/vad.rs``); this resolver returns a string path or
+``None`` and lets the bridge layer be authoritative on errors. That keeps
+the Python layer testable in isolation and avoids drift between Python-side
+and Rust-side validation messages.
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+import logging
+import os
+import sys
+from pathlib import Path
+
+__all__ = ["resolve_ort_dylib_path"]
+
+_LOGGER = logging.getLogger(__name__)
+
+# Platform-appropriate filename glob for the bundled dylib. Pattern (not
+# exact match) tolerates auditwheel and delocate hash-suffix renaming
+# applied at wheel-repair time (e.g. ``libonnxruntime-abc123.so``). One
+# entry per supported ``sys.platform`` value: ``linux``, ``darwin``,
+# ``win32``. Other platforms fall through to ``None`` and the bundled
+# lookup returns nothing.
+_PLATFORM_PATTERNS: dict[str, str] = {
+    "linux": "libonnxruntime*.so",
+    "darwin": "libonnxruntime*.dylib",
+    "win32": "onnxruntime*.dll",
+}
+
+
+def _bundled_dylib_path() -> str | None:
+    """Return the absolute path to the bundled ORT dylib, or None.
+
+    Enumerates ``decibri/_ort/`` for files matching the platform glob and
+    returns the first hit (sorted for determinism when multiple match).
+    Returns ``None`` if the directory is missing, empty, or the platform
+    is unsupported.
+
+    Defensive against edge cases: if ``importlib.resources`` raises (e.g.
+    the ``decibri`` package can't be located when running from an unusual
+    import path), the exception is logged at debug and ``None`` is
+    returned. Loud failures here would prevent users from constructing
+    ``Decibri(vad=False)`` which doesn't need ORT at all.
+    """
+    pattern = _PLATFORM_PATTERNS.get(sys.platform)
+    if pattern is None:
+        return None
+
+    try:
+        ort_dir = importlib.resources.files("decibri") / "_ort"
+        if not ort_dir.is_dir():
+            return None
+        candidates = sorted(
+            child.name
+            for child in ort_dir.iterdir()
+            if child.is_file() and Path(child.name).match(pattern)
+        )
+        if not candidates:
+            return None
+        match = ort_dir / candidates[0]
+        return str(match)
+    except (ModuleNotFoundError, FileNotFoundError, NotADirectoryError) as exc:
+        _LOGGER.debug("Bundled ORT lookup failed: %s", exc)
+        return None
+
+
+def resolve_ort_dylib_path(user_override: str | Path | None) -> str | None:
+    """Resolve the ONNX Runtime dynamic library path via the decibri priority order.
+
+    Priority (first match wins):
+
+    1. ``user_override`` (the ``ort_library_path`` constructor argument).
+       Returned as a string regardless of input type. Not pre-validated;
+       the Rust core's ``init_ort_once`` raises ``OrtPathInvalid`` if the
+       path doesn't exist or isn't a regular file.
+    2. ``DECIBRI_ORT_DYLIB_PATH`` environment variable.
+    3. ``ORT_DYLIB_PATH`` environment variable. Respected for
+       compatibility with the upstream ``ort`` crate's standard env var,
+       so existing users of bare ``ort``-based deployments continue to
+       work without code changes.
+    4. The bundled dylib at ``decibri/_ort/<platform-glob>``, included
+       in the wheel by maturin's include directive.
+
+    Returns the resolved path as a string, or ``None`` if nothing
+    resolves. A ``None`` return indicates the resolver could not find a
+    bundled or configured ORT dylib; the caller (typically the Rust
+    bridge) falls back to ORT's default loader, which itself respects
+    ``ORT_DYLIB_PATH`` if set after decibri import.
+
+    Empty-string env var values are treated as unset, mirroring how POSIX
+    and Windows shells typically intend ``FOO=`` to disable a setting.
+    """
+    if user_override is not None:
+        return str(Path(user_override))
+
+    decibri_env = os.environ.get("DECIBRI_ORT_DYLIB_PATH")
+    if decibri_env:
+        return decibri_env
+
+    ort_env = os.environ.get("ORT_DYLIB_PATH")
+    if ort_env:
+        return ort_env
+
+    return _bundled_dylib_path()

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -1,26 +1,73 @@
 """Pytest configuration for the decibri Python binding test suite.
 
-Registers three hardware-required markers and auto-skips them in CI.
+Registers three precondition markers with two distinct auto-skip policies.
 
 Markers:
     requires_audio_input: test reads real audio frames from a microphone.
     requires_audio_output: test writes real audio frames to a speaker.
-    requires_bundled_ort: test constructs Decibri(vad=True, vad_mode='silero',
-        ...). Independent of audio markers; gates ORT runtime availability,
-        which is a separate precondition from microphone/speaker hardware.
+    requires_bundled_ort: test exercises the bundled ONNX Runtime dylib
+        in decibri/_ort/, populated at wheel build time by python-ci.yml's
+        download step. Independent of audio markers; gates ORT runtime
+        availability, which is a separate precondition from
+        microphone/speaker hardware.
 
-Auto-skip semantics: when the CI environment variable is set (any non-empty
-value), all hardware-marked tests are skipped. Local developer runs (CI
-unset) execute every test.
+Auto-skip semantics:
+    Audio hardware markers (requires_audio_input, requires_audio_output):
+        Skipped when the CI environment variable is set. CI runners have
+        no real audio devices; local dev boxes do.
+
+    Bundled ORT marker (requires_bundled_ort):
+        Skipped when the bundled _ort/ directory is missing or contains
+        no platform-appropriate dylib (libonnxruntime*.so on Linux,
+        libonnxruntime*.dylib on macOS, onnxruntime*.dll on Windows). This
+        is the inverse of "skip in CI": Phase 3 CI populates _ort/ before
+        running tests, so these tests RUN in CI and SKIP on dev installs
+        where maturin develop leaves _ort/ empty. The check inspects the
+        installed package via importlib.resources, so editable installs
+        and wheel installs both go through the same code path.
 """
 
+from __future__ import annotations
+
+import importlib.resources
 import os
+import sys
+from pathlib import Path
 
 import pytest
 
+_PLATFORM_PATTERN: dict[str, str] = {
+    "linux": "libonnxruntime*.so",
+    "darwin": "libonnxruntime*.dylib",
+    "win32": "onnxruntime*.dll",
+}
+
+
+def _bundled_ort_available() -> bool:
+    """Return True iff decibri/_ort/ contains a platform-appropriate dylib.
+
+    Mirrors the resolver's enumeration approach in _ort_resolver.py so the
+    skip decision matches the resolver's would-it-resolve outcome. Defensive
+    against the package not being importable yet (rare; a sibling test that
+    breaks the import would surface that separately).
+    """
+    pattern = _PLATFORM_PATTERN.get(sys.platform)
+    if pattern is None:
+        return False
+    try:
+        ort_dir = importlib.resources.files("decibri") / "_ort"
+        if not ort_dir.is_dir():
+            return False
+        return any(
+            child.is_file() and Path(child.name).match(pattern)
+            for child in ort_dir.iterdir()
+        )
+    except (ModuleNotFoundError, FileNotFoundError, NotADirectoryError):
+        return False
+
 
 def pytest_configure(config: pytest.Config) -> None:
-    """Register the three hardware markers."""
+    """Register the three precondition markers."""
     config.addinivalue_line(
         "markers",
         "requires_audio_input: test needs a real audio input device (auto-skipped in CI)",
@@ -31,23 +78,28 @@ def pytest_configure(config: pytest.Config) -> None:
     )
     config.addinivalue_line(
         "markers",
-        "requires_bundled_ort: test needs the bundled Silero model + ORT runtime (auto-skipped in CI)",
+        "requires_bundled_ort: test needs decibri/_ort/ populated with the platform dylib "
+        "(auto-skipped on dev installs where _ort/ is empty)",
     )
 
 
 def pytest_collection_modifyitems(
     config: pytest.Config, items: list[pytest.Item]
 ) -> None:
-    """Auto-skip hardware-marked tests when running in CI."""
-    if not os.environ.get("CI"):
-        return
+    """Apply the two auto-skip policies described in the module docstring."""
+    in_ci = bool(os.environ.get("CI"))
     skip_audio_input = pytest.mark.skip(reason="no audio input device in CI")
     skip_audio_output = pytest.mark.skip(reason="no audio output device in CI")
-    skip_bundled_ort = pytest.mark.skip(reason="ORT runtime not available in CI")
+    skip_bundled_ort = pytest.mark.skip(
+        reason="_ort directory not bundled (dev install or platform mismatch)"
+    )
+
+    bundled_available = _bundled_ort_available()
+
     for item in items:
-        if "requires_audio_input" in item.keywords:
+        if in_ci and "requires_audio_input" in item.keywords:
             item.add_marker(skip_audio_input)
-        if "requires_audio_output" in item.keywords:
+        if in_ci and "requires_audio_output" in item.keywords:
             item.add_marker(skip_audio_output)
-        if "requires_bundled_ort" in item.keywords:
+        if (not bundled_available) and "requires_bundled_ort" in item.keywords:
             item.add_marker(skip_bundled_ort)

--- a/bindings/python/tests/test_ort_bundling.py
+++ b/bindings/python/tests/test_ort_bundling.py
@@ -1,0 +1,272 @@
+"""Phase 3 ORT bundling and resolver tests.
+
+Three tiers:
+
+1. Resolver unit tests (no hardware, no ORT load): verify the four-arm
+   priority order in `_ort_resolver.resolve_ort_dylib_path` using
+   `monkeypatch` for env vars and `tmp_path` for synthetic `_ort/`
+   layouts. Always run; no precondition markers.
+
+2. Wheel-content integration tests (no ORT load, requires bundled `_ort/`):
+   verify that the wheel actually ships a platform-appropriate dylib and
+   that the resolver picks it. Marked `requires_bundled_ort`; auto-skipped
+   on dev installs where `_ort/` is empty (per `conftest.py`).
+
+3. End-to-end construction smoke (requires bundled `_ort/`): construct
+   `Decibri(vad=True, vad_mode='silero')` and verify the load path
+   reaches Silero session creation without raising. Marked
+   `requires_bundled_ort`. Inference (forward pass against synthesized
+   audio) is intentionally deferred to Phase 4+; the existing Decibri
+   class consumes from a real microphone and does not expose a
+   buffer-injection API, so a deterministic inference smoke would need
+   an additional surface that is out of Phase 3 scope.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+import decibri
+from decibri._ort_resolver import resolve_ort_dylib_path
+
+_ENV_VARS = ("DECIBRI_ORT_DYLIB_PATH", "ORT_DYLIB_PATH")
+
+_PLATFORM_FILENAME = {
+    "linux": "libonnxruntime.so",
+    "darwin": "libonnxruntime.dylib",
+    "win32": "onnxruntime.dll",
+}
+
+_PLATFORM_HASH_SUFFIXED = {
+    "linux": "libonnxruntime-abc123.so",
+    "darwin": "libonnxruntime-abc123.dylib",
+    "win32": "onnxruntime-abc123.dll",
+}
+
+_PLATFORM_PATTERN = {
+    "linux": "libonnxruntime*.so",
+    "darwin": "libonnxruntime*.dylib",
+    "win32": "onnxruntime*.dll",
+}
+
+
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Strip both ORT-related env vars so tests run in known-state isolation."""
+    for var in _ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: Resolver unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_user_override_path_object(
+    clean_env: None, tmp_path: Path
+) -> None:
+    """A Path user override is converted to a string and returned verbatim."""
+    fake = tmp_path / "user.so"
+    fake.write_bytes(b"")
+    result = resolve_ort_dylib_path(fake)
+    assert result == str(fake)
+
+
+def test_resolver_user_override_str(clean_env: None, tmp_path: Path) -> None:
+    """A str user override is returned through Path normalization."""
+    fake = tmp_path / "user.so"
+    fake.write_bytes(b"")
+    result = resolve_ort_dylib_path(str(fake))
+    assert result == str(fake)
+
+
+def test_resolver_user_override_beats_env_vars(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """User override takes priority over both env var arms."""
+    user_path = tmp_path / "user.so"
+    decibri_path = tmp_path / "decibri_env.so"
+    ort_path = tmp_path / "ort_env.so"
+    for f in (user_path, decibri_path, ort_path):
+        f.write_bytes(b"")
+    monkeypatch.setenv("DECIBRI_ORT_DYLIB_PATH", str(decibri_path))
+    monkeypatch.setenv("ORT_DYLIB_PATH", str(ort_path))
+    assert resolve_ort_dylib_path(user_path) == str(user_path)
+
+
+def test_resolver_decibri_env(
+    clean_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """DECIBRI_ORT_DYLIB_PATH env var is honored when no user override."""
+    target = tmp_path / "env.so"
+    target.write_bytes(b"")
+    monkeypatch.setenv("DECIBRI_ORT_DYLIB_PATH", str(target))
+    assert resolve_ort_dylib_path(None) == str(target)
+
+
+def test_resolver_ort_env_compat(
+    clean_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """ORT_DYLIB_PATH env var is honored for upstream ort crate compat."""
+    target = tmp_path / "ort.so"
+    target.write_bytes(b"")
+    monkeypatch.setenv("ORT_DYLIB_PATH", str(target))
+    assert resolve_ort_dylib_path(None) == str(target)
+
+
+def test_resolver_decibri_env_beats_ort_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When both env vars are set, DECIBRI_ORT_DYLIB_PATH wins."""
+    decibri_path = tmp_path / "decibri.so"
+    ort_path = tmp_path / "ort.so"
+    decibri_path.write_bytes(b"")
+    ort_path.write_bytes(b"")
+    monkeypatch.setenv("DECIBRI_ORT_DYLIB_PATH", str(decibri_path))
+    monkeypatch.setenv("ORT_DYLIB_PATH", str(ort_path))
+    assert resolve_ort_dylib_path(None) == str(decibri_path)
+
+
+def test_resolver_empty_decibri_env_falls_through(
+    clean_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Empty-string env var is treated as unset; resolver falls through."""
+    target = tmp_path / "ort.so"
+    target.write_bytes(b"")
+    monkeypatch.setenv("DECIBRI_ORT_DYLIB_PATH", "")
+    monkeypatch.setenv("ORT_DYLIB_PATH", str(target))
+    assert resolve_ort_dylib_path(None) == str(target)
+
+
+def test_resolver_returns_none_when_empty(
+    clean_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No user override, no env vars, empty bundled dir: returns None.
+
+    Mocks ``importlib.resources.files`` so the test is portable regardless
+    of whether the local dev install has ``_ort/`` populated. The
+    substitute returns ``tmp_path``; ``tmp_path / '_ort'`` does not exist,
+    so the resolver's ``is_dir()`` check returns False.
+    """
+    import importlib.resources
+
+    monkeypatch.setattr(
+        importlib.resources, "files", lambda _pkg: tmp_path
+    )
+    assert resolve_ort_dylib_path(None) is None
+
+
+def test_resolver_bundled_handles_hash_suffix(
+    clean_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Resolver picks an auditwheel/delocate-renamed file via glob match.
+
+    auditwheel and delocate may rename bundled libraries to include a
+    content hash (e.g. ``libonnxruntime-abc123.so``). The resolver must
+    match these via glob pattern, not exact filename. This test
+    synthesizes a fake ``_ort/`` directory containing only a hash-suffixed
+    file and asserts the resolver still finds it.
+    """
+    import importlib.resources
+
+    suffixed_name = _PLATFORM_HASH_SUFFIXED.get(sys.platform)
+    if suffixed_name is None:
+        pytest.skip(f"unsupported platform for hash-suffix test: {sys.platform}")
+
+    ort_dir = tmp_path / "_ort"
+    ort_dir.mkdir()
+    suffixed = ort_dir / suffixed_name
+    suffixed.write_bytes(b"")
+
+    monkeypatch.setattr(
+        importlib.resources, "files", lambda _pkg: tmp_path
+    )
+
+    result = resolve_ort_dylib_path(None)
+    assert result is not None
+    assert Path(result).name == suffixed_name
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: Wheel-content integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_bundled_ort
+def test_wheel_bundle_present() -> None:
+    """The installed wheel contains a platform-appropriate ORT dylib.
+
+    Uses ``importlib.resources`` to enumerate the installed package's
+    ``_ort/`` directory. Validates the maturin include directive in
+    pyproject.toml landed correctly and python-ci.yml's download step
+    populated the directory before the wheel was packed.
+    """
+    import importlib.resources
+
+    pattern = _PLATFORM_PATTERN.get(sys.platform)
+    if pattern is None:
+        pytest.skip(f"unsupported platform: {sys.platform}")
+
+    ort_dir = importlib.resources.files("decibri") / "_ort"
+    assert ort_dir.is_dir(), "decibri/_ort/ is missing from the installed package"
+
+    matches = sorted(
+        child.name
+        for child in ort_dir.iterdir()
+        if child.is_file() and Path(child.name).match(pattern)
+    )
+    assert matches, (
+        f"decibri/_ort/ contains no files matching {pattern!r}; "
+        f"directory contents: {sorted(c.name for c in ort_dir.iterdir())}"
+    )
+
+
+@pytest.mark.requires_bundled_ort
+def test_resolver_bundled_default(
+    clean_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default resolution (no override, no env vars) returns the bundled path.
+
+    Exercises the live ``importlib.resources`` lookup against the actual
+    installed package; no monkeypatching of ``files()``. The returned
+    path is verified to exist and to match the platform glob.
+    """
+    pattern = _PLATFORM_PATTERN.get(sys.platform)
+    if pattern is None:
+        pytest.skip(f"unsupported platform: {sys.platform}")
+
+    result = resolve_ort_dylib_path(None)
+    assert result is not None, "expected bundled fallback to return a path"
+    resolved = Path(result)
+    assert resolved.is_file(), f"resolver returned non-existent path: {result}"
+    assert resolved.match(pattern), (
+        f"resolver returned {resolved.name!r} which does not match {pattern!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tier 3: End-to-end construction smoke
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_bundled_ort
+def test_decibri_silero_construction() -> None:
+    """``Decibri(vad=True, vad_mode='silero')`` constructs end-to-end.
+
+    Exercises the full Phase 3 load path in one assertion: the resolver
+    finds the bundled dylib, the Rust bridge receives the resolved path,
+    ``init_ort_once`` validates and loads it via ``ort::init_from()``, and
+    the Silero session is built against the bundled model. If any link
+    in that chain breaks (resolver returns None unexpectedly, dylib is
+    invalid, model is missing, ort::init_from rejects the path), this
+    test surfaces the failure. The construction does not start audio
+    capture; no microphone is required.
+    """
+    instance = decibri.Decibri(vad=True, vad_mode="silero")
+    assert instance is not None
+    assert isinstance(instance, decibri.Decibri)

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -19,6 +19,9 @@ wheels = [
 name = "decibri"
 version = "0.1.0a1"
 source = { editable = "." }
+dependencies = [
+    { name = "typing-extensions" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -29,6 +32,7 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "typing-extensions", specifier = ">=4.15" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Closes the Phase 2 gap where Python wheels built successfully but broke for end users on `from decibri import Decibri; Decibri(vad=True)` because libonnxruntime was not bundled.

Phase 3 implements ORT dylib bundling per the Phase 3 plan (`phase-3-ort-bundling.md`):

- CI downloads the per-platform ORT tarball from microsoft/onnxruntime releases (matches release.yml's pattern)
- Extracts the dylib and Linux companion solib into _ort/
- maturin bundles _ort/ into the wheel via include directive
- New _ort_resolver.py implements four-arm priority resolution:
  1. ort_library_path constructor argument
  2. DECIBRI_ORT_DYLIB_PATH environment variable
  3. ORT_DYLIB_PATH environment variable (upstream ort compat)
  4. Bundled dylib in decibri/_ort/ (default)
- Decibri.__init__ wires the resolver when vad=True and vad_mode='silero'; no-op otherwise
- New test_ort_bundling.py with 12 tests across three tiers: resolver units (always run), wheel-content integration (requires bundled _ort/), end-to-end construction smoke
- requires_bundled_ort marker semantics flipped: now skips when _ort/ is empty rather than when CI=true (the new semantics align with the marker's name and let CI actually exercise the gate)
- CI install-test step: builds release wheel, installs into clean venv, runs test_ort_bundling.py against the installed wheel. Catches "wheel built fine but breaks on user install" before shipping

Validation: all 8 push-matrix jobs (4 OS x 2 Python: 3.10 floor + 3.14 ceiling) pass. test_decibri_silero_construction passes end-to-end on all four platforms (Linux x64, Linux aarch64, macOS arm64, Windows x64).

Cross-binding compat: Python-only. Rust core, Node binding, npm package, browser shim, release.yml all unchanged. Guardrail 2 satisfied.

Out of scope (deferred):
- GPU execution providers (CoreML, CUDA, DirectML) deferred to the
  GPU EP Integration project (P4)
- Async support deferred to Phase 5
- NumPy zero-copy deferred to Phase 6
- TestPyPI publish deferred to Phase 11
- macOS x86_64 wheels (Intel users build from source)
- sdist exclusion of _ort/ via Cargo.toml package.exclude (Phase 5)
- macOS codesign behavior on the renamed dylib (Phase 5 polish)
- test_decibri_silero_inference (forward-pass smoke) deferred to Phase 4+ pending a buffer-injection API

Phase 3 implementation is complete. Phase 4 (bridge restructure for async-readiness) is next.