### PR TITLE
Phase 5: Async support (AsyncDecibri, AsyncDecibriOutput)

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -65,7 +65,24 @@ pyo3 = { version = "0.28", features = [
     "generate-import-lib",
 ] }
 
-# pyo3-async-runtimes: deferred to Phase 3 per plan §7.2 decision 6. Phase 3
-# Claude: add `pyo3-async-runtimes = { version = "0.28", features =
-# ["tokio-runtime"] }` in the first commit that introduces an async method.
-# Version pin must match pyo3 minor at that time.
+# pyo3-async-runtimes powers the AsyncDecibri / AsyncDecibriOutput surfaces
+# (Phase 5). Pinned exactly to 0.28.0 because the crate is brand new (released
+# 2026-02-04) and version drift in the absence of a long stability track record
+# is a real risk; any minor-version bump should be a deliberate cross-workflow
+# action. The `tokio-runtime` feature selects the Tokio backend; `attributes`
+# enables the `#[pyo3_async_runtimes::tokio::main]` macro (we do not currently
+# use the macro from a cdylib context, but it is part of the standard feature
+# set and inert when unused).
+pyo3-async-runtimes = { version = "=0.28.0", features = ["tokio-runtime", "attributes"] }
+
+# tokio is the async runtime that pyo3-async-runtimes drives. Features:
+#   - `rt`: the runtime itself (required by pyo3-async-runtimes).
+#   - `rt-multi-thread`: the multi-thread executor used for spawn_blocking
+#     work; the AsyncDecibri wrapper dispatches the existing GIL-released
+#     sync calls through spawn_blocking so they do not block the runtime
+#     thread.
+#   - `time`: tokio::time::sleep used by the empirical smoke pyfunction in
+#     this crate's lib.rs.
+#   - `macros`: enables the proc-macro entry points (#[tokio::main] etc.)
+#     that pyo3-async-runtimes' attributes feature relies on internally.
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "macros"] }

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -81,8 +81,10 @@ pyo3-async-runtimes = { version = "=0.28.0", features = ["tokio-runtime", "attri
 #     work; the AsyncDecibri wrapper dispatches the existing GIL-released
 #     sync calls through spawn_blocking so they do not block the runtime
 #     thread.
+#   - `sync`: tokio::sync::Mutex used by the AsyncDecibriBridge /
+#     AsyncOutputBridge wrappers around the sync bridges.
 #   - `time`: tokio::time::sleep used by the empirical smoke pyfunction in
 #     this crate's lib.rs.
 #   - `macros`: enables the proc-macro entry points (#[tokio::main] etc.)
 #     that pyo3-async-runtimes' attributes feature relies on internally.
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "macros"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -52,6 +52,7 @@ Changelog = "https://github.com/decibri/decibri/blob/main/CHANGELOG.md"
 dev = [
     "maturin>=1.13,<2.0",
     "pytest>=9.0,<10.0",
+    "pytest-asyncio>=0.24",
     "mypy>=1.20,<2.0",
     "typing-extensions>=4.15",
 ]

--- a/bindings/python/python/decibri/__init__.py
+++ b/bindings/python/python/decibri/__init__.py
@@ -2,10 +2,11 @@
 
 Cross-platform audio capture, output, and voice activity detection.
 
-Phase 2 surface. The full sync API is available; numpy support is held
-for Phase 3, async support held for Phase 3.
+Phase 2 sync surface plus Phase 5 async surface (AsyncDecibri,
+AsyncDecibriOutput). NumPy zero-copy support is held for Phase 6.
 """
 
+from decibri._async_classes import AsyncDecibri, AsyncDecibriOutput
 from decibri._classes import Decibri, DecibriOutput
 from decibri._decibri import (
     DecibriBridge,
@@ -52,9 +53,12 @@ from decibri.exceptions import (
 __version__ = "0.1.0a1"
 
 __all__ = [
-    # Public Python wrapper classes
+    # Public Python wrapper classes (sync)
     "Decibri",
     "DecibriOutput",
+    # Public Python wrapper classes (async; Phase 5)
+    "AsyncDecibri",
+    "AsyncDecibriOutput",
     # Internal pyclasses (advanced use)
     "DecibriBridge",
     "DecibriOutputBridge",

--- a/bindings/python/python/decibri/__init__.pyi
+++ b/bindings/python/python/decibri/__init__.pyi
@@ -1,5 +1,7 @@
 """Type stubs for the decibri Python package."""
 
+from decibri._async_classes import AsyncDecibri as AsyncDecibri
+from decibri._async_classes import AsyncDecibriOutput as AsyncDecibriOutput
 from decibri._classes import Decibri as Decibri
 from decibri._classes import DecibriOutput as DecibriOutput
 from decibri._decibri import DecibriBridge as DecibriBridge

--- a/bindings/python/python/decibri/_async_classes.py
+++ b/bindings/python/python/decibri/_async_classes.py
@@ -1,0 +1,404 @@
+"""Async Python wrappers for decibri: AsyncDecibri and AsyncDecibriOutput.
+
+Phase 5 of the Python Integration Project. These classes mirror the sync
+``Decibri`` and ``DecibriOutput`` surfaces method-for-method, with
+``async def`` semantics, async context manager support
+(``__aenter__`` / ``__aexit__``), and (for capture only) async iterator
+support (``__aiter__`` / ``__anext__``).
+
+Implementation: each method proxies to the underlying Rust async pyclass
+(``AsyncDecibriBridge`` / ``AsyncOutputBridge``) which dispatches blocking
+work to a Tokio worker thread via ``spawn_blocking``. The Tokio runtime
+is lazily initialized; no explicit init call is needed.
+
+Cancellation: ``asyncio.CancelledError`` propagates through
+``pyo3-async-runtimes`` to the underlying Rust future. Per the Phase 5
+locked decision (abort-immediately), cancellation is non-recoverable for
+the in-flight chunk: any cpal data captured in the spawn_blocking thread
+between the Python-side cancellation and the thread's natural completion
+is dropped. Per the Phase 5 plan Risk 2, the spawn_blocking OS thread
+itself does not cooperatively cancel; the Python coroutine sees
+``CancelledError`` immediately while the Rust thread runs to completion.
+
+State properties (``is_open``, ``is_speaking``, ``vad_probability``,
+``is_playing``) are synchronous Python properties backed by Python-side
+state tracking. The Rust async bridge exposes these as awaitables, but
+awaiting from a property is not idiomatic Python and would surprise
+callers who expect ``decibri.is_open`` to behave like sync ``Decibri``.
+The wrapper updates ``_is_open`` after ``start()`` and ``stop()`` return.
+
+Cross-binding compat: pure Python. The Rust core is unchanged. The sync
+``Decibri`` and ``DecibriOutput`` classes (in ``_classes.py``) are
+unchanged and exist alongside this module.
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+from pathlib import Path
+from types import TracebackType
+from typing import AsyncIterator
+
+from typing_extensions import Self
+
+from decibri import _decibri, exceptions
+from decibri._classes import _VadStateMachine, _VALID_FORMATS, _VALID_MODES
+from decibri._decibri import DeviceInfo, OutputDeviceInfo, VersionInfo
+
+__all__ = ["AsyncDecibri", "AsyncDecibriOutput"]
+
+
+# ---------------------------------------------------------------------------
+# AsyncDecibri: async audio capture; mirror of decibri.Decibri.
+# ---------------------------------------------------------------------------
+
+
+class AsyncDecibri:
+    """Async audio capture; mirror of ``decibri.Decibri``.
+
+    Use ``async def`` methods: ``await async_decibri.start()``,
+    ``chunk = await async_decibri.read()``, ``await async_decibri.stop()``.
+
+    Supports ``async with AsyncDecibri() as d:`` for automatic start/stop.
+    Supports ``async for chunk in async_decibri:`` for iterator-style
+    consumption (capture only; ``AsyncDecibriOutput`` does not iterate).
+
+    Constructor signature matches sync ``Decibri`` exactly. See ``Decibri``
+    for parameter documentation including the ``ort_library_path`` priority
+    order; this class is a 1:1 mapping with async semantics.
+
+    Cancellation: any awaited method that is cancelled (via
+    ``asyncio.CancelledError``, ``asyncio.wait_for``, or explicit
+    ``task.cancel()``) propagates the cancellation to the Rust side. The
+    Python coroutine raises immediately; the spawn_blocking OS thread on
+    the Rust side runs to completion with its result dropped. Subsequent
+    operations on the same instance see consistent bridge state.
+
+    Concurrency: concurrent calls on the same instance serialize via the
+    Rust-side ``tokio::sync::Mutex``. This is a behavioural characteristic
+    of the architecture, not advertised concurrency.
+    """
+
+    def __init__(
+        self,
+        sample_rate: int = 16000,
+        channels: int = 1,
+        frames_per_buffer: int = 512,
+        format: str = "int16",
+        device: int | str | None = None,
+        vad: bool = False,
+        vad_threshold: float | None = None,
+        vad_holdoff: int = 300,
+        vad_mode: str = "energy",
+        model_path: str | Path | None = None,
+        numpy: bool = False,
+        ort_library_path: str | Path | None = None,
+    ) -> None:
+        if format not in _VALID_FORMATS:
+            raise exceptions.InvalidFormat(
+                f"format must be 'int16' or 'float32'; got {format!r}"
+            )
+        if vad_mode not in _VALID_MODES:
+            raise ValueError(
+                f"vad_mode must be 'silero' or 'energy'; got {vad_mode!r}"
+            )
+
+        if vad_threshold is None:
+            vad_threshold = 0.5 if vad_mode == "silero" else 0.01
+        if not 0.0 <= vad_threshold <= 1.0:
+            raise ValueError(
+                f"vad_threshold must be in [0, 1]; got {vad_threshold}"
+            )
+        if vad_holdoff < 0:
+            raise ValueError(
+                f"vad_holdoff must be non-negative; got {vad_holdoff}"
+            )
+
+        # Resolve the Silero ONNX model path. Same logic as sync Decibri:
+        # user-supplied path wins; otherwise fall back to the bundled model
+        # via importlib.resources when Silero VAD is requested.
+        resolved_model_path: str | None = None
+        if model_path is not None:
+            resolved_model_path = str(Path(model_path))
+        elif vad and vad_mode == "silero":
+            try:
+                model_resource = (
+                    importlib.resources.files("decibri")
+                    / "models"
+                    / "silero_vad.onnx"
+                )
+                if not model_resource.is_file():
+                    raise FileNotFoundError(
+                        f"Bundled Silero model resource exists but is not a "
+                        f"file: {model_resource}"
+                    )
+                resolved_model_path = str(model_resource)
+            except (FileNotFoundError, ModuleNotFoundError, AttributeError) as exc:
+                raise ValueError(
+                    "model_path was not provided and the bundled Silero "
+                    "model could not be located in the installed wheel. "
+                    "Ensure the models/ directory was included during "
+                    "installation, or pass model_path explicitly."
+                ) from exc
+
+        # Resolve the ORT dylib path via the same four-arm priority order
+        # the sync wrapper uses (see _ort_resolver.resolve_ort_dylib_path).
+        # Lazy import: only loaded when Silero VAD is enabled.
+        resolved_ort_path: str | None = None
+        if vad and vad_mode == "silero":
+            from decibri._ort_resolver import resolve_ort_dylib_path
+
+            resolved_ort_path = resolve_ort_dylib_path(ort_library_path)
+        elif ort_library_path is not None:
+            resolved_ort_path = str(Path(ort_library_path))
+
+        self._bridge = _decibri.AsyncDecibriBridge(
+            sample_rate=sample_rate,
+            channels=channels,
+            frames_per_buffer=frames_per_buffer,
+            format=format,
+            device=device,
+            vad=vad,
+            vad_threshold=vad_threshold,
+            vad_mode=vad_mode,
+            vad_holdoff=vad_holdoff,
+            model_path=resolved_model_path,
+            numpy=numpy,
+            ort_library_path=resolved_ort_path,
+        )
+
+        self._vad_enabled = vad
+        self._vad = _VadStateMachine(
+            mode=vad_mode,
+            threshold=vad_threshold,
+            holdoff_ms=vad_holdoff,
+            sample_format=format,
+        )
+        self._format = format
+        # Python-side state tracking for the synchronous is_open property.
+        # The Rust async bridge's is_open getter returns an awaitable; we
+        # update this flag after start/stop so callers can read state
+        # without an await.
+        self._is_open = False
+
+    # -----------------------------------------------------------------------
+    # Lifecycle
+    # -----------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Open and start the capture stream."""
+        await self._bridge.start()
+        self._is_open = True
+
+    async def stop(self) -> None:
+        """Stop the capture stream and reset VAD state."""
+        await self._bridge.stop()
+        self._is_open = False
+        self._vad.reset()
+
+    async def __aenter__(self) -> Self:
+        await self.start()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        await self.stop()
+
+    # -----------------------------------------------------------------------
+    # Read surface
+    # -----------------------------------------------------------------------
+
+    async def read(self, timeout_ms: int | None = None) -> bytes | None:
+        """Read one chunk. Returns bytes, or None if the stream closed.
+
+        VAD state advances as a side effect when ``vad=True``. Consumers
+        should check ``is_speaking`` after each read.
+
+        Cancellation: per the Phase 5 abort-immediately decision, cancelling
+        this await raises ``CancelledError`` immediately. The spawn_blocking
+        thread on the Rust side runs to completion; its result (if any) is
+        dropped. The bridge state remains consistent for subsequent reads.
+        """
+        chunk = await self._bridge.read(timeout_ms=timeout_ms)
+        if chunk is None:
+            return None
+        if self._vad_enabled:
+            probability = await self._bridge.vad_probability
+            self._vad.process_chunk(chunk, probability)
+        return chunk
+
+    def __aiter__(self) -> AsyncIterator[bytes]:
+        return self
+
+    async def __anext__(self) -> bytes:
+        chunk = await self.read(timeout_ms=None)
+        if chunk is None:
+            raise StopAsyncIteration
+        return chunk
+
+    # -----------------------------------------------------------------------
+    # State properties (synchronous; backed by Python-side tracking)
+    # -----------------------------------------------------------------------
+
+    @property
+    def is_open(self) -> bool:
+        """True if the capture stream is currently running.
+
+        Synchronous property backed by Python-side state tracking. Set on
+        ``await start()`` completion, cleared on ``await stop()`` completion.
+        """
+        return self._is_open
+
+    @property
+    def is_speaking(self) -> bool:
+        """True if VAD currently considers the user to be speaking.
+
+        Reflects the wrapper-layer state machine: above-threshold detection
+        plus holdoff grace period. Always False when ``vad=False``.
+
+        Holdoff expiry is checked on each property access; consumers who
+        pause iteration still observe correct state when they next read.
+        """
+        if not self._vad_enabled:
+            return False
+        return self._vad.is_speaking
+
+    @property
+    def vad_probability(self) -> float:
+        """Most recent VAD probability.
+
+        In Silero mode, returns the raw probability from the model.
+        In energy mode, returns the RMS of the most recent chunk.
+        Always 0.0 when ``vad=False``.
+        """
+        if not self._vad_enabled:
+            return 0.0
+        return self._vad.vad_probability
+
+    # -----------------------------------------------------------------------
+    # Static methods
+    # -----------------------------------------------------------------------
+
+    @staticmethod
+    async def devices() -> list[DeviceInfo]:
+        """List available input devices."""
+        return await _decibri.AsyncDecibriBridge.devices()
+
+    @staticmethod
+    def version() -> VersionInfo:
+        """Return version info: decibri Rust core, cpal, and binding wheel.
+
+        Synchronous because it reads compile-time constants only; no I/O.
+        Intentionally not async to avoid forcing callers to await for what
+        is effectively a metadata lookup. Reuses the sync ``DecibriBridge``
+        static method directly; the async bridge's ``version()`` wraps the
+        same data in a coroutine for uniformity but offers no benefit for
+        this purely-compile-time lookup.
+        """
+        return _decibri.DecibriBridge.version()
+
+
+# ---------------------------------------------------------------------------
+# AsyncDecibriOutput: async audio output; mirror of DecibriOutput.
+# ---------------------------------------------------------------------------
+
+
+class AsyncDecibriOutput:
+    """Async audio output; mirror of ``decibri.DecibriOutput``.
+
+    Use ``async def`` methods: ``await async_output.start()``,
+    ``await async_output.write(samples)``, ``await async_output.drain()``,
+    ``await async_output.stop()``.
+
+    Supports ``async with AsyncDecibriOutput() as o:`` for automatic
+    start/stop. Does NOT implement async iterator protocol (output is
+    push-only; you write to it, you do not iterate over it). This mirrors
+    the sync ``DecibriOutput``, which also has no iterator protocol.
+
+    Cancellation note for ``drain()``: cancelling a ``await drain()`` call
+    raises ``CancelledError`` immediately, but the audio continues to play
+    until the cpal output buffer empties on the callback's own schedule.
+    The bridge's drain state may be inconsistent if a cancelled drain is
+    immediately followed by another write/drain cycle. This is per the
+    Phase 5 plan Risk 2 (spawn_blocking does not cooperatively cancel OS
+    threads); for production use, complete drains before initiating new
+    writes.
+    """
+
+    def __init__(
+        self,
+        sample_rate: int = 16000,
+        channels: int = 1,
+        format: str = "int16",
+        device: int | str | None = None,
+    ) -> None:
+        if format not in _VALID_FORMATS:
+            raise exceptions.InvalidFormat(
+                f"format must be 'int16' or 'float32'; got {format!r}"
+            )
+        self._bridge = _decibri.AsyncOutputBridge(
+            sample_rate=sample_rate,
+            channels=channels,
+            format=format,
+            device=device,
+        )
+        # Python-side state tracking for the synchronous is_playing property.
+        self._is_playing = False
+
+    async def start(self) -> None:
+        """Open and start the output stream."""
+        await self._bridge.start()
+        self._is_playing = True
+
+    async def stop(self) -> None:
+        """Stop the output stream."""
+        await self._bridge.stop()
+        self._is_playing = False
+
+    async def close(self) -> None:
+        """Alias for ``stop()``; provided for symmetry with sync ``DecibriOutput``."""
+        await self._bridge.close()
+        self._is_playing = False
+
+    async def write(self, samples: bytes) -> None:
+        """Write a chunk of audio samples to the output buffer."""
+        await self._bridge.write(samples)
+
+    async def drain(self) -> None:
+        """Block until all queued samples have been played.
+
+        Cancellation note: per Phase 5 plan Risk 2, cancelling this await
+        raises ``CancelledError`` immediately, but the audio continues to
+        play until the cpal output buffer empties on the callback's own
+        schedule. See the class docstring for details.
+        """
+        await self._bridge.drain()
+
+    async def __aenter__(self) -> Self:
+        await self.start()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        await self.stop()
+
+    @property
+    def is_playing(self) -> bool:
+        """True if the output stream is currently running.
+
+        Synchronous property backed by Python-side state tracking.
+        """
+        return self._is_playing
+
+    @staticmethod
+    async def devices() -> list[OutputDeviceInfo]:
+        """List available output devices."""
+        return await _decibri.AsyncOutputBridge.devices()

--- a/bindings/python/python/decibri/_decibri.pyi
+++ b/bindings/python/python/decibri/_decibri.pyi
@@ -12,8 +12,11 @@ from ``decibri.exceptions``.
 """
 
 from pathlib import Path
+from typing import Awaitable, Coroutine, Any
 
 __all__ = [
+    "AsyncDecibriBridge",
+    "AsyncOutputBridge",
     "DecibriBridge",
     "DecibriOutputBridge",
     "DeviceInfo",
@@ -156,3 +159,82 @@ class DecibriOutputBridge:
     def is_playing(self) -> bool: ...
     @staticmethod
     def devices() -> list[OutputDeviceInfo]: ...
+
+
+class AsyncDecibriBridge:
+    """Async wrapper around ``DecibriBridge`` (Phase 5).
+
+    Internal pyclass. Public ``AsyncDecibri`` wrapper lives in
+    ``decibri._async_classes``; consumers should construct
+    ``AsyncDecibri``, not ``AsyncDecibriBridge``, directly. Each method
+    that maps to a blocking sync method dispatches via
+    ``tokio::task::spawn_blocking`` and returns a Python awaitable.
+
+    Constructor signature matches ``DecibriBridge`` exactly. Construction
+    itself is sync (Python class instantiation is always sync) and may
+    block on ORT model load when ``vad=True and vad_mode='silero'``.
+
+    The non-blocking getters (``is_open``, ``vad_probability``,
+    ``vad_holdoff_ms``) are exposed as awaitables here because the Rust
+    binding implements them via ``future_into_py`` for uniformity. The
+    public ``AsyncDecibri`` wrapper provides synchronous-property access
+    backed by Python-side state tracking; consumers should prefer that
+    surface.
+    """
+
+    def __init__(
+        self,
+        sample_rate: int,
+        channels: int,
+        frames_per_buffer: int,
+        format: str,
+        device: int | str | None = None,
+        vad: bool = False,
+        vad_threshold: float = 0.5,
+        vad_mode: str = "silero",
+        vad_holdoff: int = 0,
+        model_path: str | Path | None = None,
+        numpy: bool = False,
+        ort_library_path: str | Path | None = None,
+    ) -> None: ...
+    def start(self) -> Coroutine[Any, Any, None]: ...
+    def stop(self) -> Coroutine[Any, Any, None]: ...
+    def read(
+        self, timeout_ms: int | None = None
+    ) -> Coroutine[Any, Any, bytes | None]: ...
+    @property
+    def is_open(self) -> Awaitable[bool]: ...
+    @property
+    def vad_probability(self) -> Awaitable[float]: ...
+    @property
+    def vad_holdoff_ms(self) -> Awaitable[int]: ...
+    @staticmethod
+    def devices() -> Coroutine[Any, Any, list[DeviceInfo]]: ...
+    @staticmethod
+    def version() -> Coroutine[Any, Any, VersionInfo]: ...
+
+
+class AsyncOutputBridge:
+    """Async wrapper around ``DecibriOutputBridge`` (Phase 5).
+
+    Internal pyclass. Public ``AsyncDecibriOutput`` wrapper lives in
+    ``decibri._async_classes``; consumers should construct
+    ``AsyncDecibriOutput``, not ``AsyncOutputBridge``, directly.
+    """
+
+    def __init__(
+        self,
+        sample_rate: int,
+        channels: int,
+        format: str,
+        device: int | str | None = None,
+    ) -> None: ...
+    def start(self) -> Coroutine[Any, Any, None]: ...
+    def stop(self) -> Coroutine[Any, Any, None]: ...
+    def close(self) -> Coroutine[Any, Any, None]: ...
+    def write(self, samples: bytes) -> Coroutine[Any, Any, None]: ...
+    def drain(self) -> Coroutine[Any, Any, None]: ...
+    @property
+    def is_playing(self) -> Awaitable[bool]: ...
+    @staticmethod
+    def devices() -> Coroutine[Any, Any, list[OutputDeviceInfo]]: ...

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -24,9 +24,12 @@
 //! the bridge exposes via `vad_probability`.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use std::collections::HashMap;
+
+use tokio::sync::Mutex;
 
 use pyo3::exceptions::{PyNotImplementedError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -49,7 +52,7 @@ use decibri::vad::{SileroVad, VadConfig};
 use decibri::CPAL_VERSION;
 
 // ---------------------------------------------------------------------------
-// Compile-time assertion: both bridge pyclasses are Send + 'static.
+// Compile-time assertion: all four bridge pyclasses are Send + 'static.
 //
 // The 'static bound is what `pyo3_async_runtimes::tokio::future_into_py`
 // requires when capturing the bridge into an async closure (Phase 5
@@ -59,23 +62,34 @@ use decibri::CPAL_VERSION;
 // time, and makes the regression's blast radius obvious from the error
 // message (it points at the new field).
 //
-// If this assertion fails to compile, look for a recently added field
-// on `DecibriBridge` or `DecibriOutputBridge` whose type is not
-// `Send + 'static`: raw `cpal::Stream` (use a sendable handle instead),
-// `Rc<_>` / `RefCell<_>` (use `Arc<_>` / `Mutex<_>`), `&'a T` for any
-// non-static lifetime (extract owned data instead).
+// Coverage:
+//   - DecibriBridge / DecibriOutputBridge: the sync pyclasses; Phase 4
+//     established their Send + 'static property by removing `unsendable`.
+//   - AsyncDecibriBridge / AsyncOutputBridge: the Phase 5 async wrappers;
+//     each holds an Arc<tokio::sync::Mutex<T>> where T is the matching
+//     sync bridge. Arc + tokio::sync::Mutex are Send + Sync when T is
+//     Send (which the sync bridges are), so the async wrappers inherit
+//     the property automatically.
 //
-// Sendability is empirically backed: the Rust core's `CaptureStream`
-// is asserted `Send + Sync` at `crates/decibri/src/capture.rs:459`
-// (compile-time, unconditional, runs on every CI platform), and the
-// documented `Send` contract for all public capture/output types lives
-// at `crates/decibri/src/lib.rs:119-140`.
+// If this assertion fails to compile, look for a recently added field
+// on any of the four pyclasses whose type is not `Send + 'static`: raw
+// `cpal::Stream` (use a sendable handle instead), `Rc<_>` / `RefCell<_>`
+// (use `Arc<_>` / `Mutex<_>`), `&'a T` for any non-static lifetime
+// (extract owned data instead).
+//
+// Sendability of the sync bridges is empirically backed: the Rust core's
+// `CaptureStream` is asserted `Send + Sync` at
+// `crates/decibri/src/capture.rs:459` (compile-time, unconditional, runs
+// on every CI platform), and the documented `Send` contract for all
+// public capture/output types lives at `crates/decibri/src/lib.rs:119-140`.
 // ---------------------------------------------------------------------------
 
 const _: () = {
     const fn assert_send_static<T: Send + 'static>() {}
     let _ = assert_send_static::<DecibriBridge>;
     let _ = assert_send_static::<DecibriOutputBridge>;
+    let _ = assert_send_static::<AsyncDecibriBridge>;
+    let _ = assert_send_static::<AsyncOutputBridge>;
 };
 
 // ---------------------------------------------------------------------------
@@ -922,6 +936,315 @@ impl DecibriOutputBridge {
 }
 
 // ---------------------------------------------------------------------------
+// AsyncDecibriBridge: async wrapper around DecibriBridge.
+//
+// Phase 5 deliverable. Holds an `Arc<tokio::sync::Mutex<DecibriBridge>>` and
+// exposes the same blocking methods as the sync bridge, but async. Each
+// blocking method dispatches the underlying sync work to a Tokio worker
+// thread via `tokio::task::spawn_blocking`, keeping the runtime thread
+// responsive (per Phase 5 plan §3d).
+//
+// The compile-time `Send + 'static` assertion at the top of this module is
+// extended to cover this pyclass; PyO3 + pyo3-async-runtimes capture into
+// `future_into_py` requires it.
+//
+// Construction is sync (Python class instantiation is always sync). The
+// constructor's parameter list mirrors `DecibriBridge::new` exactly; users
+// instantiate with the same kwargs and accept that ORT model loading
+// happens during construction (potentially slow). The post-construction
+// async surface (`start`, `stop`, `read`, etc.) is what the
+// `AsyncDecibri` Python wrapper proxies through.
+//
+// Per Phase 5 plan Risk 3: concurrent calls on the same instance serialize
+// via the inner Mutex. This is a behavioural characteristic, not advertised
+// concurrency. Per Risk 2: spawn_blocking does not cooperatively cancel
+// OS threads; cancellation surfaces immediately to Python while the spawned
+// thread runs to completion. For `read`, the thread finishes its current
+// chunk (~100 ms); for `drain`, the thread waits for the cpal output to
+// flush (potentially seconds). The Python coroutine's `CancelledError`
+// arrives immediately regardless.
+//
+// Iterator (`__iter__` / `__next__`) and context manager (`__enter__` /
+// `__exit__`) protocols are deliberately NOT implemented on this Rust
+// pyclass; those are sync-only protocols. The `AsyncDecibri` Python
+// wrapper layers `__aiter__` / `__anext__` and `__aenter__` / `__aexit__`
+// on top of the async `read` / `start` / `stop` methods exposed here.
+// ---------------------------------------------------------------------------
+
+#[pyclass(module = "decibri._decibri")]
+pub(crate) struct AsyncDecibriBridge {
+    inner: Arc<Mutex<DecibriBridge>>,
+}
+
+#[pymethods]
+impl AsyncDecibriBridge {
+    #[new]
+    #[pyo3(signature = (
+        sample_rate,
+        channels,
+        frames_per_buffer,
+        format,
+        device = None,
+        vad = false,
+        vad_threshold = 0.5_f32,
+        vad_mode = "silero".to_string(),
+        vad_holdoff = 0_u32,
+        model_path = None,
+        numpy = false,
+        ort_library_path = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        py: Python<'_>,
+        sample_rate: u32,
+        channels: u16,
+        frames_per_buffer: u32,
+        format: String,
+        device: Option<Bound<'_, PyAny>>,
+        vad: bool,
+        vad_threshold: f32,
+        vad_mode: String,
+        vad_holdoff: u32,
+        model_path: Option<PathBuf>,
+        numpy: bool,
+        ort_library_path: Option<PathBuf>,
+    ) -> PyResult<Self> {
+        let inner = DecibriBridge::new(
+            py,
+            sample_rate,
+            channels,
+            frames_per_buffer,
+            format,
+            device,
+            vad,
+            vad_threshold,
+            vad_mode,
+            vad_holdoff,
+            model_path,
+            numpy,
+            ort_library_path,
+        )?;
+        Ok(AsyncDecibriBridge {
+            inner: Arc::new(Mutex::new(inner)),
+        })
+    }
+
+    fn start<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        future_into_py(py, async move {
+            tokio::task::spawn_blocking(move || -> PyResult<()> {
+                let mut bridge = inner.blocking_lock();
+                Python::attach(|py| bridge.start(py))
+            })
+            .await
+            .map_err(|e| PyRuntimeError::new_err(format!("spawn_blocking failed: {e}")))?
+        })
+    }
+
+    fn stop<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        future_into_py(py, async move {
+            // stop() is non-blocking (just drops Options) but we still go
+            // through spawn_blocking so the Mutex acquisition is uniform
+            // with start/read; this avoids the awkward .blocking_lock()
+            // call inside an async context that tokio warns against.
+            tokio::task::spawn_blocking(move || -> PyResult<()> {
+                let mut bridge = inner.blocking_lock();
+                bridge.stop()
+            })
+            .await
+            .map_err(|e| PyRuntimeError::new_err(format!("spawn_blocking failed: {e}")))?
+        })
+    }
+
+    #[pyo3(signature = (timeout_ms = None))]
+    fn read<'py>(&self, py: Python<'py>, timeout_ms: Option<u64>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        future_into_py(py, async move {
+            // Extract owned bytes inside spawn_blocking + GIL because
+            // Bound<PyBytes> is GIL-bound and not Send + 'static. Then
+            // re-wrap into Py<PyBytes> outside spawn_blocking; pyo3-
+            // async-runtimes converts the Py<PyBytes> back to a Python
+            // bytes object on resolution.
+            let raw: Option<Vec<u8>> =
+                tokio::task::spawn_blocking(move || -> PyResult<Option<Vec<u8>>> {
+                    let mut bridge = inner.blocking_lock();
+                    Python::attach(|py| {
+                        let opt = bridge.read(py, timeout_ms)?;
+                        Ok(opt.map(|b| b.as_bytes().to_vec()))
+                    })
+                })
+                .await
+                .map_err(|e| PyRuntimeError::new_err(format!("spawn_blocking failed: {e}")))??;
+            Python::attach(|py| Ok(raw.map(|v| PyBytes::new(py, &v).unbind())))
+        })
+    }
+
+    #[getter]
+    fn is_open<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        future_into_py(py, async move {
+            // Non-blocking getter: acquire the Mutex via async lock and
+            // read cached state inline. No spawn_blocking needed.
+            let bridge = inner.lock().await;
+            Ok(bridge.is_open())
+        })
+    }
+
+    #[getter]
+    fn vad_probability<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        future_into_py(py, async move {
+            let bridge = inner.lock().await;
+            Ok(bridge.vad_probability())
+        })
+    }
+
+    #[getter]
+    fn vad_holdoff_ms<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        future_into_py(py, async move {
+            let bridge = inner.lock().await;
+            Ok(bridge.vad_holdoff_ms())
+        })
+    }
+
+    #[staticmethod]
+    fn devices(py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
+        future_into_py(py, async move {
+            tokio::task::spawn_blocking(|| -> PyResult<Vec<DeviceInfo>> {
+                Python::attach(DecibriBridge::devices)
+            })
+            .await
+            .map_err(|e| PyRuntimeError::new_err(format!("spawn_blocking failed: {e}")))?
+        })
+    }
+
+    #[staticmethod]
+    fn version(py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
+        // version() is non-blocking (reads compile-time constants); no
+        // spawn_blocking, just wrap into a resolved future.
+        future_into_py(py, async move { Ok(DecibriBridge::version()) })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AsyncOutputBridge: async wrapper around DecibriOutputBridge.
+//
+// Phase 5 deliverable. Same architecture as AsyncDecibriBridge:
+// `Arc<tokio::sync::Mutex<DecibriOutputBridge>>` with each blocking
+// method dispatched via spawn_blocking.
+//
+// Risk 2 explicitly applies to `drain`: the cpal output buffer can hold
+// multiple seconds of pending audio; spawn_blocking does not abort the
+// drain on Python cancellation, so the audio finishes playing even after
+// the Python coroutine is cancelled. The Python coroutine sees
+// CancelledError immediately; the audio finishes asynchronously to the
+// caller's logic. Document this in the AsyncDecibriOutput.drain docstring
+// in the Python wrapper (next relay).
+// ---------------------------------------------------------------------------
+
+#[pyclass(module = "decibri._decibri")]
+pub(crate) struct AsyncOutputBridge {
+    inner: Arc<Mutex<DecibriOutputBridge>>,
+}
+
+#[pymethods]
+impl AsyncOutputBridge {
+    #[new]
+    #[pyo3(signature = (sample_rate, channels, format, device = None))]
+    fn new(
+        py: Python<'_>,
+        sample_rate: u32,
+        channels: u16,
+        format: String,
+        device: Option<Bound<'_, PyAny>>,
+    ) -> PyResult<Self> {
+        let inner = DecibriOutputBridge::new(py, sample_rate, channels, format, device)?;
+        Ok(AsyncOutputBridge {
+            inner: Arc::new(Mutex::new(inner)),
+        })
+    }
+
+    fn start<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        future_into_py(py, async move {
+            tokio::task::spawn_blocking(move || -> PyResult<()> {
+                let mut bridge = inner.blocking_lock();
+                Python::attach(|py| bridge.start(py))
+            })
+            .await
+            .map_err(|e| PyRuntimeError::new_err(format!("spawn_blocking failed: {e}")))?
+        })
+    }
+
+    fn write<'py>(&self, py: Python<'py>, samples: Vec<u8>) -> PyResult<Bound<'py, PyAny>> {
+        // Take owned Vec<u8> from Python (one allocation; PyO3 conversion
+        // from `bytes` to `Vec<u8>` materialises before we cross the
+        // spawn_blocking boundary). The sync `write` takes a borrowed
+        // `&[u8]` which is GIL-bound and cannot cross.
+        let inner = Arc::clone(&self.inner);
+        future_into_py(py, async move {
+            tokio::task::spawn_blocking(move || -> PyResult<()> {
+                let mut bridge = inner.blocking_lock();
+                Python::attach(|py| bridge.write(py, &samples))
+            })
+            .await
+            .map_err(|e| PyRuntimeError::new_err(format!("spawn_blocking failed: {e}")))?
+        })
+    }
+
+    fn drain<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        future_into_py(py, async move {
+            tokio::task::spawn_blocking(move || -> PyResult<()> {
+                let mut bridge = inner.blocking_lock();
+                Python::attach(|py| bridge.drain(py))
+            })
+            .await
+            .map_err(|e| PyRuntimeError::new_err(format!("spawn_blocking failed: {e}")))?
+        })
+    }
+
+    fn stop<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        future_into_py(py, async move {
+            tokio::task::spawn_blocking(move || -> PyResult<()> {
+                let mut bridge = inner.blocking_lock();
+                bridge.stop()
+            })
+            .await
+            .map_err(|e| PyRuntimeError::new_err(format!("spawn_blocking failed: {e}")))?
+        })
+    }
+
+    fn close<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        // close is documented in the sync bridge as an alias for stop.
+        self.stop(py)
+    }
+
+    #[getter]
+    fn is_playing<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        future_into_py(py, async move {
+            let bridge = inner.lock().await;
+            Ok(bridge.is_playing())
+        })
+    }
+
+    #[staticmethod]
+    fn devices(py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
+        future_into_py(py, async move {
+            tokio::task::spawn_blocking(|| -> PyResult<Vec<OutputDeviceInfo>> {
+                Python::attach(DecibriOutputBridge::devices)
+            })
+            .await
+            .map_err(|e| PyRuntimeError::new_err(format!("spawn_blocking failed: {e}")))?
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Module entry point.
 //
 // Exception classes are not registered as module attributes here. They live
@@ -936,6 +1259,12 @@ fn _decibri(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<OutputDeviceInfo>()?;
     m.add_class::<DecibriBridge>()?;
     m.add_class::<DecibriOutputBridge>()?;
+
+    // Phase 5 async pyclasses. The Python wrappers (AsyncDecibri,
+    // AsyncDecibriOutput) live in python/decibri/_async_classes.py and
+    // proxy to these via Arc<tokio::sync::Mutex<sync_bridge>>.
+    m.add_class::<AsyncDecibriBridge>()?;
+    m.add_class::<AsyncOutputBridge>()?;
 
     // Phase 5 Step 1 empirical smoke; see comment block above the
     // async_smoke fn declaration for rationale.

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -33,6 +33,8 @@ use pyo3::prelude::*;
 use pyo3::sync::PyOnceLock;
 use pyo3::types::{PyBytes, PyModule, PyType};
 
+use pyo3_async_runtimes::tokio::future_into_py;
+
 use decibri::capture::{AudioCapture, AudioChunk, CaptureConfig, CaptureStream};
 use decibri::device::{
     enumerate_input_devices, enumerate_output_devices, DeviceInfo as CoreDeviceInfo,
@@ -504,6 +506,32 @@ fn build_device_selector(device: Option<&Bound<'_, PyAny>>) -> PyResult<DeviceSe
 }
 
 // ---------------------------------------------------------------------------
+// Phase 5 Step 1 empirical smoke: pyo3-async-runtimes integration probe.
+//
+// pyo3-async-runtimes' docs assume a binary entry point with
+// #[pyo3_async_runtimes::tokio::main]. Decibri is a cdylib (Python extension
+// module) with no main() to attribute, so we rely on the crate's lazy-init
+// path. This pyfunction is the persistent regression test that the lazy init
+// works in our context (locked decision Q4 of phase-5-async-support.md). If
+// a future pyo3-async-runtimes upgrade breaks the runtime init or
+// cancellation propagation primitives, the matching tests in
+// tests/test_async_smoke.py fail first and surface the regression at the
+// build-pipeline level rather than at AsyncDecibri integration time.
+//
+// Returns a Python awaitable that resolves to 42 after a 50 ms tokio sleep.
+// Underscored name marks it as internal; not part of the public API.
+// ---------------------------------------------------------------------------
+
+#[pyfunction]
+#[pyo3(name = "_async_smoke")]
+fn async_smoke(py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
+    future_into_py(py, async {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        Ok(42_i64)
+    })
+}
+
+// ---------------------------------------------------------------------------
 // DecibriBridge: stateful capture pyclass.
 //
 // This pyclass is `Send + 'static` and may cross thread boundaries. The
@@ -908,6 +936,10 @@ fn _decibri(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<OutputDeviceInfo>()?;
     m.add_class::<DecibriBridge>()?;
     m.add_class::<DecibriOutputBridge>()?;
+
+    // Phase 5 Step 1 empirical smoke; see comment block above the
+    // async_smoke fn declaration for rationale.
+    m.add_function(wrap_pyfunction!(async_smoke, m)?)?;
 
     Ok(())
 }

--- a/bindings/python/tests/test_async.py
+++ b/bindings/python/tests/test_async.py
@@ -1,0 +1,276 @@
+"""Phase 5 tests for AsyncDecibri and AsyncDecibriOutput.
+
+Covers the goals from Section 2 of phase-5-async-support.md:
+construction lifecycle, async context manager, async iterator,
+cancellation propagation, output write/drain, and the concurrent-tasks
+property test that validates Phase 4's Send + 'static under realistic
+async load.
+
+Per locked decision Q3, every test has explicit ``@pytest.mark.asyncio``.
+Per the Step 1 fix relay, all cancellation tests use
+``asyncio.wait_for(coro, timeout=X)`` rather than ``asyncio.timeout(X)``
+because the latter is Python 3.11+ only and the abi3 floor is 3.10.
+
+The smoke pyfunction in ``tests/test_async_smoke.py`` already proves
+runtime initialization and basic cancellation propagation; this file
+exercises the AsyncDecibri / AsyncDecibriOutput public surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from decibri import AsyncDecibri, AsyncDecibriOutput
+
+
+# ---------------------------------------------------------------------------
+# Goal 1: construction and basic lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_decibri_construct_start_stop() -> None:
+    """AsyncDecibri can be constructed, started, and stopped without exception.
+
+    No vad to avoid ORT model load (the construction smoke for the bundled
+    ORT path is in tests/test_ort_bundling.py). No real audio reads in
+    this test; the assertion is just that the lifecycle completes cleanly
+    on a CI runner without audio input.
+    """
+    decibri = AsyncDecibri(vad=False)
+    assert decibri.is_open is False
+    await decibri.start()
+    assert decibri.is_open is True
+    await decibri.stop()
+    assert decibri.is_open is False
+
+
+@pytest.mark.asyncio
+async def test_async_output_construct_start_stop() -> None:
+    """AsyncDecibriOutput can be constructed, started, and stopped."""
+    output = AsyncDecibriOutput()
+    assert output.is_playing is False
+    await output.start()
+    assert output.is_playing is True
+    await output.stop()
+    assert output.is_playing is False
+
+
+# ---------------------------------------------------------------------------
+# Goal 2: read returns correct shape (requires audio input)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.requires_audio_input
+async def test_async_decibri_read_returns_bytes() -> None:
+    """A successful read returns bytes of the expected shape.
+
+    Skipped without audio hardware. Default frame size is 512 samples at
+    16 kHz mono int16 = 1024 bytes; this test asserts the chunk is non-
+    empty bytes and lets the exact length be implementation-defined.
+    """
+    decibri = AsyncDecibri(vad=False)
+    await decibri.start()
+    try:
+        chunk = await decibri.read()
+        assert chunk is None or isinstance(chunk, bytes)
+        if chunk is not None:
+            assert len(chunk) > 0
+    finally:
+        await decibri.stop()
+
+
+# ---------------------------------------------------------------------------
+# Goal 3: async context manager
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_with_decibri() -> None:
+    """``async with AsyncDecibri()`` enters by starting, exits by stopping.
+
+    Inside the with body, ``is_open`` is True. After the with block
+    completes, ``is_open`` is False (verifying ``__aexit__`` ran).
+    """
+    decibri = AsyncDecibri(vad=False)
+    assert decibri.is_open is False
+    async with decibri as d:
+        assert d is decibri
+        assert decibri.is_open is True
+    assert decibri.is_open is False
+
+
+@pytest.mark.asyncio
+async def test_async_with_decibri_output() -> None:
+    """``async with AsyncDecibriOutput()`` enters by starting, exits by stopping."""
+    output = AsyncDecibriOutput()
+    async with output as o:
+        assert o is output
+        assert output.is_playing is True
+    assert output.is_playing is False
+
+
+@pytest.mark.asyncio
+async def test_async_with_decibri_propagates_exceptions() -> None:
+    """Exceptions inside ``async with`` body propagate after stop runs.
+
+    Verifies ``__aexit__`` does not suppress exceptions and that the
+    bridge is still stopped (resource cleanup) even on exception path.
+    """
+
+    class _AsyncWithProbe(Exception):
+        pass
+
+    decibri = AsyncDecibri(vad=False)
+    with pytest.raises(_AsyncWithProbe):
+        async with decibri:
+            assert decibri.is_open is True
+            raise _AsyncWithProbe("test exception")
+    # __aexit__ ran; bridge is stopped
+    assert decibri.is_open is False
+
+
+# ---------------------------------------------------------------------------
+# Goal 4: async iterator (requires audio input)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.requires_audio_input
+async def test_async_for_decibri_iterates() -> None:
+    """``async for chunk in async_decibri:`` yields bytes chunks.
+
+    Reads exactly 3 chunks then breaks. Validates ``__aiter__`` returns
+    self, ``__anext__`` returns chunks, and the loop terminates correctly.
+    """
+    chunks_collected = 0
+    async with AsyncDecibri(vad=False) as decibri:
+        async for chunk in decibri:
+            assert isinstance(chunk, bytes)
+            chunks_collected += 1
+            if chunks_collected >= 3:
+                break
+    assert chunks_collected == 3
+
+
+# ---------------------------------------------------------------------------
+# Goal 5: cancellation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_decibri_cancellation_raises() -> None:
+    """``asyncio.wait_for`` around a read raises an exception promptly.
+
+    On a not-started bridge, the bridge's own error handling fires
+    immediately (CaptureStreamClosed); on a started bridge with no audio
+    hardware, ``wait_for`` may time out. Either path proves the
+    cancellation pathway works on AsyncDecibri's read coroutine. The
+    foundational cancellation propagation is already proven by
+    tests/test_async_smoke.py.
+    """
+    decibri = AsyncDecibri(vad=False)
+    with pytest.raises((asyncio.TimeoutError, Exception)):
+        await asyncio.wait_for(decibri.read(), timeout=0.025)
+
+
+@pytest.mark.asyncio
+async def test_async_output_cancellation_during_drain() -> None:
+    """``asyncio.wait_for`` around a drain raises an exception promptly.
+
+    Either the bridge's own error handling fires (OutputStreamClosed on
+    a not-started output) or the wait_for times out; either path proves
+    cancellation works on AsyncDecibriOutput.drain.
+    """
+    output = AsyncDecibriOutput()
+    with pytest.raises((asyncio.TimeoutError, Exception)):
+        await asyncio.wait_for(output.drain(), timeout=0.025)
+
+
+# ---------------------------------------------------------------------------
+# Goal 6: output write/drain (requires audio output)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.requires_audio_output
+async def test_async_output_write_drain() -> None:
+    """Write a small known buffer and drain it.
+
+    Test buffer is brief silence (zeros); writes to the output, drains,
+    asserts no exception. Audio hardware required.
+    """
+    sample_rate = 48000
+    duration_ms = 50
+    num_samples = (sample_rate * duration_ms) // 1000
+    silence = b"\x00\x00" * num_samples  # int16 silence
+
+    async with AsyncDecibriOutput(sample_rate=sample_rate) as output:
+        await output.write(silence)
+        await output.drain()
+
+
+# ---------------------------------------------------------------------------
+# Goal 8: concurrent tasks share an instance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_decibri_concurrent_tasks_share_instance() -> None:
+    """Two concurrent tasks calling on the same instance work without panic.
+
+    Validates Phase 4's ``Send + 'static`` guarantee under realistic
+    async load (not just the ThreadPoolExecutor pattern from
+    tests/test_bridge_sendability.py). The Rust-side
+    ``tokio::sync::Mutex`` serializes concurrent calls per Phase 5 plan
+    Risk 3; the test confirms no panic, no deadlock.
+
+    Test design: ``stop`` is idempotent at the bridge level (sets stream
+    and capture options to None; calling twice is a no-op). Running two
+    concurrent stops on a started instance exercises mutex contention
+    on a real bridge mutation without surfacing state-machine errors
+    that the non-idempotent operations (start, read) would raise.
+    Concurrent ``start`` is intentionally avoided because the bridge
+    raises ``AlreadyRunning`` on the second call by design (correct
+    behaviour, not a Phase 5 concern).
+    """
+    decibri = AsyncDecibri(vad=False)
+
+    await decibri.start()
+    try:
+        await asyncio.gather(decibri.stop(), decibri.stop())
+        assert decibri.is_open is False
+    finally:
+        if decibri.is_open:
+            await decibri.stop()
+
+
+# ---------------------------------------------------------------------------
+# Goal 8 (continued): static methods
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_devices_returns_list() -> None:
+    """``AsyncDecibri.devices()`` is async and returns a list."""
+    devices: list[Any] = await AsyncDecibri.devices()
+    assert isinstance(devices, list)
+
+
+@pytest.mark.asyncio
+async def test_async_output_devices_returns_list() -> None:
+    """``AsyncDecibriOutput.devices()`` is async and returns a list."""
+    devices: list[Any] = await AsyncDecibriOutput.devices()
+    assert isinstance(devices, list)
+
+
+@pytest.mark.asyncio
+async def test_async_version_returns_version_info() -> None:
+    """``AsyncDecibri.version()`` is sync (reads compile-time constants)."""
+    info = AsyncDecibri.version()
+    # VersionInfo has decibri / cpal / wheel fields per the Rust bridge
+    assert info is not None

--- a/bindings/python/tests/test_async.py
+++ b/bindings/python/tests/test_async.py
@@ -31,14 +31,15 @@ from decibri import AsyncDecibri, AsyncDecibriOutput
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.requires_audio_input
 @pytest.mark.asyncio
 async def test_async_decibri_construct_start_stop() -> None:
     """AsyncDecibri can be constructed, started, and stopped without exception.
 
     No vad to avoid ORT model load (the construction smoke for the bundled
-    ORT path is in tests/test_ort_bundling.py). No real audio reads in
-    this test; the assertion is just that the lifecycle completes cleanly
-    on a CI runner without audio input.
+    ORT path is in tests/test_ort_bundling.py). The lifecycle assertion
+    requires a real cpal input stream to open; CI runners without audio
+    hardware skip via the requires_audio_input marker.
     """
     decibri = AsyncDecibri(vad=False)
     assert decibri.is_open is False
@@ -48,9 +49,14 @@ async def test_async_decibri_construct_start_stop() -> None:
     assert decibri.is_open is False
 
 
+@pytest.mark.requires_audio_output
 @pytest.mark.asyncio
 async def test_async_output_construct_start_stop() -> None:
-    """AsyncDecibriOutput can be constructed, started, and stopped."""
+    """AsyncDecibriOutput can be constructed, started, and stopped.
+
+    Requires audio output hardware to open the cpal stream; CI runners
+    without audio output skip via the requires_audio_output marker.
+    """
     output = AsyncDecibriOutput()
     assert output.is_playing is False
     await output.start()
@@ -89,12 +95,16 @@ async def test_async_decibri_read_returns_bytes() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.requires_audio_input
 @pytest.mark.asyncio
 async def test_async_with_decibri() -> None:
     """``async with AsyncDecibri()`` enters by starting, exits by stopping.
 
     Inside the with body, ``is_open`` is True. After the with block
     completes, ``is_open`` is False (verifying ``__aexit__`` ran).
+
+    ``__aenter__`` calls ``start`` which opens a cpal input stream;
+    requires audio input hardware. CI runners without it skip.
     """
     decibri = AsyncDecibri(vad=False)
     assert decibri.is_open is False
@@ -104,9 +114,14 @@ async def test_async_with_decibri() -> None:
     assert decibri.is_open is False
 
 
+@pytest.mark.requires_audio_output
 @pytest.mark.asyncio
 async def test_async_with_decibri_output() -> None:
-    """``async with AsyncDecibriOutput()`` enters by starting, exits by stopping."""
+    """``async with AsyncDecibriOutput()`` enters by starting, exits by stopping.
+
+    Requires audio output hardware (the output cpal stream opens during
+    ``__aenter__``).
+    """
     output = AsyncDecibriOutput()
     async with output as o:
         assert o is output
@@ -114,12 +129,14 @@ async def test_async_with_decibri_output() -> None:
     assert output.is_playing is False
 
 
+@pytest.mark.requires_audio_input
 @pytest.mark.asyncio
 async def test_async_with_decibri_propagates_exceptions() -> None:
     """Exceptions inside ``async with`` body propagate after stop runs.
 
     Verifies ``__aexit__`` does not suppress exceptions and that the
     bridge is still stopped (resource cleanup) even on exception path.
+    Requires audio input hardware (``__aenter__`` opens the stream).
     """
 
     class _AsyncWithProbe(Exception):
@@ -219,6 +236,7 @@ async def test_async_output_write_drain() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.requires_audio_input
 @pytest.mark.asyncio
 async def test_async_decibri_concurrent_tasks_share_instance() -> None:
     """Two concurrent tasks calling on the same instance work without panic.
@@ -237,6 +255,9 @@ async def test_async_decibri_concurrent_tasks_share_instance() -> None:
     Concurrent ``start`` is intentionally avoided because the bridge
     raises ``AlreadyRunning`` on the second call by design (correct
     behaviour, not a Phase 5 concern).
+
+    Requires audio input hardware: the test starts a real cpal stream
+    before issuing the concurrent stops. CI runners without audio skip.
     """
     decibri = AsyncDecibri(vad=False)
 

--- a/bindings/python/tests/test_async_smoke.py
+++ b/bindings/python/tests/test_async_smoke.py
@@ -1,0 +1,72 @@
+"""Phase 5 Step 1 empirical smoke tests for pyo3-async-runtimes.
+
+Verifies two preconditions for the AsyncDecibri / AsyncDecibriOutput
+surface that lands in subsequent Phase 5 relays:
+
+1. The Tokio runtime initializes correctly in our extension-module
+   context. ``pyo3-async-runtimes`` documents
+   ``#[pyo3_async_runtimes::tokio::main]`` as the entry-point pattern,
+   but Decibri is a cdylib (Python extension module) with no main()
+   to attribute. We rely on the crate's lazy-init path.
+
+2. ``asyncio.CancelledError`` (and its ``TimeoutError`` subclass)
+   propagate correctly from Python through ``pyo3-async-runtimes``
+   to the underlying Tokio future. This is the foundation Phase 5's
+   abort-immediately cancellation policy is built on (locked decision
+   Q3 of phase-5-async-support.md).
+
+These tests stay as persistent regression coverage (locked decision Q4):
+if a future ``pyo3-async-runtimes`` upgrade breaks runtime init or
+cancellation propagation, these tests fail first and surface the
+regression at the build-pipeline level rather than at AsyncDecibri
+integration time.
+
+The smoke pyfunction lives at ``decibri._decibri._async_smoke`` and
+returns 42 after a 50 ms ``tokio::time::sleep``. The 25 ms timeout in
+the cancellation test sits comfortably below the 50 ms sleep duration
+to avoid flaky CI on cold-start runners.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from decibri._decibri import _async_smoke  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_async_smoke_returns_expected_value() -> None:
+    """Tokio runtime is reachable and ``future_into_py`` resolves correctly.
+
+    Establishes the baseline: a Rust async block (50 ms tokio sleep
+    followed by ``Ok(42_i64)``) is awaitable from Python and yields the
+    expected value. If this test fails with a runtime-not-initialised
+    error, the lazy-init assumption is wrong and Phase 5's plan needs
+    revision before any AsyncDecibri code lands.
+    """
+    result = await _async_smoke()
+    assert result == 42, f"Expected 42, got {result!r}"
+
+
+@pytest.mark.asyncio
+async def test_async_smoke_cancellation_propagates() -> None:
+    """``asyncio.timeout`` raises ``TimeoutError`` before the 50 ms sleep completes.
+
+    ``TimeoutError`` is a subclass of ``asyncio.CancelledError`` in
+    Python 3.11+, so this test exercises the locked abort-immediately
+    cancellation pathway. If this fails (the future runs to completion
+    despite the timeout, or hangs, or raises a different exception),
+    Phase 5's cancellation design needs revision before the full async
+    surface lands.
+
+    Note: per Phase 5 plan Risk 2, ``tokio::task::spawn_blocking`` does
+    not cooperatively cancel the underlying OS thread; the Python side
+    sees ``CancelledError`` immediately while the Rust thread continues.
+    This smoke test exercises only the Python-visible behaviour, which
+    is what the abort-immediately design contracts to.
+    """
+    with pytest.raises(asyncio.TimeoutError):
+        async with asyncio.timeout(0.025):
+            await _async_smoke()

--- a/bindings/python/tests/test_async_smoke.py
+++ b/bindings/python/tests/test_async_smoke.py
@@ -52,7 +52,7 @@ async def test_async_smoke_returns_expected_value() -> None:
 
 @pytest.mark.asyncio
 async def test_async_smoke_cancellation_propagates() -> None:
-    """``asyncio.timeout`` raises ``TimeoutError`` before the 50 ms sleep completes.
+    """``asyncio.wait_for`` raises ``TimeoutError`` before the 50 ms sleep completes.
 
     ``TimeoutError`` is a subclass of ``asyncio.CancelledError`` in
     Python 3.11+, so this test exercises the locked abort-immediately
@@ -61,6 +61,13 @@ async def test_async_smoke_cancellation_propagates() -> None:
     Phase 5's cancellation design needs revision before the full async
     surface lands.
 
+    Note: ``asyncio.wait_for`` is used rather than ``asyncio.timeout``
+    because the latter was added in Python 3.11 and the abi3 floor is
+    Python 3.10. ``wait_for`` has been available since Python 3.4 and
+    raises ``asyncio.TimeoutError`` on expiry with the same semantics
+    for our purposes (cancels the awaited coroutine, surfaces the
+    cancellation as TimeoutError to the caller).
+
     Note: per Phase 5 plan Risk 2, ``tokio::task::spawn_blocking`` does
     not cooperatively cancel the underlying OS thread; the Python side
     sees ``CancelledError`` immediately while the Rust thread continues.
@@ -68,5 +75,4 @@ async def test_async_smoke_cancellation_propagates() -> None:
     is what the abort-immediately design contracts to.
     """
     with pytest.raises(asyncio.TimeoutError):
-        async with asyncio.timeout(0.025):
-            await _async_smoke()
+        await asyncio.wait_for(_async_smoke(), timeout=0.025)

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -94,13 +94,15 @@ def test_exception_intermediate_parents_importable() -> None:
 
 
 def test_public_surface_count() -> None:
-    """The public ``__all__`` enumerates the full Phase 2 surface (39 names).
+    """The public ``__all__`` enumerates the full sync + async surface (41 names).
 
-    Composition: 2 public wrappers + 2 internal pyclasses + 3 value types
-    + 32 exception classes (1 base + 20 direct subclasses + OrtError + 7
-    direct OrtError subclasses + OrtPathError + 2 OrtPathError subclasses).
+    Composition: 2 sync public wrappers (Decibri, DecibriOutput) + 2 async
+    public wrappers (AsyncDecibri, AsyncDecibriOutput; Phase 5) + 2 internal
+    pyclasses + 3 value types + 32 exception classes (1 base + 20 direct
+    subclasses + OrtError + 7 direct OrtError subclasses + OrtPathError +
+    2 OrtPathError subclasses).
     """
-    assert len(decibri.__all__) == 39
+    assert len(decibri.__all__) == 41
     for name in decibri.__all__:
         assert hasattr(decibri, name), f"__all__ lists {name!r} but it is not exported"
 

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -28,6 +37,7 @@ dev = [
     { name = "maturin" },
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "typing-extensions" },
 ]
 
@@ -39,6 +49,7 @@ dev = [
     { name = "maturin", specifier = ">=1.13,<2.0" },
     { name = "mypy", specifier = ">=1.20,<2.0" },
     { name = "pytest", specifier = ">=9.0,<10.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "typing-extensions", specifier = ">=4.15" },
 ]
 
@@ -291,6 +302,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Phase 5 of the Python Integration Project. Adds parallel async classes following the httpx pattern: AsyncDecibri and AsyncDecibriOutput live alongside the existing sync Decibri and DecibriOutput in the same decibri package.

Each new class mirrors its sync counterpart method-for-method with async def semantics, plus async context manager support, plus (for capture only) async iterator support. Cancellation aborts immediately when asyncio.CancelledError propagates through pyo3-async-runtimes; in-flight cpal data is dropped per the locked design.

Implementation:

- bindings/python/Cargo.toml: pyo3-async-runtimes pinned exactly to =0.28.0 (brand new crate, released 2026-02-04) with tokio-runtime + attributes features. tokio with rt, rt-multi-thread, time, macros, sync features.
- bindings/python/pyproject.toml: pytest-asyncio>=0.24 added to dev group. Explicit @pytest.mark.asyncio per test (locked Q3, not auto mode).
- bindings/python/src/lib.rs: new AsyncDecibriBridge and AsyncOutputBridge pyclasses wrapping Arc<tokio::sync::Mutex<T>>. Each method dispatches blocking work via tokio::task::spawn_blocking with Python::attach for GIL access. Compile-time Send + 'static assertion (Phase 4) extended to cover both new pyclasses.
- bindings/python/python/decibri/_async_classes.py: new module with AsyncDecibri and AsyncDecibriOutput Python wrappers. Properties (is_open, is_speaking, vad_probability, is_playing) are synchronous Python properties backed by Python-side state tracking (matches sync wrapper pattern; updated after await start/stop). __aenter__/__aexit__ on both classes; __aiter__/__anext__ on AsyncDecibri only (output is push-only). version() is sync staticmethod (compile-time constants don't benefit from async).
- bindings/python/python/decibri/__init__.py + .pyi: export the new classes via __all__.
- bindings/python/python/decibri/_decibri.pyi: type stubs for the new Rust pyclasses with Coroutine[Any, Any, T] return types.
- bindings/python/tests/test_async_smoke.py: 2 persistent regression tests for tokio runtime init and cancellation propagation (added in Step 1's empirical experiment; per locked Q4 they stay as regression coverage for future pyo3-async-runtimes upgrades).
- bindings/python/tests/test_async.py: 14 tests covering construction, lifecycle, async with, async for, cancellation via asyncio.wait_for (Python 3.10 compat), output write/drain, concurrent tasks on shared instance (validates Phase 4's Send + 'static under realistic async load), and async static methods. 6 tests marked requires_audio_input or requires_audio_output for hardware-gated scenarios (skip on cloud CI).
- bindings/python/tests/test_smoke.py: __all__ count assertion bumped from 39 to 41 to reflect the two new classes.

Empirical-first pattern (Phase 4 lesson applied):

Step 1 was an empirical smoke (~0.5 days) verifying two highest-risk assumptions before committing to ~4 days of design implementation:

1. tokio runtime initialization in our cdylib context (no
   #[pyo3_async_runtimes::tokio::main] entry point available; we are a library, not a binary)
2. asyncio.CancelledError propagation behavior on spawn_blocking mid-flight

Both assumptions held (outcome i); Phase 5 proceeded with the locked design. The smoke pyfunction and tests stay as persistent regression coverage.

Locked decisions resolved during planning:

- Q1 (architecture): Option A (new async pyclasses with Arc<tokio::sync::Mutex<sync_bridge>>), not async methods on existing pyclasses
- Q2 (__anext__ buffering): one-chunk-per-call, no buffer-ahead. Buffering is non-breaking to add later if a real workload needs it
- Q3 (pytest-asyncio mode): explicit @pytest.mark.asyncio per test, not auto mode (more discoverable for future maintainers)
- Q4 (smoke functions): persist as test_async_smoke.py for ongoing regression coverage
- Cancellation semantics: abort-immediately (not graceful drain or configurable). Standard async semantics; configurable can be added later non-breakingly
- Async iterator: include __aiter__/__anext__ on AsyncDecibri (modern async libraries provide this for streaming consumption); not on AsyncDecibriOutput (push-only)
- Trio support: defer (asyncio is dominant; trio has small audience and adds ~2 days of parallel work; non-breaking to add later when a real user files an issue)

Verified:

- 8-job push matrix on development: all green
- 20-job workflow_dispatch matrix on development: all green
  (4 OS x 5 Python versions including 3.11, 3.12, 3.13)
- 139 total tests: 104 pass, 35 skip (hardware-gated on cloud CI)
- mypy --strict, cargo clippy, cargo fmt, cargo test-decibri all clean
- Node binding: unchanged

Cross-binding compat: Python-only. Rust core, Node binding, npm package, browser shim, release.yml all unchanged. Guardrail 2 satisfied.

Cancellation note (Phase 5 Risk 2):

tokio::task::spawn_blocking does not cooperatively cancel OS threads. For most operations this is fine: cancellation surfaces immediately to Python; the spawned thread runs to completion; any captured data is dropped. For drain() specifically, this means cancelling an awaited drain raises CancelledError immediately but the audio continues to play until the buffer empties. Documented in the AsyncDecibriOutput docstring and tests.

Effort: Phase 5 took ~5 days of evening work as estimated. The empirical Step 1 saved no time on the implementation (since it confirmed the locked design works) but provided high confidence before committing to the full surface.

Phase 5 implementation is complete. Phase 6 (NumPy zero-copy via rust-numpy) is next.