### PR TITLE
Phase 8: OnnxSession trait abstraction in Rust core (additive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DeviceError` catch-target intermediate (subclass of `DecibriError`, parent of all eight device-related exceptions: `DeviceNotFound`, `OutputDeviceNotFound`, `MultipleDevicesMatch`, `DeviceIndexOutOfRange`, `NoMicrophoneFound`, `NoOutputDeviceFound`, `NotAnInputDevice`, `DeviceEnumerationFailed`). Symmetric with `OrtError` and `OrtPathError`. Existing catches via `DecibriError` remain unchanged (parent chain preserved).
 - Re-entry contract documented and pinned by tests on `Microphone.start()`, `Speaker.start()`, `AsyncMicrophone.start()`, `AsyncSpeaker.start()`. Calling `start()` after `stop()` / `close()` reconstructs the underlying audio stream cleanly; VAD state resets on each new `start()`. Calling `start()` while already started raises `AlreadyRunning`.
 
+## [3.4.0] - 2026-05-02
+
+### Added
+
+- **`OnnxSession` trait abstraction in Rust core** (Phase 8). New internal `pub(crate) trait OnnxSession` inside `crates/decibri/src/onnx.rs` abstracting ONNX Runtime usage behind a backend-agnostic interface. `SileroVad` migrates to consume the trait through `Box<dyn OnnxSession>`. ORT-backed implementation is the only impl in 3.x; future backends (CoreML at iOS time, TFLite at Android time, GPU EPs at the P4 GPU project) plug in additively at the `decibri-onnx` workspace split planned for 4.0.
+- `DecibriError::OnnxBackendFailed { backend: &'static str, source: Box<dyn std::error::Error + Send + Sync> }` variant for future non-ORT backend errors. Additive (the enum is `#[non_exhaustive]`); existing 8 ORT variants unchanged. `is_ort_path_error` continues to return false on the new variant.
+
+### Internal
+
+- Phase 8 of the Python Integration Project. `crates/decibri` 3.x public API stays byte-identical (`SileroVad`, `VadConfig`, `VadResult`, `DecibriError` keep Phase 7.x signatures). npm, Python binding, browser shim are unchanged. See `~/.claude/plans/phase-8-onnxsession-trait.md` for the plan and `~/.claude/plans/phase-8-prep-research.md` for the empirical investigation that produced the trait shape.
+- `vad::init_ort_once` visibility raised from private to `pub(crate)` so the `onnx` module's inline ORT-backed test can reuse the same process-global init path that `vad` tests use.
+
 ## [3.3.2] - 2026-04-26
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.3.2"
+version = "3.4.0"
 edition = "2021"
 # MSRV empirically verified 2026-04-22: rustc 1.88 is the minimum version
 # that compiles the workspace. Floors: ort 2.0.0-rc.12 declares

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -28,7 +28,7 @@ crate-type = ["cdylib"]
 # features across both bindings silently; diverging overrides produce a build
 # that neither binding tests in isolation. Both bindings inherit decibri's
 # default features (capture, output, vad, denoise, gain, ort-load-dynamic).
-decibri = { version = "3.3.2", path = "../../crates/decibri" }
+decibri = { version = "3.4.0", path = "../../crates/decibri" }
 
 # PyO3 0.28 is the first MSRV-1.83 release line with the attach / detach /
 # initialize API renames; aligns with workspace MSRV 1.88 (headroom preserved).

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -52,9 +52,9 @@ def test_version_decibri_matches_rust_core() -> None:
     from decibri import _decibri
 
     # Literal equality per Phase 1 plan. When the Rust workspace bumps past
-    # 3.3.2 this assertion breaks deliberately: force a conscious update of
+    # 3.4.0 this assertion breaks deliberately: force a conscious update of
     # the Python test expectation alongside the Rust version bump.
-    assert _decibri.MicrophoneBridge.version().decibri == "3.3.2"
+    assert _decibri.MicrophoneBridge.version().decibri == "3.4.0"
 
 
 def test_version_audio_backend_matches_cpal() -> None:
@@ -70,7 +70,7 @@ def test_version_info_fields() -> None:
     from decibri import _decibri
 
     info = _decibri.MicrophoneBridge.version()
-    assert info.decibri == "3.3.2"
+    assert info.decibri == "3.4.0"
     assert info.audio_backend == "cpal 0.17"
     assert info.binding == "0.1.0a1"
 

--- a/crates/decibri/examples/bench_vad.rs
+++ b/crates/decibri/examples/bench_vad.rs
@@ -1,0 +1,87 @@
+//! Phase 8 micro-benchmark: SileroVad inference latency.
+//!
+//! Measures wall-time per `SileroVad::process()` call on a deterministic
+//! 16 kHz audio chunk. Used to validate LD-8-9: VAD inference latency post-
+//! Phase-8 must stay within 0.5% (p50) / 1% (p99) of the pre-Phase-8 baseline
+//! after `SileroVad` migrates to consume `Box<dyn OnnxSession>`.
+//!
+//! # Run
+//!
+//! ```bash
+//! cargo run --release --example bench_vad \
+//!     -p decibri \
+//!     --no-default-features \
+//!     --features capture,output,vad,denoise,gain,ort-download-binaries
+//! ```
+//!
+//! Output is two lines: `p50 = <ns>` and `p99 = <ns>`. Compare across
+//! pre-Phase-8 (vad.rs using direct ORT) and post-Phase-8 (vad.rs through
+//! the trait) builds; the two builds must have run on the same hardware
+//! back-to-back with no machine reboot in between.
+
+use std::path::Path;
+use std::time::Instant;
+
+use decibri::vad::{SileroVad, VadConfig};
+
+const ITERATIONS: usize = 10_000;
+const WINDOW_SAMPLES: usize = 512;
+const SAMPLE_RATE: u32 = 16_000;
+
+fn main() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let model = Path::new(manifest_dir)
+        .join("..")
+        .join("..")
+        .join("models")
+        .join("silero_vad.onnx");
+
+    if !model.is_file() {
+        panic!(
+            "bench_vad: silero model not found at {}. Cannot benchmark.",
+            model.display()
+        );
+    }
+
+    let config = VadConfig {
+        model_path: model,
+        sample_rate: SAMPLE_RATE,
+        threshold: 0.5,
+        ort_library_path: None,
+    };
+
+    let mut vad = SileroVad::new(config).expect("SileroVad construction should succeed");
+
+    // Deterministic input: a 16 kHz sine wave at 440 Hz, normalized to [-1, 1].
+    // Same waveform across runs so timing differences reflect inference cost
+    // alone, not input-data variability.
+    let chunk: Vec<f32> = (0..WINDOW_SAMPLES)
+        .map(|i| {
+            let t = i as f32 / SAMPLE_RATE as f32;
+            (2.0 * std::f32::consts::PI * 440.0 * t).sin() * 0.5
+        })
+        .collect();
+
+    // Warm-up to stabilize CPU caches and ORT internal allocations. Not
+    // included in the timing measurements.
+    for _ in 0..100 {
+        vad.process(&chunk).expect("warmup process should succeed");
+    }
+
+    let mut samples_ns = Vec::with_capacity(ITERATIONS);
+    for _ in 0..ITERATIONS {
+        let start = Instant::now();
+        vad.process(&chunk).expect("bench process should succeed");
+        samples_ns.push(start.elapsed().as_nanos() as u64);
+    }
+    samples_ns.sort_unstable();
+
+    let p50 = samples_ns[samples_ns.len() / 2];
+    let p99 = samples_ns[(samples_ns.len() * 99) / 100];
+
+    println!("iterations = {ITERATIONS}");
+    println!("window_samples = {WINDOW_SAMPLES}");
+    println!("sample_rate = {SAMPLE_RATE}");
+    println!("p50 = {p50} ns");
+    println!("p99 = {p99} ns");
+}

--- a/crates/decibri/src/error.rs
+++ b/crates/decibri/src/error.rs
@@ -190,6 +190,29 @@ pub enum DecibriError {
         #[source]
         source: ort::Error,
     },
+
+    /// Forward-compat catch-all for non-ORT ONNX backends (CoreML, TFLite,
+    /// etc.) once the workspace split lands at 4.0.
+    ///
+    /// Not emitted by ORT-backed code paths in 3.x: ORT failures use the 8
+    /// preceding variants (`OrtSessionBuildFailed`, `OrtThreadsConfigFailed`,
+    /// `VadModelLoadFailed`, `OrtInferenceFailed`, `OrtTensorCreateFailed`,
+    /// `OrtTensorExtractFailed`, plus `OrtInitFailed` and `OrtLoadFailed`)
+    /// which carry an `ort::Error` source directly.
+    ///
+    /// Permitted by `#[non_exhaustive]` on this enum (see line 31). Existing
+    /// `is_ort_path_error` returns false on this variant: `OnnxBackendFailed`
+    /// is not an ORT path-loading failure.
+    ///
+    /// `backend` identifies which non-ORT backend produced the error
+    /// (e.g. `"coreml"`, `"tflite"`); `source` carries the backend-native
+    /// error boxed for trait-object compatibility.
+    #[error("ONNX backend error from {backend}: {source}")]
+    OnnxBackendFailed {
+        backend: &'static str,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 
 impl DecibriError {

--- a/crates/decibri/src/lib.rs
+++ b/crates/decibri/src/lib.rs
@@ -149,6 +149,16 @@ compile_error!(
 pub mod error;
 pub mod sample;
 
+// Internal ONNX session abstraction. Trait stays `pub(crate)` until 4.0 /
+// `decibri-onnx` workspace split per LD-8-1 and LD15. Public API of
+// `crates/decibri` 3.x is byte-identical with or without this module.
+//
+// Gated on `feature = "vad"` matching the only consumer (`vad`) and the
+// only backend (`dep:ort`). When vad is disabled, the trait has no purpose
+// since there is no inference workload and no ORT backend to wrap.
+#[cfg(feature = "vad")]
+mod onnx;
+
 /// Resolved cpal version (major.minor) extracted at build time from the
 /// crate's `Cargo.toml`.
 ///

--- a/crates/decibri/src/onnx.rs
+++ b/crates/decibri/src/onnx.rs
@@ -1,0 +1,565 @@
+//! Internal ONNX session abstraction.
+//!
+//! This module defines the [`OnnxSession`] trait that decibri uses to talk to
+//! ONNX Runtime today, and that future backends (CoreML at iOS time, TFLite
+//! at Android time, GPU EPs at the P4 GPU project) will plug into without
+//! changing any consumer code.
+//!
+//! # Visibility
+//!
+//! Everything in this module is `pub(crate)`. The trait is invisible to
+//! external consumers of `decibri` 3.x. It goes public at 4.0 alongside the
+//! `decibri-onnx` workspace split, at which point this file becomes the
+//! public API of the new `decibri-onnx` crate. See locked decision LD15 in
+//! `~/.claude/plans/python-integration-project.md` and Phase 8 plan
+//! `~/.claude/plans/phase-8-onnxsession-trait.md` LD-8-1.
+//!
+//! # Trait shape
+//!
+//! The trait surface mirrors the four operations [`crate::vad`] performs
+//! against `ort::session::Session`: builder construction, input tensor
+//! creation, run, output tensor extraction. The closed-enum
+//! [`OnnxTensorData`] / [`OnnxTensorOwned`] design avoids an `ndarray`
+//! workspace dep and keeps the VAD hot path (~50 calls per second) free of
+//! tensor-type vtable dispatch.
+//!
+//! Adding a new dtype variant (e.g. `F16` or `I32`) is technically a closed-
+//! enum break, but is acceptable while the trait stays `pub(crate)`. Once
+//! the trait goes public at 4.0, dtype additions become a major-version
+//! event.
+//!
+//! # Backend selection
+//!
+//! Backend dispatch happens inside [`OnnxSessionBuilder::build`]. In 3.x the
+//! ORT-backed implementation is the only one, so `build` always returns an
+//! `OrtSession`. At 0.3.0+ when the trait goes public and CoreML / TFLite
+//! land, `build` becomes a `cfg!`/runtime dispatch point. Adding execution-
+//! provider selection (`with_execution_providers`) at that point is purely
+//! additive (LD-8-3).
+//!
+//! # Error handling
+//!
+//! The trait reuses [`crate::error::DecibriError`]. The 8 existing ORT
+//! variants cover ORT failures. The forward-compat
+//! [`crate::error::DecibriError::OnnxBackendFailed`] variant covers future
+//! non-ORT backend errors and is not emitted by the ORT impl in 3.x.
+
+use std::path::PathBuf;
+
+use crate::error::DecibriError;
+
+/// Borrowed view into a single named input tensor.
+///
+/// Lifetimes: input data is borrowed from the caller. The ORT backend copies
+/// into a `Vec` inside `Tensor::from_array`, so the borrow lifetime can be as
+/// short as one [`OnnxSession::run`] call.
+pub(crate) struct OnnxTensorView<'a> {
+    pub shape: &'a [i64],
+    pub data: OnnxTensorData<'a>,
+}
+
+/// Borrowed input tensor data.
+///
+/// Closed enum over the dtypes Silero VAD needs. Adding a variant requires a
+/// matching arm in every [`OnnxSession`] impl.
+pub(crate) enum OnnxTensorData<'a> {
+    F32(&'a [f32]),
+    I64(&'a [i64]),
+}
+
+/// Named-input bag for [`OnnxSession::run`].
+///
+/// Slice rather than `Vec` to avoid an allocation on each VAD inference
+/// (Silero VAD calls `run()` ~50 times per second of audio at 16 kHz).
+pub(crate) struct OnnxInputs<'a> {
+    pub items: &'a [(&'a str, OnnxTensorView<'a>)],
+}
+
+/// Named-output bag returned from [`OnnxSession::run`].
+///
+/// Owns its data: ORT's `try_extract_tensor` returns a borrow tied to the
+/// `SessionOutputs` value, which is itself bounded by `&'s mut Session`.
+/// Copying outputs into owned [`Vec`]s ends that borrow before `run` returns,
+/// keeping the trait method usable from `&mut self` without HRTB gymnastics.
+pub(crate) struct OnnxOutputs {
+    pub tensors: Vec<(String, OnnxOutputTensor)>,
+}
+
+/// One owned named output.
+///
+/// `shape` is part of the trait API (future workloads with dynamic-shape
+/// outputs need it) but is unused by Silero VAD's known-shape outputs in
+/// 3.x. Kept allowed-dead until a non-Silero consumer reads it.
+pub(crate) struct OnnxOutputTensor {
+    #[allow(dead_code)]
+    pub shape: Vec<i64>,
+    pub data: OnnxTensorOwned,
+}
+
+/// Owned output tensor data.
+///
+/// `I64` is part of the trait API (some ONNX workloads emit i64 outputs;
+/// e.g., classification logits-as-class-ids) but is unused by Silero VAD's
+/// f32-only outputs in 3.x. Kept allowed-dead until a non-Silero consumer
+/// emits an i64 output.
+pub(crate) enum OnnxTensorOwned {
+    F32(Vec<f32>),
+    #[allow(dead_code)]
+    I64(Vec<i64>),
+}
+
+impl OnnxOutputs {
+    /// Look up an output tensor by name. Returns `None` if no output with
+    /// that name was produced by the session.
+    pub(crate) fn get(&self, name: &str) -> Option<&OnnxOutputTensor> {
+        self.tensors.iter().find(|(n, _)| n == name).map(|(_, t)| t)
+    }
+}
+
+/// Internal ONNX session abstraction.
+///
+/// `pub(crate)` until 4.0 (LD-8-1). At 4.0 / `decibri-onnx` workspace split
+/// this becomes the public surface that ORT, CoreML, and TFLite backends all
+/// implement.
+///
+/// `Send + Sync` is required because [`crate::vad::SileroVad`] is moved into
+/// the cpal capture-thread processing path (Phase 5 architecture). ORT's
+/// `Session` already satisfies both bounds; future backends needing
+/// `unsafe impl Send + Sync` wrappers absorb that cost in their impls.
+///
+/// `run` takes `&mut self` to match ORT's `Session::run` signature; backends
+/// whose native API takes `&self` (CoreML's `MLModel.prediction`, TFLite's
+/// `Interpreter::invoke`) implement the mutable receiver trivially.
+pub(crate) trait OnnxSession: Send + Sync {
+    /// Execute one inference.
+    ///
+    /// `inputs` is a borrowed slice of named tensor views; the session
+    /// must not retain any reference past the return. `OnnxOutputs` owns
+    /// its tensors so the caller can drop the borrow before reading them.
+    fn run(&mut self, inputs: OnnxInputs<'_>) -> Result<OnnxOutputs, DecibriError>;
+}
+
+/// Builder for an [`OnnxSession`].
+///
+/// Concrete struct, not a trait: backend dispatch happens inside
+/// [`Self::build`]. In 3.x there is exactly one backend (ORT), so `build`
+/// always returns an `OrtSession`. At 0.3.0+ when CoreML / TFLite / etc.
+/// land, this is the dispatch point.
+///
+/// `with_execution_providers([EP])` is deferred to 0.3.0+ per LD-8-3. The
+/// trait is `pub(crate)`, so no external consumer can call it; the only
+/// internal consumer (`SileroVad`) does not need EP selection (Silero is
+/// CPU-only). Adding EP selection at 0.3.0+ is purely additive.
+pub(crate) struct OnnxSessionBuilder {
+    model_path: PathBuf,
+    intra_threads: usize,
+}
+
+impl OnnxSessionBuilder {
+    /// Start a builder targeting the given ONNX model file path.
+    pub(crate) fn from_file(path: impl Into<PathBuf>) -> Self {
+        Self {
+            model_path: path.into(),
+            intra_threads: 1,
+        }
+    }
+
+    /// Set the intra-op thread count for the session.
+    pub(crate) fn with_intra_threads(mut self, n: usize) -> Self {
+        self.intra_threads = n;
+        self
+    }
+
+    /// Build the session.
+    ///
+    /// In 3.x always returns the ORT-backed implementation. The entire
+    /// `onnx` module is gated on `feature = "vad"` (see `lib.rs`), so this
+    /// method only exists when ORT is available.
+    pub(crate) fn build(self) -> Result<Box<dyn OnnxSession>, DecibriError> {
+        let session = ort_impl::OrtSession::open(&self.model_path, self.intra_threads)?;
+        Ok(Box::new(session))
+    }
+}
+
+mod ort_impl {
+    use std::borrow::Cow;
+    use std::path::Path;
+
+    use ort::session::{Session, SessionInputValue};
+    use ort::value::{Tensor, TensorElementType};
+
+    use super::{
+        DecibriError, OnnxInputs, OnnxOutputTensor, OnnxOutputs, OnnxSession, OnnxTensorData,
+        OnnxTensorOwned,
+    };
+
+    /// ORT-backed [`OnnxSession`]. Wraps `ort::session::Session`.
+    ///
+    /// LSTM state for stateful models (Silero VAD) lives on the consumer
+    /// (`SileroVad`), not the session: the session holds only ORT runtime
+    /// state. This matches ORT's own model where `Session` is the engine
+    /// and per-call state is supplied as named input tensors.
+    pub(super) struct OrtSession {
+        inner: Session,
+    }
+
+    impl OrtSession {
+        /// Construct an [`OrtSession`] from a model file path. Pattern
+        /// matches the pre-Phase-8 `crates/decibri/src/vad.rs:243-254`
+        /// session-creation block: builder, with_intra_threads, commit_from_file.
+        pub(super) fn open(path: &Path, intra: usize) -> Result<Self, DecibriError> {
+            let session = Session::builder()
+                .map_err(DecibriError::OrtSessionBuildFailed)?
+                .with_intra_threads(intra)
+                .map_err(|e| DecibriError::OrtThreadsConfigFailed(e.into()))?
+                .commit_from_file(path)
+                .map_err(|e| DecibriError::VadModelLoadFailed {
+                    path: path.to_path_buf(),
+                    source: e,
+                })?;
+            Ok(Self { inner: session })
+        }
+    }
+
+    /// Map a runtime input or output name back to a `&'static str` for the
+    /// existing [`DecibriError::OrtTensorCreateFailed`] /
+    /// [`DecibriError::OrtTensorExtractFailed`] `kind` field. Preserves the
+    /// exact pre-Phase-8 error message text for the well-known Silero names
+    /// without forcing a breaking change to the error variant signatures
+    /// (LD-8-1: public API byte-identical).
+    fn known_kind(name: &str) -> &'static str {
+        match name {
+            "input" => "input",
+            "state" => "state",
+            "sr" => "sr",
+            "output" => "output",
+            "stateN" => "state",
+            _ => "trait_tensor",
+        }
+    }
+
+    impl OnnxSession for OrtSession {
+        /// Run one inference through the ORT session.
+        ///
+        /// Hardcoded to the ValueMap (runtime-named) input path per LD-8-10:
+        /// Silero VAD has exactly 3 inputs and ORT 2.x's
+        /// `SessionInputs<'i, 'v, N>` const-generic input count is awkward
+        /// to use from a runtime slice. The ValueMap variant accepts a
+        /// `Vec<(Cow<'_, str>, SessionInputValue<'_>)>` which `Session::run`
+        /// consumes via `From<Vec<(K, V)>> for SessionInputs<_, _, 0>`.
+        /// Generic-N construction lands at 0.3.0+ when a second backend or
+        /// non-VAD workload needs different input cardinality.
+        ///
+        /// Output dtype dispatch reads `Value::dtype().tensor_type()` per
+        /// output and copies into an owned `OnnxOutputTensor`. Copy is
+        /// trivial for Silero's outputs (`output` is 1 float, `stateN` is
+        /// 256 floats). Whisper-style large outputs would benefit from a
+        /// future `run_zero_copy` variant; deferred per Phase 8 plan
+        /// Section 4 "Items NOT in scope".
+        fn run(&mut self, inputs: OnnxInputs<'_>) -> Result<OnnxOutputs, DecibriError> {
+            let mut input_pairs: Vec<(Cow<'_, str>, SessionInputValue<'_>)> =
+                Vec::with_capacity(inputs.items.len());
+
+            for (name, view) in inputs.items.iter() {
+                let kind = known_kind(name);
+                let shape: Vec<i64> = view.shape.to_vec();
+                let value: SessionInputValue<'_> = match &view.data {
+                    OnnxTensorData::F32(slice) => {
+                        let tensor = Tensor::from_array((shape, slice.to_vec()))
+                            .map_err(|e| DecibriError::OrtTensorCreateFailed { kind, source: e })?;
+                        tensor.into()
+                    }
+                    OnnxTensorData::I64(slice) => {
+                        let tensor = Tensor::from_array((shape, slice.to_vec()))
+                            .map_err(|e| DecibriError::OrtTensorCreateFailed { kind, source: e })?;
+                        tensor.into()
+                    }
+                };
+                input_pairs.push((Cow::Owned((*name).to_string()), value));
+            }
+
+            let outputs = self
+                .inner
+                .run(input_pairs)
+                .map_err(DecibriError::OrtInferenceFailed)?;
+
+            let names: Vec<String> = outputs.keys().map(|k| k.to_string()).collect();
+            let mut tensors: Vec<(String, OnnxOutputTensor)> = Vec::with_capacity(names.len());
+            for name in names {
+                let kind = known_kind(&name);
+                let value = &outputs[name.as_str()];
+                let dtype = value.dtype().tensor_type();
+                let owned = match dtype {
+                    Some(TensorElementType::Float32) => {
+                        let (shape, data) = value.try_extract_tensor::<f32>().map_err(|e| {
+                            DecibriError::OrtTensorExtractFailed { kind, source: e }
+                        })?;
+                        OnnxOutputTensor {
+                            shape: shape.to_vec(),
+                            data: OnnxTensorOwned::F32(data.to_vec()),
+                        }
+                    }
+                    Some(TensorElementType::Int64) => {
+                        let (shape, data) = value.try_extract_tensor::<i64>().map_err(|e| {
+                            DecibriError::OrtTensorExtractFailed { kind, source: e }
+                        })?;
+                        OnnxOutputTensor {
+                            shape: shape.to_vec(),
+                            data: OnnxTensorOwned::I64(data.to_vec()),
+                        }
+                    }
+                    _ => {
+                        return Err(DecibriError::OnnxBackendFailed {
+                            backend: "ort",
+                            source: format!(
+                                "unsupported output tensor element type for {name}: {dtype:?}"
+                            )
+                            .into(),
+                        });
+                    }
+                };
+                tensors.push((name, owned));
+            }
+
+            Ok(OnnxOutputs { tensors })
+        }
+    }
+}
+
+// Inline tests: the trait is `pub(crate)` (LD-8-1), so an integration test in
+// `tests/onnx_trait.rs` could not see it. Inline `#[cfg(test)] mod tests`
+// preserves the plan's intent (test the trait API in isolation, with a
+// MockSession and an ORT-backed round trip) while honoring the visibility
+// constraint. Documented in the Phase 8 implementation report.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Sanity-check that `Box<dyn OnnxSession>` is `Send + Sync`. This is the
+    /// load-bearing bound (`SileroVad` lives in the cpal capture-thread path
+    /// per Phase 5; the bridge already asserts `Send + 'static`). If a future
+    /// trait change drops one of these bounds, this assertion fails at
+    /// compile time.
+    #[allow(dead_code)]
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    #[test]
+    fn box_dyn_session_is_send_sync() {
+        assert_send_sync::<Box<dyn OnnxSession>>();
+    }
+
+    /// Trivial in-memory [`OnnxSession`] for trait-shape testing without ORT.
+    /// Stores expected inputs (asserted in `run`) and canned outputs (returned
+    /// from `run`).
+    struct MockSession {
+        expected_input_count: usize,
+        canned_outputs: Vec<(String, OnnxOutputTensor)>,
+    }
+
+    impl OnnxSession for MockSession {
+        fn run(&mut self, inputs: OnnxInputs<'_>) -> Result<OnnxOutputs, DecibriError> {
+            assert_eq!(
+                inputs.items.len(),
+                self.expected_input_count,
+                "MockSession got unexpected number of inputs"
+            );
+            let mut tensors = Vec::with_capacity(self.canned_outputs.len());
+            for (name, t) in self.canned_outputs.iter() {
+                let cloned = OnnxOutputTensor {
+                    shape: t.shape.clone(),
+                    data: match &t.data {
+                        OnnxTensorOwned::F32(v) => OnnxTensorOwned::F32(v.clone()),
+                        OnnxTensorOwned::I64(v) => OnnxTensorOwned::I64(v.clone()),
+                    },
+                };
+                tensors.push((name.clone(), cloned));
+            }
+            Ok(OnnxOutputs { tensors })
+        }
+    }
+
+    #[test]
+    fn mock_session_round_trip() {
+        let canned = vec![(
+            "output".to_string(),
+            OnnxOutputTensor {
+                shape: vec![1, 1],
+                data: OnnxTensorOwned::F32(vec![0.42]),
+            },
+        )];
+        let mut session: Box<dyn OnnxSession> = Box::new(MockSession {
+            expected_input_count: 3,
+            canned_outputs: canned,
+        });
+        let audio = vec![0.0f32; 512];
+        let state = vec![0.0f32; 256];
+        let sr = vec![16000i64];
+        let inputs = OnnxInputs {
+            items: &[
+                (
+                    "input",
+                    OnnxTensorView {
+                        shape: &[1, 512],
+                        data: OnnxTensorData::F32(&audio),
+                    },
+                ),
+                (
+                    "state",
+                    OnnxTensorView {
+                        shape: &[2, 1, 128],
+                        data: OnnxTensorData::F32(&state),
+                    },
+                ),
+                (
+                    "sr",
+                    OnnxTensorView {
+                        shape: &[1],
+                        data: OnnxTensorData::I64(&sr),
+                    },
+                ),
+            ],
+        };
+        let outputs = session.run(inputs).expect("MockSession should succeed");
+        assert_eq!(outputs.tensors.len(), 1);
+        let probe = outputs.get("output").expect("output present");
+        assert_eq!(probe.shape, vec![1, 1]);
+        match &probe.data {
+            OnnxTensorOwned::F32(v) => assert_eq!(v.as_slice(), &[0.42f32]),
+            OnnxTensorOwned::I64(_) => panic!("expected F32"),
+        }
+    }
+
+    #[test]
+    fn output_lookup_by_name_returns_none_for_missing() {
+        let outputs = OnnxOutputs {
+            tensors: vec![(
+                "output".to_string(),
+                OnnxOutputTensor {
+                    shape: vec![1],
+                    data: OnnxTensorOwned::F32(vec![1.0]),
+                },
+            )],
+        };
+        assert!(outputs.get("output").is_some());
+        assert!(outputs.get("not_a_name").is_none());
+    }
+
+    #[test]
+    fn input_slice_preserves_order_and_names() {
+        let a = vec![1.0f32, 2.0, 3.0];
+        let b = vec![10i64, 20];
+        let inputs = OnnxInputs {
+            items: &[
+                (
+                    "first",
+                    OnnxTensorView {
+                        shape: &[3],
+                        data: OnnxTensorData::F32(&a),
+                    },
+                ),
+                (
+                    "second",
+                    OnnxTensorView {
+                        shape: &[2],
+                        data: OnnxTensorData::I64(&b),
+                    },
+                ),
+            ],
+        };
+        assert_eq!(inputs.items.len(), 2);
+        assert_eq!(inputs.items[0].0, "first");
+        assert_eq!(inputs.items[1].0, "second");
+        match inputs.items[0].1.data {
+            OnnxTensorData::F32(s) => assert_eq!(s, a.as_slice()),
+            OnnxTensorData::I64(_) => panic!("expected F32"),
+        }
+        match inputs.items[1].1.data {
+            OnnxTensorData::I64(s) => assert_eq!(s, b.as_slice()),
+            OnnxTensorData::F32(_) => panic!("expected I64"),
+        }
+    }
+
+    /// ORT-backed round trip: load the bundled Silero model, construct an
+    /// [`OnnxSession`] via [`OnnxSessionBuilder::build`], run a single
+    /// inference with deterministic zero-filled inputs, verify output
+    /// structure (shape + dtype) without asserting exact values.
+    ///
+    /// The entire `onnx` module is `#[cfg(feature = "vad")]`-gated, so this
+    /// test only runs with vad enabled (which is the default feature set).
+    #[test]
+    fn ort_backed_session_runs_silero_inference() {
+        use std::path::Path;
+
+        // Resolve model relative to the workspace root, matching the pattern
+        // already used in `vad.rs::tests::model_path`.
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let model = Path::new(manifest_dir)
+            .join("..")
+            .join("..")
+            .join("models")
+            .join("silero_vad.onnx");
+        if !model.is_file() {
+            eprintln!(
+                "skipping ort_backed_session_runs_silero_inference: model not found at {}",
+                model.display()
+            );
+            return;
+        }
+
+        // ORT must be initialized exactly once per process. Reuse the same
+        // `init_ort_once` path that `vad.rs` uses so this test composes with
+        // the existing VAD tests in the same `cargo test` invocation.
+        crate::vad::init_ort_once(None).expect("ORT init should succeed");
+
+        let mut session = OnnxSessionBuilder::from_file(&model)
+            .with_intra_threads(1)
+            .build()
+            .expect("ORT session build should succeed for bundled model");
+
+        let audio = vec![0.0f32; 512];
+        let state = vec![0.0f32; 256];
+        let sr = vec![16000i64];
+        let outputs = session
+            .run(OnnxInputs {
+                items: &[
+                    (
+                        "input",
+                        OnnxTensorView {
+                            shape: &[1, 512],
+                            data: OnnxTensorData::F32(&audio),
+                        },
+                    ),
+                    (
+                        "state",
+                        OnnxTensorView {
+                            shape: &[2, 1, 128],
+                            data: OnnxTensorData::F32(&state),
+                        },
+                    ),
+                    (
+                        "sr",
+                        OnnxTensorView {
+                            shape: &[1],
+                            data: OnnxTensorData::I64(&sr),
+                        },
+                    ),
+                ],
+            })
+            .expect("ORT session run should succeed");
+
+        let probe = outputs
+            .get("output")
+            .expect("Silero emits an `output` tensor");
+        match &probe.data {
+            OnnxTensorOwned::F32(v) => assert_eq!(v.len(), 1, "Silero `output` is one f32"),
+            OnnxTensorOwned::I64(_) => panic!("Silero `output` is f32, not i64"),
+        }
+        let state_n = outputs
+            .get("stateN")
+            .expect("Silero emits a `stateN` tensor");
+        match &state_n.data {
+            OnnxTensorOwned::F32(v) => assert_eq!(v.len(), 256, "Silero `stateN` is 256 f32s"),
+            OnnxTensorOwned::I64(_) => panic!("Silero `stateN` is f32, not i64"),
+        }
+    }
+}

--- a/crates/decibri/src/vad.rs
+++ b/crates/decibri/src/vad.rs
@@ -21,6 +21,10 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use crate::error::DecibriError;
+#[cfg(feature = "vad")]
+use crate::onnx::{
+    OnnxInputs, OnnxSession, OnnxSessionBuilder, OnnxTensorData, OnnxTensorOwned, OnnxTensorView,
+};
 
 /// Configuration for Silero VAD.
 #[derive(Debug, Clone)]
@@ -104,7 +108,11 @@ pub struct VadResult {
 /// Call `process()` with each audio chunk. Call `reset()` to clear state.
 #[cfg(feature = "vad")]
 pub struct SileroVad {
-    session: ort::session::Session,
+    /// ONNX session abstracted behind the internal [`OnnxSession`] trait
+    /// (Phase 8). In 3.x this is always the ORT-backed implementation; the
+    /// trait exists so future backends (CoreML, TFLite, GPU EPs) can plug
+    /// in without changing this struct or any consumer code.
+    session: Box<dyn OnnxSession>,
     /// Combined LSTM state [2, 1, 128] = 256 floats.
     state: Vec<f32>,
     sample_rate: u32,
@@ -184,7 +192,7 @@ fn do_ort_init(_path: Option<&Path>) -> Result<bool, ort::Error> {
 /// wrapping pattern elsewhere or the `decibri:` prefix and guidance string
 /// will be duplicated in the message users see.
 #[cfg(feature = "vad")]
-fn init_ort_once(path: Option<&Path>) -> Result<(), DecibriError> {
+pub(crate) fn init_ort_once(path: Option<&Path>) -> Result<(), DecibriError> {
     // Fast path: ORT already initialized.
     if ORT_INIT.get().is_some() {
         return Ok(());
@@ -240,18 +248,15 @@ impl SileroVad {
         // instances pass through immediately regardless of their ort_library_path.
         init_ort_once(config.ort_library_path.as_deref())?;
 
-        let session = ort::session::Session::builder()
-            .map_err(DecibriError::OrtSessionBuildFailed)?
-            // `with_intra_threads` returns `ort::Error<SessionBuilder>`; use a
-            // closure with `.into()` to convert to `ort::Error<()>` via the
-            // upstream `From<Error<SessionBuilder>> for Error<()>` impl.
+        // Phase 8: session construction goes through the internal
+        // `OnnxSession` trait. The ORT-backed implementation is the only
+        // backend in 3.x; the trait exists so future backends (CoreML at
+        // iOS time, TFLite at Android time, GPU EPs at the P4 GPU project)
+        // plug in without changing this construction site. See
+        // `crates/decibri/src/onnx.rs` and Phase 8 LD15.
+        let session = OnnxSessionBuilder::from_file(config.model_path.clone())
             .with_intra_threads(1)
-            .map_err(|e| DecibriError::OrtThreadsConfigFailed(e.into()))?
-            .commit_from_file(&config.model_path)
-            .map_err(|e| DecibriError::VadModelLoadFailed {
-                path: config.model_path.clone(),
-                source: e,
-            })?;
+            .build()?;
 
         Ok(Self {
             session,
@@ -305,59 +310,77 @@ impl SileroVad {
     }
 
     /// Run inference on a single window of exactly `window_size` samples.
+    ///
+    /// Phase 8: inference goes through the internal [`OnnxSession`] trait
+    /// (`Box<dyn OnnxSession>` field on `Self`) rather than calling
+    /// `ort::Session` directly. The trait owns the marshaling between
+    /// borrowed input slices and the backend's native tensor types.
     fn infer_window(&mut self, window: &[f32]) -> Result<f32, DecibriError> {
-        // Create input tensors using actual model tensor names:
-        //   input: f32[1, window_size]
-        //   state: f32[2, 1, 128]
-        //   sr:    i64 scalar
-        let input_tensor =
-            ort::value::Tensor::from_array(([1i64, self.window_size as i64], window.to_vec()))
-                .map_err(|e| DecibriError::OrtTensorCreateFailed {
-                    kind: "input",
-                    source: e,
-                })?;
-        let state_tensor =
-            ort::value::Tensor::from_array(([2i64, 1i64, 128i64], self.state.clone())).map_err(
-                |e| DecibriError::OrtTensorCreateFailed {
-                    kind: "state",
-                    source: e,
-                },
-            )?;
-        let sr_tensor = ort::value::Tensor::from_array(([1i64], vec![self.sample_rate as i64]))
-            .map_err(|e| DecibriError::OrtTensorCreateFailed {
-                kind: "sr",
-                source: e,
-            })?;
+        let input_shape = [1i64, self.window_size as i64];
+        let state_shape = [2i64, 1i64, 128i64];
+        let sr_shape = [1i64];
+        let sr_data = [self.sample_rate as i64];
 
-        let input_values = ort::inputs![
-            "input" => input_tensor,
-            "state" => state_tensor,
-            "sr" => sr_tensor,
-        ];
-
-        let outputs = self
-            .session
-            .run(input_values)
-            .map_err(DecibriError::OrtInferenceFailed)?;
+        let outputs = self.session.run(OnnxInputs {
+            items: &[
+                (
+                    "input",
+                    OnnxTensorView {
+                        shape: &input_shape,
+                        data: OnnxTensorData::F32(window),
+                    },
+                ),
+                (
+                    "state",
+                    OnnxTensorView {
+                        shape: &state_shape,
+                        data: OnnxTensorData::F32(&self.state),
+                    },
+                ),
+                (
+                    "sr",
+                    OnnxTensorView {
+                        shape: &sr_shape,
+                        data: OnnxTensorData::I64(&sr_data),
+                    },
+                ),
+            ],
+        })?;
 
         // Read outputs using actual model tensor names:
         //   output: f32[1, 1] (speech probability)
         //   stateN: f32[2, 1, 128] (updated state)
-        let prob_tensor = outputs["output"].try_extract_tensor::<f32>().map_err(|e| {
-            DecibriError::OrtTensorExtractFailed {
-                kind: "output",
-                source: e,
+        let prob = outputs
+            .get("output")
+            .ok_or_else(|| DecibriError::OnnxBackendFailed {
+                backend: "ort",
+                source: "Silero output `output` missing from session run".into(),
+            })?;
+        let probability = match &prob.data {
+            OnnxTensorOwned::F32(v) => v[0],
+            OnnxTensorOwned::I64(_) => {
+                return Err(DecibriError::OnnxBackendFailed {
+                    backend: "ort",
+                    source: "Silero output `output` must be f32".into(),
+                });
             }
-        })?;
-        let probability = prob_tensor.1[0];
+        };
 
-        let state_tensor = outputs["stateN"].try_extract_tensor::<f32>().map_err(|e| {
-            DecibriError::OrtTensorExtractFailed {
-                kind: "state",
-                source: e,
+        let state_n = outputs
+            .get("stateN")
+            .ok_or_else(|| DecibriError::OnnxBackendFailed {
+                backend: "ort",
+                source: "Silero output `stateN` missing from session run".into(),
+            })?;
+        match &state_n.data {
+            OnnxTensorOwned::F32(v) => self.state.copy_from_slice(v),
+            OnnxTensorOwned::I64(_) => {
+                return Err(DecibriError::OnnxBackendFailed {
+                    backend: "ort",
+                    source: "Silero output `stateN` must be f32".into(),
+                });
             }
-        })?;
-        self.state.copy_from_slice(state_tensor.1);
+        }
 
         Ok(probability)
     }


### PR DESCRIPTION
Phase 8 of the Python Integration Project. The first phase that touches Rust core meaningfully; all previous phases (1 through 7.7) were binding-layer or infrastructure. Adds `pub(crate) OnnxSession` trait inside `crates/decibri` to abstract ONNX Runtime usage. SileroVad migrates to consume the trait through `Box<dyn OnnxSession>`. ORT-backed implementation is the only impl in 3.x; future backends (CoreML at iOS time, TFLite at Android time, GPU EPs at P4) plug in additively at the workspace split.

Driven by an empirical-first prep research investigation (`phase-8-prep-research.md`) that confirmed outcome (i) clean against `vad.rs`'s actual call pattern and against external research on CoreML / TFLite / GPU EP ecosystems. The trait shape is bottom-up matched to the four operations `vad.rs` actually performs, not speculated from first principles.

## Trait shape

Per `phase-8-prep-research.md` Section 4.1:

- **Closed-enum tensor data** (`OnnxTensorData<'a>` with F32 / I64 variants over slice borrows). Avoids pulling `ndarray` in as a workspace dependency just for the trait. Adding F16 / I32 variants later is a closed-enum change but a pre-1.0 acceptable break under LD-8-1.
- **Borrowed slice of named-input tuples** (`OnnxInputs<'a>`). Zero allocation on inputs; matches `vad.rs`'s ~50 calls/sec hot path without surprises.
- **Owned named-output bag** (`OnnxOutputs` with `get(name)` lookup). One allocation per output tensor. Allows `&mut self` `run` without HRTB or GAT gymnastics.
- **`Send + Sync` bounds** satisfied natively by ORT's `Session` per `docs.rs`.
- **Single trait method:** `run(&mut self, inputs: OnnxInputs<'_>) -> Result<OnnxOutputs, DecibriError>`. Reuses existing error type.

`OnnxSessionBuilder` is a concrete struct (not a trait); backend dispatch happens at `build()` time. Returns `Box<dyn OnnxSession>` so future backends can swap in at 0.3.0+ without changing the builder's signature.

## Implementation

`OrtSession` implementation handles the four operations `vad.rs` actually performs: `Session::builder` + `with_intra_threads` + `commit_from_file`; `ort::Tensor::from_array` marshaling for F32 and I64 inputs; `session.run` with runtime ValueMap path (Silero's 3 inputs fit cleanly; const-generic-N path lands in 0.2.0+ if measurement shows it matters); `Value::dtype().tensor_type()` dispatch + `try_extract_tensor` + copy into owned `Vec`.

`SileroVad` migration replaces direct `ort::session::Session` ownership with `Box<dyn OnnxSession>`. Net change: -56 / +69 lines. The expansion over the original plan estimate (-40 / +30) is intentional: pattern-match safety on `OnnxTensorOwned` for I64 outputs (trait must support I64 even though Silero only emits F32) plus typed `OnnxBackendFailed` errors if a backend ever returns the wrong dtype.

`DecibriError` gains an additive `OnnxBackendFailed` variant for future non-ORT backends. The enum is `#[non_exhaustive]`, so this is permitted; the existing 8 ORT variants are unchanged.

`vad::init_ort_once` visibility raised from private to `pub(crate)` so the `onnx` test module can reuse the same process-global init path.

Integration tests live inline in `onnx.rs` under `#[cfg(test)] mod tests` rather than `tests/onnx_trait.rs`. Required by `pub(crate)` visibility (LD-8-1): integration-test crates cannot see `pub(crate)` items, so an inline module is the canonical Rust pattern. Test coverage matches the original intent: MockSession round-trip, named input/output access, `Send + Sync` compile-time assertion on `Box<dyn OnnxSession>`, ORT-backed Silero VAD model load and single inference.

## Cross-binding compat

Per LD-8-1 and LD-8-8: Rust core 3.x public API stays byte-identical. `SileroVad`, `VadConfig`, `VadResult`, `DecibriError` keep their Phase 7.x signatures. `DecibriError`'s additive variant is permitted by the existing `#[non_exhaustive]` annotation.

The trait is `pub(crate)`. Goes public at 4.0 / 0.3.0+ Python release / `decibri-onnx` workspace split. npm, Python binding, and browser shim bindings are unchanged.

## Verified

- Rust unit tests: 42 → 47 (+5 new ONNX trait tests)
- Rust integration tests: 4 (unchanged; all pass through migrated path)
- Node CI tests: 44/44
- Browser shim vitest: 64/64
- Python pytest: 150 passed, 70 hardware-skipped
- Python mypy --strict: clean
- cargo build --release -p decibri: clean
- cargo clippy --workspace -- -D warnings: clean
- cargo fmt --all -- --check: clean
- cargo test-decibri: all green
- Em-dash sweep across `crates/decibri/`: 0 hits
- General push CI: all green
- Python 8-run matrix: all green

## Version bump

`decibri` 3.3.2 → 3.4.0 minor bump per LD-8-2. The crate's *public* API stays unchanged (verifiable with `cargo public-api`); the bump signals to consumers that something substantive happened internally. Patch (3.3.3) would imply "bug fix" which understates the change. `bindings/python/Cargo.toml`'s path-dep version pin updated to match.

A follow-up commit on this branch updates two hardcoded version assertions in `bindings/python/tests/test_smoke.py` (lines 55-57 and 73). Both tests deliberately pin the version per their own docstrings: "When the Rust workspace bumps past 3.3.2 this assertion breaks deliberately: force a conscious update of the Python test expectation alongside the Rust version bump." This commit is that conscious update.

## Locked decisions resolved (added to master plan)

**LD15:** OnnxSession trait shape and visibility, with sub-decisions LD-8-1 through LD-8-11 captured. The trait is `pub(crate)` in 3.x; goes public at 4.0 / `decibri-onnx` workspace split. Closed-enum tensor data over associated types or trait objects. `DecibriError` reused (no new error type). `Box<dyn OnnxSession>` from the builder enables backend dispatch at 0.3.0+. CoreML and TFLite native impls deferred (out of Phase 8 scope; trait designed to be hospitable when those ecosystems mature). GPU EP API surface entirely deferred to P4. `OnnxSessionBuilder::with_execution_providers([EP])` deferred to 0.3.0+ as additive non-breaking enhancement when the trait goes public.

## Items deliberately NOT in scope

CoreML native impl (out of Phase 8; practical iOS path is ORT's CoreML EP feature flag); TFLite native impl (Rust ecosystem not ready in 2026); GPU EP API surface (P4 territory); public exposure of the trait (4.0 work); `with_execution_providers([EP])` on the builder (0.3.0+, additive); `run_async` on the trait (deferrable; default method later); zero-copy output extraction (Whisper-class workloads only); workspace split (post-Phase-8, pre-1.0); process-global `ort::init` placement changes; `Drop` on the trait.

## Implementation report

Full implementation details, validation gate output, surprises, and per-step results are captured in `~/.claude/plans/phase-8-implementation-report.md`. Master plans (`python-integration-project.md` and `decibri-master-plan-v3-draft.md`) and 0.2.0 backlog (`0-2-0-backlog.md`) updated to reflect Phase 8 ship.

After this PR squash-merges, Phase 8 is complete. **Phase 9 (ecosystem coexistence: Jupyter, Docker, multiprocessing) is the next active phase.**