### PR TITLE
Phase 4: Drop unsendable annotation; bridge is now Send + 'static

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -47,6 +47,36 @@ use decibri::vad::{SileroVad, VadConfig};
 use decibri::CPAL_VERSION;
 
 // ---------------------------------------------------------------------------
+// Compile-time assertion: both bridge pyclasses are Send + 'static.
+//
+// The 'static bound is what `pyo3_async_runtimes::tokio::future_into_py`
+// requires when capturing the bridge into an async closure (Phase 5
+// async surface). Asserting at compile time means a future change that
+// reintroduces a !Send field, or adds a non-static reference, fails the
+// build at the point of regression rather than at Phase 5 integration
+// time, and makes the regression's blast radius obvious from the error
+// message (it points at the new field).
+//
+// If this assertion fails to compile, look for a recently added field
+// on `DecibriBridge` or `DecibriOutputBridge` whose type is not
+// `Send + 'static`: raw `cpal::Stream` (use a sendable handle instead),
+// `Rc<_>` / `RefCell<_>` (use `Arc<_>` / `Mutex<_>`), `&'a T` for any
+// non-static lifetime (extract owned data instead).
+//
+// Sendability is empirically backed: the Rust core's `CaptureStream`
+// is asserted `Send + Sync` at `crates/decibri/src/capture.rs:459`
+// (compile-time, unconditional, runs on every CI platform), and the
+// documented `Send` contract for all public capture/output types lives
+// at `crates/decibri/src/lib.rs:119-140`.
+// ---------------------------------------------------------------------------
+
+const _: () = {
+    const fn assert_send_static<T: Send + 'static>() {}
+    let _ = assert_send_static::<DecibriBridge>;
+    let _ = assert_send_static::<DecibriOutputBridge>;
+};
+
+// ---------------------------------------------------------------------------
 // Exception class lookup.
 //
 // The 31-class hierarchy is defined once in pure Python at
@@ -476,6 +506,16 @@ fn build_device_selector(device: Option<&Bound<'_, PyAny>>) -> PyResult<DeviceSe
 // ---------------------------------------------------------------------------
 // DecibriBridge: stateful capture pyclass.
 //
+// This pyclass is `Send + 'static` and may cross thread boundaries. The
+// compile-time assertion at the top of this module enforces the property;
+// do not add a field whose type lacks `Send + 'static` without first
+// removing the assertion (which would also block Phase 5's async work).
+// Sendability comes from the Rust core's `CaptureStream` already being
+// `Send` (see `crates/decibri/src/lib.rs:119-140` for the contract and
+// `crates/decibri/src/capture.rs:459` for the unconditional compile-time
+// assertion). The bridge holds the stream directly; no pump thread or
+// channel proxy is needed.
+//
 // Owns:
 //   - capture_config: CaptureConfig (built from constructor args, retained
 //     for diagnostic introspection)
@@ -489,7 +529,7 @@ fn build_device_selector(device: Option<&Bound<'_, PyAny>>) -> PyResult<DeviceSe
 //     on each read() that runs Silero inference)
 // ---------------------------------------------------------------------------
 
-#[pyclass(module = "decibri._decibri", unsendable)]
+#[pyclass(module = "decibri._decibri")]
 struct DecibriBridge {
     capture_config: CaptureConfig,
     format: BindingSampleFormat,
@@ -712,6 +752,15 @@ impl DecibriBridge {
 // ---------------------------------------------------------------------------
 // DecibriOutputBridge: stateful output pyclass.
 //
+// This pyclass is `Send + 'static` and may cross thread boundaries; the
+// compile-time assertion at the top of this module enforces the property.
+// Sendability comes from the Rust core's `OutputStream` being `Send` per
+// the documented contract at `crates/decibri/src/lib.rs:119-140`. There
+// is no analogous compile-time assertion in `output.rs` (capture has one
+// at line 459); CI on the four-platform matrix is the empirical gate.
+// Do not add a field whose type lacks `Send + 'static` without first
+// removing the module-level assertion.
+//
 // Owns:
 //   - output_config: OutputConfig (no frames_per_buffer per F2)
 //   - format: BindingSampleFormat
@@ -719,7 +768,7 @@ impl DecibriBridge {
 //   - stream: Option<OutputStream>
 // ---------------------------------------------------------------------------
 
-#[pyclass(module = "decibri._decibri", unsendable)]
+#[pyclass(module = "decibri._decibri")]
 struct DecibriOutputBridge {
     output_config: OutputConfig,
     format: BindingSampleFormat,

--- a/bindings/python/tests/test_bridge_sendability.py
+++ b/bindings/python/tests/test_bridge_sendability.py
@@ -1,0 +1,90 @@
+"""Phase 4 bridge sendability tests.
+
+Verifies the Phase 4 invariant from the Python side: both `Decibri` and
+`DecibriOutput` instances can cross thread boundaries without raising
+PyRuntimeError("can't access object from another thread"). The Rust
+binding asserts the same property at compile time via the
+`Send + 'static` assertion in `bindings/python/src/lib.rs`; these tests
+catch behavioural regressions where the type-level property is preserved
+but runtime behaviour breaks (e.g. a thread-local that the bridge
+implicitly depends on, or a future PyO3 release that tightens runtime
+checks beyond what Send + 'static guarantees).
+
+The strongest signal is `test_decibri_can_be_passed_through_threadpool_for_callable`,
+which simulates the capture pattern Phase 5's
+`pyo3_async_runtimes::tokio::future_into_py` will use. If that test
+passes, the bridge will compile and run inside an async closure when
+Phase 5 wires it up.
+
+These tests do not exercise audio capture or playback; they only exercise
+the bridge's identity and a pure read-only method (`is_open`). No audio
+hardware required, so no markers are applied.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+from typing import Any
+
+from decibri import Decibri, DecibriOutput
+
+
+def test_decibri_construct_no_unsendable_error() -> None:
+    """Constructed Decibri instance survives a thread-pool submission.
+
+    Pre-Phase-4 (#[pyclass(unsendable)]), this raised PyRuntimeError on
+    the worker's first attribute access. Post-Phase-4, the bridge is
+    `Send + 'static` and PyO3 admits the cross-thread access.
+    """
+    decibri = Decibri(vad=False)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(lambda d: d is not None, decibri)
+        assert future.result() is True
+
+
+def test_decibri_output_construct_no_unsendable_error() -> None:
+    """Same property for DecibriOutput; the output bridge is also Send."""
+    output = DecibriOutput()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(lambda d: d is not None, output)
+        assert future.result() is True
+
+
+def test_decibri_method_call_from_worker_thread() -> None:
+    """A real method call on the bridge from a worker thread returns
+    the expected value, not just an admission to access.
+
+    A constructed-but-not-started bridge has no open stream; `is_open`
+    must return False regardless of which thread the call originates
+    from. This catches a hypothetical regression where the type-level
+    Send property holds but a method internally relies on a thread-local
+    state that only the construction thread carries.
+    """
+    decibri = Decibri(vad=False)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(lambda d: d.is_open, decibri)
+        result = future.result()
+    assert result is False
+
+
+def test_decibri_can_be_passed_through_threadpool_for_callable() -> None:
+    """Closure-capture pattern that mirrors Phase 5's future_into_py.
+
+    `pyo3_async_runtimes::tokio::future_into_py` captures the bridge
+    into an async closure and submits the closure to a Tokio worker.
+    Python's threadpool is not the same runtime, but the requirement
+    on the captured value is the same: it must survive being moved
+    out of the calling thread.
+
+    If this test passes, the Phase 5 async wiring will compile when the
+    bridge is captured into a tokio::spawn_blocking-shaped closure.
+    """
+    decibri = Decibri(vad=False)
+
+    def use_decibri() -> bool:
+        return decibri.is_open
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future: concurrent.futures.Future[Any] = executor.submit(use_decibri)
+        result = future.result()
+    assert result is False


### PR DESCRIPTION
Phase 4 of the Python Integration Project. Removes the `unsendable` annotation from both DecibriBridge and DecibriOutputBridge pyclasses, unblocking Phase 5's async work which requires Send + 'static for pyo3_async_runtimes::tokio::future_into_py.

The empirical Step 1 experiment (drop the annotation, observe the build result) confirmed outcome (i): the bridge compiles cleanly as Send + 'static. The Phase 2 annotation was conservative leftover; the Rust core's already-existing Send contract (capture.rs:459 unconditional test, lib.rs:119-140 documentation) was empirically backed and the binding can leverage it directly.

Phase 4 collapsed from the master plan's ~5 day envelope to ~1 day because the empirical-first approach (locked decision Q1) caught that the simpler path worked.

Changes:

- bindings/python/src/lib.rs: drop unsendable from both pyclass declarations
- bindings/python/src/lib.rs: add compile-time Send + 'static assertion (locked decision Q5: 'static, not just Send) catching future regressions at build time
- bindings/python/src/lib.rs: extend doc comments above each pyclass documenting the Send + 'static property, the assertion, and what field types would regress it
- bindings/python/tests/test_bridge_sendability.py: 4 persistent tests proving the bridge crosses thread boundaries correctly, including test_decibri_can_be_passed_through_threadpool_for_callable which simulates the exact future_into_py capture pattern Phase 5 will require

Skipped per locked decisions:
- Steps 2-3 (pump-thread restructure): Q2 — not needed since outcome (i) confirmed
- Step 8 (five-file split of lib.rs): Q4 — deferred to separate cleanup PR

Verified:
- 8-job push matrix on development: all green
- 20-job workflow_dispatch matrix on development: all green (4 OS x 5 Python versions including 3.11, 3.12, 3.13)
- 119 existing tests + 4 new bridge sendability tests = 123 total, all passing across all platforms
- Compile-time Send + 'static assertion compiles on all 4 platforms (catches OutputStream cross-platform Send divergence if any; none surfaced)
- mypy --strict, cargo clippy, cargo fmt, cargo test-decibri all clean
- Node binding: unchanged

Cross-binding compat: Python-only. Rust core, Node binding, npm package, browser shim, release.yml all unchanged. Guardrail 2  satisfied.

Phase 4 implementation is complete. Phase 5 (parallel async classes via httpx pattern) is now unblocked and is the next phase.