### PR TITLE
Phase 9: Ecosystem coexistence (Jupyter, Docker, multiprocessing) (7 items)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DeviceError` catch-target intermediate (subclass of `DecibriError`, parent of all eight device-related exceptions: `DeviceNotFound`, `OutputDeviceNotFound`, `MultipleDevicesMatch`, `DeviceIndexOutOfRange`, `NoMicrophoneFound`, `NoOutputDeviceFound`, `NotAnInputDevice`, `DeviceEnumerationFailed`). Symmetric with `OrtError` and `OrtPathError`. Existing catches via `DecibriError` remain unchanged (parent chain preserved).
 - Re-entry contract documented and pinned by tests on `Microphone.start()`, `Speaker.start()`, `AsyncMicrophone.start()`, `AsyncSpeaker.start()`. Calling `start()` after `stop()` / `close()` reconstructs the underlying audio stream cleanly; VAD state resets on each new `start()`. Calling `start()` while already started raises `AlreadyRunning`.
 
+### Python binding (0.1.0a1) - Phase 9 ecosystem coexistence
+
+#### Added
+
+- `__repr__` on `Microphone`, `Speaker`, `AsyncMicrophone`, and `AsyncSpeaker` (Phase 9 Item A4). Shows construction parameters plus current `is_open` / `is_playing` state (e.g., `Microphone(sample_rate=16000, channels=1, dtype='int16', frames_per_buffer=1600, device=None, vad=False, is_open=False)`). Closes the Jupyter auto-display gap.
+- `AsyncMicrophone.open(**kwargs)` and `AsyncSpeaker.open(**kwargs)` async classmethod factories (Phase 9 Item A6). Dispatch synchronous construction to the default `ThreadPoolExecutor` via `loop.run_in_executor`, returning the constructed instance awaitably. Recommended in async contexts when `vad="silero"` is enabled (the synchronous constructor performs 100 to 500 ms of ORT model loading inline). Synchronous constructors remain supported and unchanged.
+- `ForkAfterOrtInit(DecibriError)` exception (Phase 9 Item C7). Raised on Linux when `Microphone(vad="silero")` is constructed in a parent process and then used in a forked child. Replaces silent ONNX Runtime corruption with a clean exception carrying a self-documenting remediation message (use `multiprocessing.set_start_method('spawn')` or construct VAD inside the worker). Direct `DecibriError` subclass, NOT under `OrtError` (it is a usage error rather than an ORT-internal error). `__all__` count: 17 -> 18.
+- Three docs files under `bindings/python/docs/ecosystem/`: `jupyter.md` (top-level await coexistence; auto-display behavior; kernel restart safety; logging guidance; VAD-load timing reference); `docker.md` (verified Dockerfiles for base / headless / audio scenarios; the three required flags for audio passthrough; the headless ALSA `null` device nuance; image size budget; PipeWire / PulseAudio coexistence); `multiprocessing.md` (spawn vs fork guidance; `ForkAfterOrtInit` raise behavior; pickling failure mode; recommended worker pattern; decision matrix).
+- Three reference Dockerfiles at `bindings/python/docs/ecosystem/docker/`: `Dockerfile.base`, `Dockerfile.headless`, `Dockerfile.audio`. Multi-stage builds (Rust + maturin builder stage; `python:3.12-slim` runtime stage) verified against Docker Desktop 4.71.
+
+#### Changed
+
+- `AsyncMicrophone.__init__` and `AsyncSpeaker.__init__` docstrings now point users at `AsyncMicrophone.open()` / `AsyncSpeaker.open()` for async contexts, replacing the previous "0.2.0+ roadmap" note.
+
+#### Internal
+
+- New `static ORT_INIT_PID: OnceLock<u32>` in `crates/decibri/src/vad.rs` paired with the existing `ORT_INIT`. Captured inside the ORT init success path; compared at every `SileroVad::process()` call by the new `check_pid_for_ort()` helper. Detects Linux `fork()`-after-init silent ORT corruption and raises `DecibriError::ForkAfterOrtInit { init_pid, current_pid }`.
+- New `DecibriError::ForkAfterOrtInit { init_pid: u32, current_pid: u32 }` variant. Permitted by `#[non_exhaustive]`; existing variants unchanged.
+- New `bindings/python/tests/test_repr.py` (8 tests) and `bindings/python/tests/test_fork_safety.py` (3 Linux-only tests gated by `pytest.mark.skipif(sys.platform != "linux")` + `requires_bundled_ort`). 5 new tests appended to `tests/test_async.py` for `AsyncMicrophone.open` / `AsyncSpeaker.open` behavior.
+
 ## [3.4.0] - 2026-05-02
 
 ### Added

--- a/bindings/python/docs/ecosystem/docker.md
+++ b/bindings/python/docs/ecosystem/docker.md
@@ -1,0 +1,193 @@
+# decibri in Docker containers
+
+decibri runs cleanly in Linux containers. The integration points worth knowing about are the runtime ALSA library (always required, even headless), the audio device passthrough flags (three of them, not one), and the headless behavior on hosts without `/dev/snd` (cpal exposes a null device, not an empty list).
+
+This document covers the patterns verified in the Phase 9 implementation against Docker Desktop 4.71 (Server: linux/amd64, Engine 29.4.1, manylinux_2_34 wheel built inline). Reference Dockerfiles ship under `bindings/python/docs/ecosystem/docker/`.
+
+## Platform constraint
+
+`--device /dev/snd` is a Linux-host concept. Docker Desktop on Windows or macOS runs containers in a Linux VM that has no bridge to the host audio device, so the audio-passthrough scenario is end-to-end verifiable on Linux hosts only. The image itself builds and runs anywhere Docker runs; only the audio-passthrough integration is Linux-host-only.
+
+The base and headless scenarios in this document are verified on Docker Desktop 4.71 (Windows host, WSL2 Linux backend); the audio-passthrough scenario is verified for image build and structural correctness only. Phase 11 adds a Linux-host validation note from a CI runner or production deployment.
+
+## Base scenario: minimal install + version smoke check
+
+Until 0.1.0 ships to PyPI, the minimal Dockerfile is multi-stage: a builder stage that compiles the wheel from source via maturin, and a slim runtime stage that pip-installs the wheel. After PyPI publish (Phase 11), the runtime stage is reduced to a single `pip install decibri` line.
+
+[Dockerfile.base](docker/Dockerfile.base):
+
+```dockerfile
+ARG ORT_VERSION=1.24.4
+
+FROM rust:1-bookworm AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 python3-pip python3-venv pkg-config libasound2-dev curl patchelf \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . /src
+
+# Stage the per-platform ONNX Runtime dylib into the wheel's resource
+# directory before maturin runs (matches python-ci.yml manylinux step).
+ARG ORT_VERSION
+RUN ORT_TARBALL="onnxruntime-linux-x64-${ORT_VERSION}.tgz" \
+    && curl -sL --retry 3 --retry-delay 2 \
+        -o /tmp/ort.tgz \
+        "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/${ORT_TARBALL}" \
+    && tar -xzf /tmp/ort.tgz -C /tmp \
+    && mkdir -p /src/bindings/python/python/decibri/_ort \
+    && cp -L "/tmp/onnxruntime-linux-x64-${ORT_VERSION}/lib/libonnxruntime.so" \
+        /src/bindings/python/python/decibri/_ort/libonnxruntime.so \
+    && cp "/tmp/onnxruntime-linux-x64-${ORT_VERSION}/lib/libonnxruntime_providers_shared.so" \
+        /src/bindings/python/python/decibri/_ort/
+
+RUN python3 -m venv /opt/build-venv \
+    && /opt/build-venv/bin/pip install --upgrade pip maturin \
+    && cd /src/bindings/python \
+    && /opt/build-venv/bin/maturin build --release
+
+FROM python:3.12-slim AS runtime
+
+# libasound2 is the runtime ALSA library cpal loads at first device
+# enumeration on Linux; required even in headless deployments.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libasound2 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /src/target/wheels/*manylinux*.whl /tmp/
+RUN pip install --no-cache-dir /tmp/decibri-*.whl && rm /tmp/decibri-*.whl
+
+CMD ["python", "-c", "import decibri\nprint('decibri', decibri.__version__)\nv = decibri.version()\nprint(v)\n"]
+```
+
+Build and run:
+
+```bash
+docker build -t decibri:base -f bindings/python/docs/ecosystem/docker/Dockerfile.base .
+docker run --rm decibri:base
+```
+
+Verified output (Docker Desktop 4.71, manylinux_2_34 wheel):
+
+```
+decibri 0.1.0a1
+VersionInfo(decibri='3.4.0', audio_backend='cpal 0.17', binding='0.1.0a1')
+```
+
+Image size: ~255 MB (`python:3.12-slim` ~50 MB + libasound2 ~3 MB + decibri wheel including bundled ORT ~50 MB + Python stdlib runtime). Well under typical production image budgets.
+
+## Headless scenario: no audio passthrough
+
+For batch processors, CI runners, and VAD-only pipelines that operate on pre-recorded audio bytes, run the container without `--device /dev/snd`. The image is identical to the base; only the runtime invocation differs.
+
+[Dockerfile.headless](docker/Dockerfile.headless) is structurally identical to the base; the difference is in expected behavior at runtime.
+
+```bash
+docker run --rm decibri:headless
+```
+
+Verified output (Docker Desktop 4.71, no audio passthrough):
+
+```
+input_devices: [DeviceInfo(index=0, name='Discard all samples (playback) or generate zero samples (capture)', id='alsa:null', max_input_channels=2, default_sample_rate=44100, is_default=false)]
+output_devices: [OutputDeviceInfo(index=0, name='Discard all samples (playback) or generate zero samples (capture)', id='alsa:null', max_output_channels=2, default_sample_rate=44100, is_default=false)]
+Microphone() constructed UNEXPECTEDLY in headless container
+```
+
+**Important nuance:** in a headless container ALSA exposes a `null` device (`alsa:null`) regardless of whether `/dev/snd` is passed through. cpal happily lists it as a device, and `decibri.Microphone()` will construct successfully selecting it as the default. Reading from a null-device-backed Microphone yields zero-valued samples; it does not raise.
+
+For deployments that want to fail loudly when no real audio device is available, check the device id explicitly:
+
+```python
+import decibri
+
+devs = decibri.input_devices()
+real_devs = [d for d in devs if d.id != "alsa:null"]
+if not real_devs:
+    raise RuntimeError(
+        "No real audio input device available. "
+        "If running in Docker, pass --device /dev/snd and --group-add audio."
+    )
+```
+
+For VAD-only pipelines that operate on pre-recorded audio bytes, the headless null device is irrelevant; you do not call `Microphone` at all and instead feed bytes to a `vad="silero"` pipeline directly via the SileroVad core API (or, in 0.2.0+, via a documented Python helper). The container needs only the runtime image; no audio passthrough flags.
+
+## Audio passthrough scenario: three flags, not one
+
+`--device /dev/snd` is necessary but not sufficient for audio capture in a non-root container. Three flags work in concert:
+
+| Flag                     | Why it is required                                              |
+| ------------------------ | --------------------------------------------------------------- |
+| `--device /dev/snd:/dev/snd` | Expose the host ALSA device nodes to the container.         |
+| `--group-add audio`      | Grant the container user audio group membership. Without this, non-root containers see the device files but `open(2)` returns `EPERM`. |
+| `-e ALSA_PCM_CARD=0`     | Pin cpal to the raw ALSA hardware device rather than the `default` PCM, which the host sound server (PipeWire / PulseAudio) holds exclusively. |
+
+[Dockerfile.audio](docker/Dockerfile.audio) builds a non-root image (`USER decibri`, uid 1000) so the `--group-add audio` flag is meaningful at run time.
+
+Build and run on a Linux host with audio:
+
+```bash
+docker build -t decibri:audio -f bindings/python/docs/ecosystem/docker/Dockerfile.audio .
+
+docker run --rm \
+    --device /dev/snd:/dev/snd \
+    --group-add audio \
+    -e ALSA_PCM_CARD=0 \
+    decibri:audio
+```
+
+Expected output on a Linux host with at least one audio device (build verified on Docker Desktop 4.71; end-to-end audio runtime verified separately on Linux host as a Phase 11 docs note):
+
+```
+input_devices count: <N>
+  - DeviceInfo(index=0, name='hw:0,0', ..., is_default=true)
+  - ...
+decibri version: VersionInfo(decibri='3.4.0', audio_backend='cpal 0.17', binding='0.1.0a1')
+```
+
+If `input_devices count: 1` and the single device id is `alsa:null`, audio passthrough is incomplete; check the three flags above.
+
+If the host audio gid does not match the conventional 29, use `--group-add $(getent group audio | cut -d: -f3)` instead of the literal `audio` name.
+
+If PipeWire or PulseAudio is running on the host and you want decibri to use the sound server's bridge rather than ALSA's `default`, mount the PulseAudio socket and set `device="pulse"` at the Python layer:
+
+```bash
+docker run --rm \
+    --device /dev/snd:/dev/snd \
+    --group-add audio \
+    -v /run/user/$(id -u)/pulse:/run/user/1000/pulse \
+    -e PULSE_SERVER=unix:/run/user/1000/pulse/native \
+    decibri:audio python -c "import decibri; print(decibri.Microphone(device='pulse'))"
+```
+
+PulseAudio socket integration is host-distro-specific; for production deployments with a strong opinion on backend, the cleaner path is to run decibri on bare metal or use ALSA passthrough with `ALSA_PCM_CARD` pinning.
+
+## Image size and layer breakdown
+
+Verified on Docker Desktop 4.71, all three images using `python:3.12-slim` runtime base:
+
+| Image                    | Size   | Notes                                                  |
+| ------------------------ | ------ | ------------------------------------------------------ |
+| `decibri:base`           | 255 MB | python:3.12-slim + libasound2 + decibri wheel          |
+| `decibri:headless`       | 255 MB | identical to base; differs only in expected behavior   |
+| `decibri:audio`          | 267 MB | base + alsa-utils + non-root user setup                |
+
+The bundled ORT dylib accounts for ~15 to 20 MB inside the wheel; the Python wheel itself ships at ~25 MB. A 0.2.0+ `decibri-no-ort` variant for `vad=False` / `vad="energy"` users would shave roughly 20 MB from the runtime layer; tracked in the 0.2.0 backlog.
+
+## Recommended deployment patterns
+
+| Use case                                | Pattern                                                    |
+| --------------------------------------- | ---------------------------------------------------------- |
+| Production live audio capture           | Linux host, ALSA passthrough with the three flags          |
+| Batch processing of pre-recorded audio  | Headless container; do not call `Microphone()`             |
+| CI runners, smoke tests                 | Headless container; use `vad="energy"` or pre-recorded bytes |
+| Local dev on macOS / Windows host       | Use the binding outside Docker; Docker Desktop has no audio bridge |
+
+## Reference Dockerfiles
+
+- [docker/Dockerfile.base](docker/Dockerfile.base)
+- [docker/Dockerfile.headless](docker/Dockerfile.headless)
+- [docker/Dockerfile.audio](docker/Dockerfile.audio)
+
+All three are verified to build cleanly against Docker Desktop 4.71 (Server: linux/amd64, Engine 29.4.1, BuildKit). The base and headless runtime behaviors are verified end-to-end; the audio-passthrough runtime requires a Linux host (Phase 11 verification).

--- a/bindings/python/docs/ecosystem/docker/Dockerfile.audio
+++ b/bindings/python/docs/ecosystem/docker/Dockerfile.audio
@@ -1,0 +1,88 @@
+# Dockerfile.audio: decibri in an audio-passthrough container.
+#
+# The image itself is identical in structure to Dockerfile.base; the audio
+# integration is supplied at `docker run` time via three flags. Documented
+# inline:
+#
+#   docker run --rm \
+#       --device /dev/snd:/dev/snd \
+#       --group-add audio \
+#       -e ALSA_PCM_CARD=0 \
+#       <image>
+#
+# Flag rationale:
+#   --device /dev/snd       expose the host ALSA device nodes.
+#   --group-add audio       grant the container user membership of the
+#                           audio group. Required when the image runs as
+#                           a non-root user (most production images do).
+#                           Use `--group-add $(getent group audio | cut -d: -f3)`
+#                           on hosts whose audio gid does not match the
+#                           default 29.
+#   -e ALSA_PCM_CARD=0      pin cpal to the raw ALSA hardware device
+#                           rather than the `default` PCM, which the host
+#                           sound server (PipeWire / PulseAudio) holds
+#                           exclusively. Alternative: pass `device="hw:0"`
+#                           to `Microphone(...)` at the Python layer.
+#
+# Platform constraint: this Dockerfile builds and the image runs anywhere
+# Docker runs, but `--device /dev/snd` requires a Linux host. Docker
+# Desktop on macOS or Windows runs containers in a Linux VM that has no
+# bridge to the host audio device, so the audio scenario is end-to-end
+# verifiable on Linux hosts only.
+#
+# Build context: project root.
+#   docker build -t decibri:audio -f Dockerfile.audio .
+
+ARG ORT_VERSION=1.24.4
+
+# ---------- Stage 1: build the wheel ----------
+FROM rust:1-bookworm AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 python3-pip python3-venv pkg-config libasound2-dev curl patchelf \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . /src
+
+ARG ORT_VERSION
+ENV ORT_VERSION=${ORT_VERSION}
+RUN ORT_TARBALL="onnxruntime-linux-x64-${ORT_VERSION}.tgz" \
+    && curl -sL --retry 3 --retry-delay 2 \
+        -o /tmp/ort.tgz \
+        "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/${ORT_TARBALL}" \
+    && tar -xzf /tmp/ort.tgz -C /tmp \
+    && mkdir -p /src/bindings/python/python/decibri/_ort \
+    && cp -L "/tmp/onnxruntime-linux-x64-${ORT_VERSION}/lib/libonnxruntime.so" \
+        /src/bindings/python/python/decibri/_ort/libonnxruntime.so \
+    && cp "/tmp/onnxruntime-linux-x64-${ORT_VERSION}/lib/libonnxruntime_providers_shared.so" \
+        /src/bindings/python/python/decibri/_ort/
+
+RUN python3 -m venv /opt/build-venv \
+    && /opt/build-venv/bin/pip install --upgrade pip maturin \
+    && cd /src/bindings/python \
+    && /opt/build-venv/bin/maturin build --release
+
+# ---------- Stage 2: slim runtime ----------
+FROM python:3.12-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libasound2 alsa-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Run as a non-root user to mirror production deployment patterns. The
+# `--group-add audio` flag at `docker run` time grants this user audio
+# group membership at container start.
+RUN useradd --create-home --shell /usr/sbin/nologin --uid 1000 decibri
+
+COPY --from=builder /src/target/wheels/*manylinux*.whl /tmp/
+RUN pip install --no-cache-dir /tmp/decibri-*.whl && rm /tmp/decibri-*.whl
+
+USER decibri
+WORKDIR /home/decibri
+
+# Audio smoke check: enumerate devices, expect at least one entry when
+# /dev/snd is passed through and audio group is granted. If devices is [],
+# audio passthrough is incomplete and the operator should consult the
+# three-flag documentation in docs/ecosystem/docker.md.
+CMD ["python", "-c", "import decibri\ndevs = decibri.input_devices()\nprint('input_devices count:', len(devs))\nfor d in devs:\n    print('  -', d)\nprint('decibri version:', decibri.version())\n"]

--- a/bindings/python/docs/ecosystem/docker/Dockerfile.base
+++ b/bindings/python/docs/ecosystem/docker/Dockerfile.base
@@ -1,0 +1,62 @@
+# Dockerfile.base: minimal decibri install + version smoke check.
+#
+# Multi-stage: stage 1 builds the wheel from source (until 0.1.0 ships to
+# PyPI; after that, the runtime stage simply runs `pip install decibri`).
+# Stage 2 is the slim runtime image users would actually deploy.
+#
+# Build context: project root (the directory containing crates/, bindings/,
+# Cargo.toml). Run from project root:
+#
+#   docker build -t decibri:base -f Dockerfile.base .
+
+ARG ORT_VERSION=1.24.4
+
+# ---------- Stage 1: build the wheel ----------
+FROM rust:1-bookworm AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 python3-pip python3-venv pkg-config libasound2-dev curl patchelf \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . /src
+
+# Stage the per-platform ONNX Runtime dylib into the wheel's resource
+# directory before maturin runs. Mirrors the python-ci.yml manylinux step:
+# decibri's default ort-load-dynamic feature expects libonnxruntime.so to
+# ship inside the wheel under decibri/_ort/. Without this, maturin builds
+# a wheel that has no bundled dylib and Silero VAD would only work when
+# DECIBRI_ORT_DYLIB_PATH or ORT_DYLIB_PATH is set externally.
+ARG ORT_VERSION
+ENV ORT_VERSION=${ORT_VERSION}
+RUN ORT_TARBALL="onnxruntime-linux-x64-${ORT_VERSION}.tgz" \
+    && curl -sL --retry 3 --retry-delay 2 \
+        -o /tmp/ort.tgz \
+        "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/${ORT_TARBALL}" \
+    && tar -xzf /tmp/ort.tgz -C /tmp \
+    && mkdir -p /src/bindings/python/python/decibri/_ort \
+    && cp -L "/tmp/onnxruntime-linux-x64-${ORT_VERSION}/lib/libonnxruntime.so" \
+        /src/bindings/python/python/decibri/_ort/libonnxruntime.so \
+    && cp "/tmp/onnxruntime-linux-x64-${ORT_VERSION}/lib/libonnxruntime_providers_shared.so" \
+        /src/bindings/python/python/decibri/_ort/
+
+# Build the wheel via maturin in a dedicated venv (PEP 668 compliant).
+RUN python3 -m venv /opt/build-venv \
+    && /opt/build-venv/bin/pip install --upgrade pip maturin \
+    && cd /src/bindings/python \
+    && /opt/build-venv/bin/maturin build --release
+
+# ---------- Stage 2: slim runtime ----------
+FROM python:3.12-slim AS runtime
+
+# libasound2 is the runtime ALSA library cpal loads at first device
+# enumeration on Linux; install even in headless deployments because
+# importing decibri eagerly resolves the symbol via the cpal init path.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libasound2 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /src/target/wheels/*manylinux*.whl /tmp/
+RUN pip install --no-cache-dir /tmp/decibri-*.whl && rm /tmp/decibri-*.whl
+
+CMD ["python", "-c", "import decibri\nprint('decibri', decibri.__version__)\nv = decibri.version()\nprint(v)\n"]

--- a/bindings/python/docs/ecosystem/docker/Dockerfile.headless
+++ b/bindings/python/docs/ecosystem/docker/Dockerfile.headless
@@ -1,0 +1,55 @@
+# Dockerfile.headless: decibri in a no-audio container.
+#
+# Demonstrates the headless pattern: no `--device /dev/snd` passthrough,
+# no audio group, no PulseAudio socket. `decibri.input_devices()` returns
+# [] cleanly; constructing `Microphone()` raises `NoMicrophoneFound`.
+# Suitable for batch processors, CI runners, VAD-only pipelines that
+# operate on pre-recorded audio bytes.
+#
+# Build context: project root.
+#   docker build -t decibri:headless -f Dockerfile.headless .
+
+ARG ORT_VERSION=1.24.4
+
+# ---------- Stage 1: build the wheel ----------
+FROM rust:1-bookworm AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 python3-pip python3-venv pkg-config libasound2-dev curl patchelf \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . /src
+
+ARG ORT_VERSION
+ENV ORT_VERSION=${ORT_VERSION}
+RUN ORT_TARBALL="onnxruntime-linux-x64-${ORT_VERSION}.tgz" \
+    && curl -sL --retry 3 --retry-delay 2 \
+        -o /tmp/ort.tgz \
+        "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/${ORT_TARBALL}" \
+    && tar -xzf /tmp/ort.tgz -C /tmp \
+    && mkdir -p /src/bindings/python/python/decibri/_ort \
+    && cp -L "/tmp/onnxruntime-linux-x64-${ORT_VERSION}/lib/libonnxruntime.so" \
+        /src/bindings/python/python/decibri/_ort/libonnxruntime.so \
+    && cp "/tmp/onnxruntime-linux-x64-${ORT_VERSION}/lib/libonnxruntime_providers_shared.so" \
+        /src/bindings/python/python/decibri/_ort/
+
+RUN python3 -m venv /opt/build-venv \
+    && /opt/build-venv/bin/pip install --upgrade pip maturin \
+    && cd /src/bindings/python \
+    && /opt/build-venv/bin/maturin build --release
+
+# ---------- Stage 2: slim runtime, no audio passthrough expected ----------
+FROM python:3.12-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libasound2 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /src/target/wheels/*manylinux*.whl /tmp/
+RUN pip install --no-cache-dir /tmp/decibri-*.whl && rm /tmp/decibri-*.whl
+
+# Headless smoke check: enumerate devices (expected []), then attempt to
+# construct a Microphone (expected NoMicrophoneFound). Both outcomes are
+# clean failures, not hangs or undefined behavior.
+CMD ["python", "-c", "import decibri\nprint('input_devices:', decibri.input_devices())\nprint('output_devices:', decibri.output_devices())\ntry:\n    mic = decibri.Microphone()\n    print('Microphone() constructed UNEXPECTEDLY in headless container')\nexcept decibri.NoMicrophoneFound as exc:\n    print('Microphone() -> NoMicrophoneFound (clean failure):', exc)\nexcept decibri.DecibriError as exc:\n    print('Microphone() ->', type(exc).__name__, ':', exc)\n"]

--- a/bindings/python/docs/ecosystem/jupyter.md
+++ b/bindings/python/docs/ecosystem/jupyter.md
@@ -1,0 +1,125 @@
+# decibri in Jupyter notebooks
+
+decibri composes cleanly with the IPython kernel (ipykernel 7.x; IPython 9.x; verified 2026-05-02 against IPython 9.13.0 + ipykernel 7.2.0). The two integration points worth knowing about are the ambient asyncio event loop (top-level `await` works) and ORT model loading (use the async factory to avoid blocking cell rendering).
+
+This document covers the patterns verified in the Phase 9 prep research, with copy-paste examples that run end-to-end in a fresh notebook.
+
+## Top-level await works
+
+IPython 9 + ipykernel 7 runs a persistent asyncio event loop per kernel (`_WindowsSelectorEventLoop` on Windows; `_UnixSelectorEventLoop` on Linux/macOS). Any coroutine awaited at the top of a cell is scheduled on that loop. `decibri.AsyncMicrophone` and `decibri.AsyncSpeaker` cooperate with whatever loop ipykernel provides; you do not need `asyncio.run` and you should not call it inside a cell.
+
+```python
+# Cell 1
+import decibri
+
+amic = decibri.AsyncMicrophone(sample_rate=16000, channels=1)
+await amic.start()
+chunk = await amic.read(timeout_ms=1000)
+print(f"got {len(chunk)} bytes")
+await amic.stop()
+```
+
+```python
+# Cell 2
+async with decibri.AsyncMicrophone() as amic:
+    async for chunk in amic:
+        if chunk is None:
+            break
+        print(len(chunk))
+        if amic.is_speaking:
+            print("speech")
+        break  # one chunk for demo
+```
+
+Constructing a fresh `AsyncMicrophone` in a subsequent cell works without any loop-state cleanup; the wrapper does not cache the loop reference across constructions.
+
+## Use AsyncMicrophone.open() with vad="silero" in async cells
+
+`Microphone(vad="silero")` and `AsyncMicrophone(vad="silero")` perform synchronous ONNX Runtime model loading inside `__init__`, which takes 100 to 500 ms (CPU-bound; slower on cold disk caches). Calling the constructor from inside an `async` cell blocks the kernel's event loop for the duration of the load, which can stall other coroutines (websocket pings, timer callbacks, JupyterLab UI updates).
+
+The async factory `AsyncMicrophone.open()` (added in Phase 9) dispatches construction to the default ThreadPoolExecutor via `loop.run_in_executor`, returning the constructed instance awaitably.
+
+```python
+# Cell: prefer .open() over the constructor in async code
+import decibri
+
+# Blocks the event loop for ~100-500 ms. Acceptable for occasional
+# construction; not acceptable in latency-sensitive pipelines.
+amic = decibri.AsyncMicrophone(vad="silero")
+
+# Non-blocking; the construction runs in a worker thread.
+amic = await decibri.AsyncMicrophone.open(vad="silero")
+
+# Symmetric on AsyncSpeaker.
+spk = await decibri.AsyncSpeaker.open(sample_rate=24000)
+```
+
+The synchronous `__init__` constructor remains supported for back-compat and for users who construct outside an async context. After construction, `AsyncMicrophone.start()`, `read()`, `stop()`, and the async-context-manager / async-iterator protocols behave identically regardless of which factory was used.
+
+## Auto-display shows useful state
+
+A bare `Microphone` or `AsyncMicrophone` instance evaluated as the last expression in a cell auto-displays the `__repr__` (Phase 9 added a useful `__repr__` to all four wrapper classes). The repr shows construction parameters plus `is_open` so you can see at a glance whether the stream is currently running:
+
+```python
+# Cell: auto-display shows construction state
+mic = decibri.Microphone(sample_rate=24000, channels=2, vad="silero")
+mic
+# -> Microphone(sample_rate=24000, channels=2, dtype='int16',
+#               frames_per_buffer=1600, vad='silero', is_open=False)
+```
+
+After `mic.start()` (or entering the context manager), `is_open` flips to `True` and the repr reflects it.
+
+## Kernel restart and explicit cleanup
+
+When you click "Restart Kernel," the kernel process dies and the OS releases all of its resources, including any cpal audio streams and the ORT runtime. From decibri's perspective, kernel restart is safe; there is no cross-process state to clean up. The new kernel process starts fresh.
+
+That said, calling `mic.close()` (or `mic.stop()`; the two are aliases) explicitly before a long-running cell ends is a cleaner pattern than relying on the defensive `__del__` finalizer. The finalizer catches the common case of a cell that forgot the context manager, but it runs at arbitrary GC points and cannot raise.
+
+```python
+# Cell: explicit cleanup is the recommended pattern
+mic = decibri.Microphone()
+try:
+    mic.start()
+    chunk = mic.read(timeout_ms=1000)
+finally:
+    mic.close()  # alias for stop(); also called by __exit__
+```
+
+## Logging output
+
+Python `print()` and `logging` from your own code work normally; ipykernel captures stdout/stderr per cell. Rust-side `tracing` output (from inside the decibri binding) does not appear in cell output by default; it goes to the file descriptors the Jupyter server inherits, which usually means the terminal where you launched `jupyter lab` or `jupyter notebook`.
+
+To see decibri's Rust-side trace output, set `RUST_LOG` before launching the Jupyter server:
+
+```bash
+RUST_LOG=info jupyter lab    # Linux/macOS
+$env:RUST_LOG="info"; jupyter lab    # PowerShell
+```
+
+This is consistent with how every Rust-PyO3 binding behaves; it is a `tracing` subscriber configuration question, not a decibri-specific limitation.
+
+## Windows: zmq RuntimeWarning at kernel boot
+
+On Windows you may see a one-time `RuntimeWarning` from pyzmq at first kernel startup:
+
+```
+zmq/_future.py:718: RuntimeWarning: Proactor event loop does not implement
+add_reader family of methods required for zmq. Registering an additional
+selector thread for add_reader support via tornado.
+```
+
+This is a pyzmq + Windows + ipykernel issue; pyzmq emits the warning and falls back to a selector thread automatically. It does not affect decibri or your code; you can ignore it.
+
+## VAD-load timing reference
+
+For users tuning latency budgets:
+
+| Construction                          | Typical first-call cost | Subsequent constructions |
+| ------------------------------------- | ----------------------- | ------------------------ |
+| `Microphone()` (no VAD)               | <10 ms                  | <10 ms                   |
+| `Microphone(vad="energy")`            | <10 ms                  | <10 ms                   |
+| `Microphone(vad="silero")`            | 100 to 500 ms           | <10 ms                   |
+| `AsyncMicrophone.open(vad="silero")`  | 100 to 500 ms (offloaded) | <10 ms (offloaded)     |
+
+ONNX Runtime initialization is process-global; once the first `Microphone(vad="silero")` warms the runtime, subsequent constructions in the same kernel process see the cached state and complete in under 10 ms. Restarting the kernel resets this; the next construction pays the full first-call cost again.

--- a/bindings/python/docs/ecosystem/multiprocessing.md
+++ b/bindings/python/docs/ecosystem/multiprocessing.md
@@ -1,0 +1,230 @@
+# decibri with Python multiprocessing
+
+decibri composes cleanly with `multiprocessing.Process` and `concurrent.futures.ProcessPoolExecutor` when the `spawn` start method is used. On Linux, where the default start method is `fork`, decibri detects the dangerous case (Silero VAD initialized in the parent process before fork) and raises a clean `ForkAfterOrtInit` exception in the child rather than allowing silent ONNX Runtime corruption.
+
+This document covers the patterns verified in the Phase 9 prep research plus the Phase 9 fork-detection fix.
+
+## TL;DR
+
+- **`spawn` is safe for everything decibri does.** Recommended on all platforms.
+- **`fork` (Linux default) is safe ONLY if you do not touch Silero VAD before forking.** Construct `Microphone(vad="silero")` inside the child, never in the parent before fork.
+- **Pickling Microphone / Speaker / AsyncMicrophone / AsyncSpeaker raises `TypeError`.** Construct them inside worker processes; do not try to pass instances across process boundaries.
+
+## Spawn start method works for everything
+
+Verified on Windows (Phase 9 prep research; spawn is the only option) and consistent with the cross-platform Python multiprocessing semantics. Spawn re-imports your module in the child process and re-runs construction from scratch, so each child gets its own decibri state without inheriting anything from the parent.
+
+```python
+# spawn_basic.py: import + version in spawned children
+import multiprocessing as mp
+
+
+def child_work(_):
+    import decibri
+    info = decibri.version()
+    return f"{info.decibri}|{info.audio_backend}|{info.binding}"
+
+
+if __name__ == "__main__":
+    mp.set_start_method("spawn", force=True)
+    ctx = mp.get_context("spawn")
+    with ctx.Pool(processes=2) as pool:
+        for r in pool.map(child_work, range(2)):
+            print(r)
+```
+
+Verified output:
+
+```
+3.4.0|cpal 0.17|0.1.0a1
+3.4.0|cpal 0.17|0.1.0a1
+```
+
+The same pattern works for `Microphone`, `Speaker`, `AsyncMicrophone`, `AsyncSpeaker`, and `decibri.input_devices()`. Each child constructs its own bridge; no cross-process state is shared.
+
+## ProcessPoolExecutor works
+
+`concurrent.futures.ProcessPoolExecutor` uses `spawn` by default on Windows and macOS, and respects `mp.get_context("spawn")` everywhere:
+
+```python
+# pool_input_devices.py
+from concurrent.futures import ProcessPoolExecutor
+import multiprocessing as mp
+
+
+def list_devices(_):
+    import decibri
+    return len(decibri.input_devices())
+
+
+if __name__ == "__main__":
+    ctx = mp.get_context("spawn")
+    with ProcessPoolExecutor(max_workers=2, mp_context=ctx) as ex:
+        for n in ex.map(list_devices, range(2)):
+            print(f"worker saw {n} input devices")
+```
+
+## Pickling Microphone fails cleanly
+
+Microphone, Speaker, and their async counterparts cannot be pickled. The underlying cpal stream lives in process-local memory and cannot be sent across process boundaries; PyO3 pyclasses are non-picklable by default. Attempting to pickle raises a clean `TypeError`:
+
+```python
+# pickle_attempt.py
+import pickle
+import decibri
+
+try:
+    pickle.dumps(decibri.Microphone())
+except TypeError as exc:
+    print(f"pickle failed cleanly: {exc}")
+# -> pickle failed cleanly: cannot pickle 'decibri._decibri.MicrophoneBridge' object
+```
+
+This is the correct behavior; the failure mode is loud and the error message identifies the specific bridge class. The recommended pattern is to construct decibri objects inside the worker process and stream raw audio bytes back through a `multiprocessing.Queue`.
+
+## Recommended pattern: construct inside the worker
+
+```python
+# producer_worker.py: capture in the worker, send bytes back via Queue
+import multiprocessing as mp
+
+
+def producer(queue, duration_seconds: float):
+    import decibri
+    with decibri.Microphone(sample_rate=16000, channels=1) as mic:
+        chunks_per_second = 10  # 100 ms chunks at 16 kHz with 1600 frames buffer
+        for _ in range(int(duration_seconds * chunks_per_second)):
+            chunk = mic.read(timeout_ms=2000)
+            if chunk is None:
+                break
+            queue.put(chunk)
+    queue.put(None)  # sentinel
+
+
+if __name__ == "__main__":
+    mp.set_start_method("spawn", force=True)
+    ctx = mp.get_context("spawn")
+    queue = ctx.Queue(maxsize=64)
+    proc = ctx.Process(target=producer, args=(queue, 3.0))
+    proc.start()
+    total_bytes = 0
+    while True:
+        chunk = queue.get()
+        if chunk is None:
+            break
+        total_bytes += len(chunk)
+    proc.join()
+    print(f"received {total_bytes} bytes from worker")
+```
+
+The same shape works for any consumer-producer split: capture in one worker, ML inference in another, output playback in a third, all communicating via `multiprocessing.Queue` with raw `bytes` payloads.
+
+## Linux fork() and Silero VAD: ForkAfterOrtInit
+
+ONNX Runtime is not safe to share across forked processes. The runtime's internal state (thread pools, allocators, model graph state) is initialized in the parent's address space and is not transparently fork-safe. A child that inherits an ORT-initialized parent and then calls `session.run` produces silent wrong answers, segfaults, or hangs depending on the specific configuration.
+
+Phase 9 added proactive detection: decibri records the parent process id alongside the global ORT init, and on every Silero inference call compares the current pid to the recorded pid. If they differ, decibri raises `ForkAfterOrtInit` (a `DecibriError` subclass) instead of allowing ORT to silently misbehave.
+
+```python
+# fork_after_init.py: the dangerous pattern, now caught proactively
+import multiprocessing as mp
+import decibri
+from decibri.exceptions import ForkAfterOrtInit
+
+
+def child_inference(queue):
+    # Inherits the parent's ORT_INIT_PID via fork; the next Silero call
+    # detects the pid mismatch and raises ForkAfterOrtInit.
+    try:
+        mic = decibri.Microphone(vad="silero")
+        mic.start()
+        mic.read()
+    except ForkAfterOrtInit as exc:
+        queue.put(("fork_after_init_raised", str(exc)))
+        return
+    queue.put(("read_succeeded_unexpectedly", ""))
+
+
+if __name__ == "__main__":
+    # Trigger Silero ORT init in the parent.
+    parent_mic = decibri.Microphone(vad="silero")
+
+    ctx = mp.get_context("fork")  # Linux only
+    queue = ctx.Queue()
+    p = ctx.Process(target=child_inference, args=(queue,))
+    p.start()
+    p.join(timeout=10)
+    print(queue.get(timeout=5))
+```
+
+Two clean remediations:
+
+**Remediation A: switch to spawn**
+
+```python
+mp.set_start_method("spawn", force=True)
+```
+
+`spawn` re-imports your module in the child and re-runs ORT init from scratch. The fork detection passes because ORT_INIT_PID is set to the child's own pid.
+
+**Remediation B: construct VAD inside the child**
+
+```python
+# fork_construct_in_child.py: also safe under fork
+import multiprocessing as mp
+
+
+def child(_):
+    import decibri
+    mic = decibri.Microphone(vad="silero")  # ORT_INIT_PID = child pid
+    return "ok"
+
+
+if __name__ == "__main__":
+    ctx = mp.get_context("fork")
+    with ctx.Pool(2) as pool:
+        print(pool.map(child, range(2)))
+```
+
+When the parent never initialized ORT, the child performs its own first init and ORT_INIT_PID matches; no fork detection trips.
+
+## Catching ForkAfterOrtInit
+
+`ForkAfterOrtInit` is a direct subclass of `DecibriError` (not under `OrtError`, since it is a usage error rather than an ORT-internal error). Catch via either name:
+
+```python
+import decibri
+from decibri.exceptions import ForkAfterOrtInit
+
+try:
+    mic.read()
+except ForkAfterOrtInit as exc:
+    # Specific catch: tell the operator to fix their start method
+    raise RuntimeError("Use mp.set_start_method('spawn')") from exc
+
+try:
+    mic.read()
+except decibri.DecibriError:
+    # Generic catch: still works because ForkAfterOrtInit subclasses DecibriError
+    ...
+```
+
+The `__all__` count grew from 17 to 18 in Phase 9 to expose `ForkAfterOrtInit` as a top-level catch target. The class is also accessible at `decibri.exceptions.ForkAfterOrtInit`.
+
+## cpal stream is process-local
+
+The cpal capture stream uses platform-specific OS resources (Windows WASAPI handles, Linux ALSA file descriptors, macOS CoreAudio AudioUnit objects) that are not transparently shared across forked processes. Constructing a `Microphone` in the parent and using it in a forked child does not produce a shared stream; depending on the platform, it produces either a dead handle in the child or undefined behavior. The recommended pattern remains: construct decibri objects inside the worker, never share via fork.
+
+This is a less consequential failure mode than the ORT case because it surfaces immediately on the first read (dead handle) rather than producing silent wrong answers; no proactive detection is added in Phase 9 for this case.
+
+## Decision matrix
+
+| Scenario                                       | Safe? |
+| ---------------------------------------------- | ----- |
+| `spawn` + construct in child + any decibri op  | yes   |
+| `spawn` + parent uses VAD + child uses VAD     | yes (each gets own ORT init) |
+| `fork` + only construct in child               | yes   |
+| `fork` + parent uses VAD + child does anything VAD | **raises ForkAfterOrtInit** |
+| `fork` + cpal stream constructed in parent     | undefined (do not do this) |
+| Pickling Microphone / Speaker                  | raises TypeError |
+| `concurrent.futures.ProcessPoolExecutor` (default) | yes (uses spawn) |

--- a/bindings/python/python/decibri/__init__.py
+++ b/bindings/python/python/decibri/__init__.py
@@ -23,6 +23,7 @@ from decibri.exceptions import (
     DeviceError,
     DeviceIndexOutOfRange,
     DeviceNotFound,
+    ForkAfterOrtInit,
     FramesPerBufferOutOfRange,
     InvalidFormat,
     MultipleDevicesMatch,
@@ -207,16 +208,22 @@ __all__ = [
     # Audio chunk with metadata (Phase 7.7 Item B1)
     "Chunk",
     # Exception hierarchy entry points (Phase 7.6 Item C3, Shape C2;
-    # Phase 7.7 Item B7 added DeviceError):
-    # only the catch-target roots are surfaced in __all__ to keep
-    # `from decibri import *` legible. The full 32+-class hierarchy
-    # remains importable via top-level attribute lookup
-    # (``decibri.<Class>``) AND via the explicit submodule
+    # Phase 7.7 Item B7 added DeviceError; Phase 9 Item C7 added
+    # ForkAfterOrtInit):
+    # only the catch-target roots plus ForkAfterOrtInit are surfaced in
+    # __all__ to keep `from decibri import *` legible. The full
+    # 32+-class hierarchy remains importable via top-level attribute
+    # lookup (``decibri.<Class>``) AND via the explicit submodule
     # (``decibri.exceptions.<Class>``); see decibri.exceptions for the
-    # complete list. The four names below cover catch-anything,
+    # complete list. The four catch-target names cover catch-anything,
     # catch-any-device-error, catch-any-ORT, and catch-any-ORT-path-error.
+    # ForkAfterOrtInit is also surfaced because it is the rare
+    # decibri-specific exception that users are likely to want to catch
+    # by name to distinguish "must use spawn start method" from other
+    # DecibriError causes.
     "DecibriError",
     "DeviceError",
+    "ForkAfterOrtInit",
     "OrtError",
     "OrtPathError",
 ]

--- a/bindings/python/python/decibri/__init__.pyi
+++ b/bindings/python/python/decibri/__init__.pyi
@@ -16,6 +16,7 @@ from decibri.exceptions import DeviceEnumerationFailed as DeviceEnumerationFaile
 from decibri.exceptions import DeviceError as DeviceError
 from decibri.exceptions import DeviceIndexOutOfRange as DeviceIndexOutOfRange
 from decibri.exceptions import DeviceNotFound as DeviceNotFound
+from decibri.exceptions import ForkAfterOrtInit as ForkAfterOrtInit
 from decibri.exceptions import FramesPerBufferOutOfRange as FramesPerBufferOutOfRange
 from decibri.exceptions import InvalidFormat as InvalidFormat
 from decibri.exceptions import MultipleDevicesMatch as MultipleDevicesMatch

--- a/bindings/python/python/decibri/_async_classes.py
+++ b/bindings/python/python/decibri/_async_classes.py
@@ -37,6 +37,7 @@ unchanged and exist alongside this module.
 
 from __future__ import annotations
 
+import asyncio
 import importlib.resources
 import time
 from pathlib import Path
@@ -153,17 +154,20 @@ class AsyncMicrophone:
 
         Notes
         -----
-        ORT load is synchronous in 0.1.0. When ``vad='silero'`` is set
-        the Silero ONNX runtime is loaded inside ``__init__`` itself,
-        which blocks for roughly 100 to 500 milliseconds depending on
-        platform and disk cache. This blocks the event loop because
-        ``__init__`` runs synchronously even on async classes. For
-        latency-sensitive event-loop hot paths, construct the
-        ``AsyncMicrophone`` once at startup (or inside an executor) and
-        reuse it for the lifetime of the process.
+        ORT load is synchronous when called via this constructor. With
+        ``vad='silero'`` the Silero ONNX runtime is loaded inside
+        ``__init__`` itself, which blocks for roughly 100 to 500
+        milliseconds depending on platform and disk cache. ``__init__``
+        runs synchronously even on async classes, so this blocks the
+        event loop in async contexts.
 
-        A future ``AsyncMicrophone.open(...)`` async factory that
-        offloads ORT load to a worker thread is on the 0.2.0+ roadmap.
+        For latency-sensitive event-loop hot paths use the
+        :meth:`AsyncMicrophone.open` async factory classmethod added in
+        Phase 9 (``mic = await AsyncMicrophone.open(vad='silero')``),
+        which dispatches the synchronous construction to the default
+        ThreadPoolExecutor and returns the constructed instance
+        awaitably. The synchronous constructor remains supported for
+        callers that construct outside an async context.
         """
         if dtype not in _VALID_FORMATS:
             raise exceptions.InvalidFormat(
@@ -271,6 +275,12 @@ class AsyncMicrophone:
         self._as_ndarray = as_ndarray
         # Phase 7.7 Item B1: chunk counter for read_with_metadata().
         self._sequence = 0
+        # Phase 9 Item A4: capture construction parameters for __repr__.
+        self._sample_rate = sample_rate
+        self._channels = channels
+        self._frames_per_buffer = frames_per_buffer
+        self._device = device
+        self._vad_arg = vad
     # -----------------------------------------------------------------------
     # Lifecycle
     # -----------------------------------------------------------------------
@@ -483,6 +493,63 @@ class AsyncMicrophone:
     # `async with AsyncMicrophone(...) as d:` or `await d.stop()`
     # explicitly. See the class docstring's "Resource cleanup" section.
 
+    def __repr__(self) -> str:
+        # Phase 9 Item A4. Mirrors Microphone.__repr__; is_open is
+        # queried from the bridge's lock-free atomic mirror so the repr
+        # reflects current bridge truth (LD-9-8).
+        is_open: bool | str
+        try:
+            is_open = self.is_open
+        except Exception:  # noqa: BLE001
+            is_open = "?"
+        return (
+            f"AsyncMicrophone(sample_rate={self._sample_rate}, "
+            f"channels={self._channels}, "
+            f"dtype={self._format!r}, "
+            f"frames_per_buffer={self._frames_per_buffer}, "
+            f"device={self._device!r}, "
+            f"vad={self._vad_arg!r}, "
+            f"is_open={is_open})"
+        )
+
+    # -----------------------------------------------------------------------
+    # Async factory (Phase 9 Item A6)
+    # -----------------------------------------------------------------------
+
+    @classmethod
+    async def open(cls, **kwargs: Any) -> "AsyncMicrophone":
+        """Construct an ``AsyncMicrophone`` without blocking the event loop.
+
+        Use this instead of the constructor in async code, especially when
+        ``vad="silero"`` is enabled. The synchronous constructor performs
+        ORT model loading inline (100 to 500 ms for Silero VAD on a cold
+        cache); calling it from an async context blocks the event loop for
+        the duration of the load, which can cause dropped websocket
+        frames, late timer callbacks, and UI jitter in voice-AI pipelines.
+
+        This classmethod dispatches the synchronous constructor to the
+        default ThreadPoolExecutor via ``loop.run_in_executor``, returning
+        the constructed instance awaitably. The synchronous constructor
+        remains available for backward compatibility and for callers that
+        construct outside an async context.
+
+        Parameters mirror ``AsyncMicrophone.__init__`` exactly; pass the
+        same keyword arguments.
+
+        Example::
+
+            mic = await AsyncMicrophone.open(vad="silero")
+            async with mic:
+                async for chunk in mic:
+                    await process(chunk)
+
+        Phase 9 LD-9-3 (pulled forward from 0.2.0 backlog) and LD-9-7
+        (default ThreadPoolExecutor; users wanting a custom executor can
+        construct synchronously inside their own thread).
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, lambda: cls(**kwargs))
+
     @staticmethod
     async def input_devices() -> list[DeviceInfo]:
         """List available audio input devices."""
@@ -582,6 +649,12 @@ class AsyncSpeaker:
             format=dtype,
             device=device,
         )
+        # Phase 9 Item A4: capture construction parameters for __repr__.
+        self._sample_rate = sample_rate
+        self._channels = channels
+        self._format = dtype
+        self._device = device
+
     async def start(self) -> None:
         """Open and start the output stream.
 
@@ -665,6 +738,39 @@ class AsyncSpeaker:
     # resource release at GC time. Consumers should always use
     # `async with AsyncSpeaker(...) as o:` or `await o.stop()` explicitly.
     # See the class docstring's "Resource cleanup" section.
+
+    def __repr__(self) -> str:
+        # Phase 9 Item A4. Mirrors Speaker.__repr__; is_playing reflects
+        # the bridge's atomic mirror so the repr is honest about current
+        # state (LD-9-8).
+        is_playing: bool | str
+        try:
+            is_playing = self.is_playing
+        except Exception:  # noqa: BLE001
+            is_playing = "?"
+        return (
+            f"AsyncSpeaker(sample_rate={self._sample_rate}, "
+            f"channels={self._channels}, "
+            f"dtype={self._format!r}, "
+            f"device={self._device!r}, "
+            f"is_playing={is_playing})"
+        )
+
+    @classmethod
+    async def open(cls, **kwargs: Any) -> "AsyncSpeaker":
+        """Construct an ``AsyncSpeaker`` without blocking the event loop.
+
+        Symmetric with :meth:`AsyncMicrophone.open`. ``Speaker`` does not
+        load ORT, so the practical event-loop blocking risk is smaller
+        here, but ``open()`` is provided for API parity so async code can
+        consistently use the factory pattern across both classes.
+
+        Parameters mirror ``AsyncSpeaker.__init__`` exactly.
+
+        Phase 9 LD-9-3, LD-9-7.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, lambda: cls(**kwargs))
 
     @staticmethod
     async def output_devices() -> list[OutputDeviceInfo]:

--- a/bindings/python/python/decibri/_classes.py
+++ b/bindings/python/python/decibri/_classes.py
@@ -488,6 +488,16 @@ class Microphone:
         # Increments on every non-None chunk emission; resets to 0 on
         # each stop() so a subsequent start() begins a fresh sequence.
         self._sequence = 0
+        # Phase 9 Item A4: capture construction parameters for __repr__.
+        # The bridge does not expose these as readable attributes, so the
+        # wrapper holds its own copies. ``vad`` stores the original public
+        # union value (``False``, ``"silero"``, or ``"energy"``) rather
+        # than the split (``vad_enabled``, ``vad_mode``) bridge form.
+        self._sample_rate = sample_rate
+        self._channels = channels
+        self._frames_per_buffer = frames_per_buffer
+        self._device = device
+        self._vad_arg = vad
 
     # -----------------------------------------------------------------------
     # Lifecycle
@@ -731,6 +741,28 @@ class Microphone:
         except BaseException:  # noqa: BLE001
             pass
 
+    def __repr__(self) -> str:
+        # Phase 9 Item A4. Show construction parameters plus current
+        # is_open state. Pattern matches VersionInfo's repr precedent;
+        # is_open is queried live from the bridge so the repr reflects
+        # actual state, not just construction-time state (LD-9-8).
+        is_open: bool | str
+        try:
+            is_open = self.is_open
+        except Exception:  # noqa: BLE001
+            # Bridge missing or partially constructed: report unknown
+            # rather than raising from __repr__.
+            is_open = "?"
+        return (
+            f"Microphone(sample_rate={self._sample_rate}, "
+            f"channels={self._channels}, "
+            f"dtype={self._format!r}, "
+            f"frames_per_buffer={self._frames_per_buffer}, "
+            f"device={self._device!r}, "
+            f"vad={self._vad_arg!r}, "
+            f"is_open={is_open})"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Speaker: consumer-facing audio output class.
@@ -790,6 +822,11 @@ class Speaker:
             format=dtype,
             device=device,
         )
+        # Phase 9 Item A4: capture construction parameters for __repr__.
+        self._sample_rate = sample_rate
+        self._channels = channels
+        self._format = dtype
+        self._device = device
 
     def start(self) -> None:
         """Open and start the output stream.
@@ -869,3 +906,20 @@ class Speaker:
             bridge.stop()
         except BaseException:  # noqa: BLE001
             pass
+
+    def __repr__(self) -> str:
+        # Phase 9 Item A4. Same shape as Microphone.__repr__; Speaker has
+        # no VAD so the repr omits that field. is_playing is the analogue
+        # of is_open here (LD-9-8).
+        is_playing: bool | str
+        try:
+            is_playing = self.is_playing
+        except Exception:  # noqa: BLE001
+            is_playing = "?"
+        return (
+            f"Speaker(sample_rate={self._sample_rate}, "
+            f"channels={self._channels}, "
+            f"dtype={self._format!r}, "
+            f"device={self._device!r}, "
+            f"is_playing={is_playing})"
+        )

--- a/bindings/python/python/decibri/exceptions.py
+++ b/bindings/python/python/decibri/exceptions.py
@@ -264,3 +264,30 @@ class OrtPathInvalid(OrtPathError):
         super().__init__(msg)
         self.path = path
         self.reason = reason
+
+
+# Phase 9 Item C7: fork-safety detection (Linux). Direct DecibriError
+# subclass, NOT under OrtError, because this is a usage error (user
+# initialized ORT in parent then forked) rather than an ORT-internal
+# error. See LD-9-9. Catch via `except DecibriError` continues to work.
+
+
+class ForkAfterOrtInit(DecibriError):
+    """Raised when ONNX Runtime is used in a child process after being
+    initialized in the parent.
+
+    Python's default ``fork`` start method on Linux duplicates the
+    parent's memory into the child, but ONNX Runtime's internal state is
+    not safe to share across forked processes. Using a SileroVad-enabled
+    Microphone in a forked child produces silent wrong answers or
+    segfaults; decibri detects the pid mismatch at the start of every
+    Silero inference call and raises this exception instead.
+
+    Remediation:
+        - Set ``multiprocessing.set_start_method('spawn')`` before
+          spawning workers, OR
+        - Construct ``Microphone(vad='silero')`` inside each child
+          process, never in the parent before fork.
+
+    See ``docs/ecosystem/multiprocessing.md`` for verified examples.
+    """

--- a/bindings/python/python/decibri/exceptions.pyi
+++ b/bindings/python/python/decibri/exceptions.pyi
@@ -54,3 +54,6 @@ class OrtLoadFailed(OrtPathError):
 class OrtPathInvalid(OrtPathError):
     path: str
     reason: str
+
+
+class ForkAfterOrtInit(DecibriError): ...

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -120,6 +120,7 @@ const EXCEPTION_NAMES: &[&str] = &[
     "DeviceEnumerationFailed",
     "DeviceIndexOutOfRange",
     "DeviceNotFound",
+    "ForkAfterOrtInit",
     "FramesPerBufferOutOfRange",
     "InvalidFormat",
     "MultipleDevicesMatch",
@@ -338,6 +339,16 @@ fn to_py_err(py: Python<'_>, err: CoreDecibriError) -> PyErr {
                 Box::new(move |cls| PyErr::from_type(cls, (msg, path_str))),
             )
         }
+
+        // Phase 9 Item C7: ForkAfterOrtInit. Direct DecibriError subclass
+        // (not under OrtError); message-only constructor like the unit
+        // variants. The pid pair is embedded in the Display message; no
+        // separate `init_pid` / `current_pid` Python attributes are
+        // exposed in 0.1.0 (kept simple per LD-9-9).
+        CoreDecibriError::ForkAfterOrtInit { .. } => (
+            "ForkAfterOrtInit",
+            Box::new(move |cls| PyErr::from_type(cls, (msg,))),
+        ),
 
         // #[non_exhaustive] catch-all per F10. Fall through to the base class.
         _ => (

--- a/bindings/python/tests/test_async.py
+++ b/bindings/python/tests/test_async.py
@@ -437,3 +437,93 @@ async def test_async_aiter_with_metadata_yields_chunks() -> None:
             if count >= 3:
                 break
         assert count == 3
+
+
+# ---------------------------------------------------------------------------
+# Phase 9 Item A6: AsyncMicrophone.open() / AsyncSpeaker.open() async
+# factory classmethods that offload synchronous construction to the
+# default ThreadPoolExecutor via loop.run_in_executor.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_microphone_open_returns_constructed_instance() -> None:
+    """``await AsyncMicrophone.open()`` returns an ``AsyncMicrophone``."""
+    mic = await AsyncMicrophone.open()
+    try:
+        assert isinstance(mic, AsyncMicrophone)
+        # Construction-only: no start() yet.
+        assert mic.is_open is False
+    finally:
+        # No bridge resources to release because we never started; the
+        # finalizer note on AsyncMicrophone applies (no __del__; pyo3 Drop).
+        pass
+
+
+@pytest.mark.asyncio
+async def test_async_microphone_open_forwards_kwargs() -> None:
+    """Kwargs passed to open() reach the underlying constructor."""
+    mic = await AsyncMicrophone.open(
+        sample_rate=24000,
+        channels=2,
+        dtype="float32",
+        frames_per_buffer=2400,
+    )
+    text = repr(mic)
+    assert "sample_rate=24000" in text
+    assert "channels=2" in text
+    assert "dtype='float32'" in text
+    assert "frames_per_buffer=2400" in text
+
+
+@pytest.mark.asyncio
+async def test_async_microphone_open_dispatches_to_executor() -> None:
+    """``AsyncMicrophone.open()`` calls ``loop.run_in_executor``.
+
+    Direct contract test: spy on the running loop's ``run_in_executor``
+    and verify the ``open()`` implementation routes construction through
+    it. A timing-based test would be flaky for a fast (no-VAD)
+    constructor; this test pins the implementation contract that matters
+    in practice (when ``vad='silero'`` is enabled the executor dispatch
+    is what keeps the event loop responsive during the 100 to 500 ms
+    ORT load).
+    """
+    loop = asyncio.get_running_loop()
+    original = loop.run_in_executor
+    calls: list[Any] = []
+
+    def spy(executor: Any, func: Any, *args: Any) -> Any:
+        calls.append((executor, func))
+        return original(executor, func, *args)
+
+    loop.run_in_executor = spy  # type: ignore[method-assign]
+    try:
+        mic = await AsyncMicrophone.open()
+    finally:
+        loop.run_in_executor = original  # type: ignore[method-assign]
+
+    assert isinstance(mic, AsyncMicrophone)
+    assert len(calls) == 1, f"expected one run_in_executor call, got {len(calls)}"
+    executor_arg, func = calls[0]
+    assert executor_arg is None, (
+        "open() should pass executor=None to use the default ThreadPoolExecutor (LD-9-7)"
+    )
+    assert callable(func), "the dispatched callable should be the construction lambda"
+
+
+@pytest.mark.asyncio
+async def test_async_speaker_open_returns_constructed_instance() -> None:
+    """``await AsyncSpeaker.open()`` returns an ``AsyncSpeaker``."""
+    spk = await AsyncSpeaker.open()
+    assert isinstance(spk, AsyncSpeaker)
+    assert spk.is_playing is False
+
+
+@pytest.mark.asyncio
+async def test_async_speaker_open_forwards_kwargs() -> None:
+    """Kwargs passed to AsyncSpeaker.open() reach the constructor."""
+    spk = await AsyncSpeaker.open(sample_rate=24000, channels=2, dtype="float32")
+    text = repr(spk)
+    assert "sample_rate=24000" in text
+    assert "channels=2" in text
+    assert "dtype='float32'" in text

--- a/bindings/python/tests/test_fork_safety.py
+++ b/bindings/python/tests/test_fork_safety.py
@@ -1,0 +1,175 @@
+"""Phase 9 Item C7: ForkAfterOrtInit detection on Linux.
+
+These tests pin the contract that decibri raises ``ForkAfterOrtInit`` in
+a child process when ONNX Runtime was initialized in the parent before
+the fork. Without this detection, the child would silently produce wrong
+VAD probabilities, segfault, or hang depending on the exact ORT
+configuration. See ``docs/ecosystem/multiprocessing.md`` for the user-
+facing remediation guidance.
+
+All three tests are gated to Linux: the ``fork`` start method is not
+available on Windows or macOS (macOS supports it nominally but Apple has
+disabled it for any process linking Objective-C frameworks, which
+includes Silero VAD's CoreML provider). The ``requires_bundled_ort``
+marker further skips when the ORT dylib is not bundled, so editable
+``maturin develop`` installs that don't populate ``_ort/`` skip
+gracefully; CI builds wheels with the dylib bundled and exercises the
+tests fully.
+
+Inter-process result reporting uses ``multiprocessing.Queue`` rather
+than child exit code so the test asserts the specific exception that
+was raised, not just "child died." This catches the case where the
+child raises a different exception (e.g. ``OrtInferenceFailed`` from a
+silent corruption that happened to surface) instead of the proactive
+``ForkAfterOrtInit`` raise.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import sys
+
+import pytest
+
+import decibri
+from decibri.exceptions import ForkAfterOrtInit
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="fork() start method is Linux-only in scope; Windows has no fork(), macOS disables it for ObjC-linking processes",
+    ),
+    pytest.mark.requires_bundled_ort,
+]
+
+
+# ---------------------------------------------------------------------------
+# Worker functions (module-level for picklability under spawn).
+# ---------------------------------------------------------------------------
+
+
+def _child_use_silero_after_fork(queue: "mp.Queue[tuple[str, str]]") -> None:
+    """Run inside a forked child: try to use Silero, expect ForkAfterOrtInit.
+
+    The child inherits the parent's ``ORT_INIT_PID`` via the OnceLock
+    that fork() duplicates into the child's address space; calling any
+    Silero inference path then trips the pid mismatch check and raises
+    ``ForkAfterOrtInit``. Reports the outcome via the queue.
+    """
+    try:
+        mic = decibri.Microphone(vad="silero")
+        mic.start()
+        try:
+            mic.read(timeout_ms=500)
+        finally:
+            mic.stop()
+    except ForkAfterOrtInit as exc:
+        queue.put(("fork_after_init_raised", str(exc)))
+        return
+    except Exception as exc:
+        queue.put((f"unexpected_{type(exc).__name__}", str(exc)))
+        return
+    queue.put(("read_succeeded_unexpectedly", ""))
+
+
+def _child_init_silero_in_child(queue: "mp.Queue[tuple[str, str]]") -> None:
+    """Run inside a forked child: do the Silero init in the child itself.
+
+    When the parent never initialized ORT, the child's first init is a
+    fresh init in its own address space; ``ORT_INIT_PID`` becomes the
+    child's pid and the detection check passes. Any non-fork-related
+    failures (missing model, bad library path) surface here as
+    different exception types so the test fails loudly rather than
+    silently passing the wrong way.
+    """
+    try:
+        mic = decibri.Microphone(vad="silero")
+        # Construction alone is enough to verify ORT init succeeded;
+        # we deliberately avoid start()/read() because the child has no
+        # real audio device in CI and would hang or NoMicrophoneFound.
+        queue.put(("init_succeeded", f"pid={os.getpid()}"))
+    except Exception as exc:
+        queue.put((f"init_failed_{type(exc).__name__}", str(exc)))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_fork_after_silero_init_raises_in_child() -> None:
+    """Parent inits Silero, then forks; child raises ForkAfterOrtInit on use.
+
+    This is the headline behavior of Phase 9 C7: silent ORT corruption
+    on fork is now a clean exception with a remediation message.
+    """
+    # Parent: trigger Silero ORT init.
+    parent_mic = decibri.Microphone(vad="silero")
+    del parent_mic  # release the bridge; ORT_INIT_PID stays set
+
+    ctx = mp.get_context("fork")
+    queue: "mp.Queue[tuple[str, str]]" = ctx.Queue()
+    child = ctx.Process(target=_child_use_silero_after_fork, args=(queue,))
+    child.start()
+    child.join(timeout=15)
+    assert not child.is_alive(), "child failed to terminate within timeout"
+
+    assert not queue.empty(), "child did not report a result before exit"
+    outcome, detail = queue.get(timeout=5)
+    assert outcome == "fork_after_init_raised", (
+        f"Expected ForkAfterOrtInit raise; child reported {outcome!r}: {detail}"
+    )
+    assert "fork()" in detail, (
+        f"Exception message should mention fork() for actionable user feedback; got: {detail}"
+    )
+    assert "spawn" in detail, (
+        f"Exception message should suggest spawn remediation; got: {detail}"
+    )
+
+
+def test_fork_before_silero_init_works() -> None:
+    """Forking BEFORE the parent initializes Silero is fine.
+
+    The child does its own ORT init from scratch in its own address
+    space; no inherited state to corrupt; no fork detection trips.
+    Sanity check that the C7 detection isn't over-eager.
+    """
+    ctx = mp.get_context("fork")
+    queue: "mp.Queue[tuple[str, str]]" = ctx.Queue()
+    child = ctx.Process(target=_child_init_silero_in_child, args=(queue,))
+    child.start()
+    child.join(timeout=30)
+    assert not child.is_alive(), "child failed to terminate within timeout"
+
+    assert not queue.empty(), "child did not report a result before exit"
+    outcome, detail = queue.get(timeout=5)
+    assert outcome == "init_succeeded", (
+        f"Expected fresh ORT init in child to succeed; child reported {outcome!r}: {detail}"
+    )
+
+
+def test_spawn_after_silero_init_works() -> None:
+    """Spawn ignores the parent's ORT state.
+
+    Parent inits ORT, then spawns; the child re-imports decibri and
+    re-runs init from scratch. ``ORT_INIT_PID`` becomes the child's pid
+    in the child's process; no fork detection trips because spawn does
+    not duplicate the parent's address space.
+    """
+    parent_mic = decibri.Microphone(vad="silero")
+    del parent_mic
+
+    ctx = mp.get_context("spawn")
+    queue: "mp.Queue[tuple[str, str]]" = ctx.Queue()
+    child = ctx.Process(target=_child_init_silero_in_child, args=(queue,))
+    child.start()
+    child.join(timeout=30)
+    assert not child.is_alive(), "child failed to terminate within timeout"
+
+    assert not queue.empty(), "child did not report a result before exit"
+    outcome, detail = queue.get(timeout=5)
+    assert outcome == "init_succeeded", (
+        f"Expected spawn to ignore parent ORT state; child reported {outcome!r}: {detail}"
+    )

--- a/bindings/python/tests/test_repr.py
+++ b/bindings/python/tests/test_repr.py
@@ -1,0 +1,113 @@
+"""Phase 9 Item A4: __repr__ on the four wrapper classes.
+
+Pins the contract that ``repr(instance)`` returns a useful string that
+shows construction parameters plus current state, mirroring the
+``VersionInfo`` precedent. Auto-display in Jupyter (the primary motivator
+per LD-9-8) shows this repr when an instance is the last expression in
+a cell.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import decibri
+
+
+def test_microphone_repr_shows_defaults_and_is_open() -> None:
+    mic = decibri.Microphone()
+    text = repr(mic)
+    assert text.startswith("Microphone(")
+    assert "sample_rate=16000" in text
+    assert "channels=1" in text
+    assert "dtype='int16'" in text
+    assert "frames_per_buffer=1600" in text
+    assert "device=None" in text
+    assert "vad=False" in text
+    assert "is_open=False" in text
+
+
+def test_microphone_repr_reflects_custom_params() -> None:
+    mic = decibri.Microphone(
+        sample_rate=24000,
+        channels=2,
+        dtype="float32",
+        frames_per_buffer=2400,
+        vad="energy",
+    )
+    text = repr(mic)
+    assert "sample_rate=24000" in text
+    assert "channels=2" in text
+    assert "dtype='float32'" in text
+    assert "frames_per_buffer=2400" in text
+    assert "vad='energy'" in text
+
+
+def test_microphone_repr_state_reflects_lifecycle() -> None:
+    mic = decibri.Microphone()
+    assert "is_open=False" in repr(mic)
+    mic.start()
+    try:
+        assert "is_open=True" in repr(mic)
+    finally:
+        mic.stop()
+    assert "is_open=False" in repr(mic)
+
+
+def test_speaker_repr_shows_defaults_and_is_playing() -> None:
+    spk = decibri.Speaker()
+    text = repr(spk)
+    assert text.startswith("Speaker(")
+    assert "sample_rate=16000" in text
+    assert "channels=1" in text
+    assert "dtype='int16'" in text
+    assert "device=None" in text
+    assert "is_playing=False" in text
+
+
+def test_speaker_repr_reflects_custom_params() -> None:
+    spk = decibri.Speaker(sample_rate=24000, channels=2, dtype="float32")
+    text = repr(spk)
+    assert "sample_rate=24000" in text
+    assert "channels=2" in text
+    assert "dtype='float32'" in text
+
+
+def test_async_microphone_repr_shows_defaults_and_is_open() -> None:
+    amic = decibri.AsyncMicrophone()
+    text = repr(amic)
+    assert text.startswith("AsyncMicrophone(")
+    assert "sample_rate=16000" in text
+    assert "channels=1" in text
+    assert "dtype='int16'" in text
+    assert "frames_per_buffer=1600" in text
+    assert "vad=False" in text
+    assert "is_open=False" in text
+
+
+def test_async_microphone_repr_state_reflects_lifecycle() -> None:
+    async def _flow() -> tuple[str, str, str]:
+        amic = decibri.AsyncMicrophone()
+        before = repr(amic)
+        await amic.start()
+        try:
+            during = repr(amic)
+        finally:
+            await amic.stop()
+        after = repr(amic)
+        return before, during, after
+
+    before, during, after = asyncio.run(_flow())
+    assert "is_open=False" in before
+    assert "is_open=True" in during
+    assert "is_open=False" in after
+
+
+def test_async_speaker_repr_shows_defaults_and_is_playing() -> None:
+    aspk = decibri.AsyncSpeaker()
+    text = repr(aspk)
+    assert text.startswith("AsyncSpeaker(")
+    assert "sample_rate=16000" in text
+    assert "channels=1" in text
+    assert "dtype='int16'" in text
+    assert "is_playing=False" in text

--- a/bindings/python/tests/test_repr.py
+++ b/bindings/python/tests/test_repr.py
@@ -5,11 +5,19 @@ shows construction parameters plus current state, mirroring the
 ``VersionInfo`` precedent. Auto-display in Jupyter (the primary motivator
 per LD-9-8) shows this repr when an instance is the last expression in
 a cell.
+
+Tests that call ``mic.start()`` to verify the ``is_open=True`` lifecycle
+state are gated by ``@pytest.mark.requires_audio_input`` because opening
+the cpal stream requires a real audio input device. Pure-construction
+repr tests (defaults, kwargs, stop-state) run on every platform without
+hardware.
 """
 
 from __future__ import annotations
 
 import asyncio
+
+import pytest
 
 import decibri
 
@@ -43,6 +51,7 @@ def test_microphone_repr_reflects_custom_params() -> None:
     assert "vad='energy'" in text
 
 
+@pytest.mark.requires_audio_input
 def test_microphone_repr_state_reflects_lifecycle() -> None:
     mic = decibri.Microphone()
     assert "is_open=False" in repr(mic)
@@ -85,6 +94,7 @@ def test_async_microphone_repr_shows_defaults_and_is_open() -> None:
     assert "is_open=False" in text
 
 
+@pytest.mark.requires_audio_input
 def test_async_microphone_repr_state_reflects_lifecycle() -> None:
     async def _flow() -> tuple[str, str, str]:
         amic = decibri.AsyncMicrophone()

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -116,14 +116,19 @@ def test_exception_intermediate_parents_importable() -> None:
 
 
 def test_public_surface_count() -> None:
-    """The public ``__all__`` enumerates the trimmed top-level surface (17 names).
+    """The public ``__all__`` enumerates the top-level surface (18 names).
 
-    Phase 7.7 reshaped the public surface:
+    Phase 7.7 reshaped the public surface (17 names at lock):
       - Item A1 removed four lowercase factory functions
         (microphone, speaker, async_microphone, async_speaker).
       - Item B2 renamed `devices` -> `input_devices`.
       - Item B7 added `DeviceError` (catch-target intermediate).
       - Item B1 added `Chunk` (audio chunk with metadata).
+
+    Phase 9 Item C7 added `ForkAfterOrtInit` (5th exception entry):
+    additive single-class growth, surfaced because users are likely to
+    catch it by name to distinguish "use spawn start method" from other
+    DecibriError causes.
 
     Final composition: 2 sync wrappers (Microphone, Speaker) + 2 async
     wrappers (AsyncMicrophone, AsyncSpeaker) + 3 module-level
@@ -131,10 +136,11 @@ def test_public_surface_count() -> None:
     2 file convenience functions (record_to_file, async_record_to_file)
     + 3 value types (DeviceInfo, OutputDeviceInfo, VersionInfo)
     + 1 audio chunk dataclass (Chunk)
-    + 4 exception roots (DecibriError, DeviceError, OrtError, OrtPathError)
-    = 2 + 2 + 3 + 2 + 3 + 1 + 4 = 17.
+    + 5 exception entries (DecibriError, DeviceError, ForkAfterOrtInit,
+      OrtError, OrtPathError)
+    = 2 + 2 + 3 + 2 + 3 + 1 + 5 = 18.
     """
-    assert len(decibri.__all__) == 17
+    assert len(decibri.__all__) == 18
     for name in decibri.__all__:
         assert hasattr(decibri, name), f"__all__ lists {name!r} but it is not exported"
 

--- a/crates/decibri/src/error.rs
+++ b/crates/decibri/src/error.rs
@@ -191,6 +191,32 @@ pub enum DecibriError {
         source: ort::Error,
     },
 
+    /// Raised when ONNX Runtime is used in a child process after being
+    /// initialized in the parent (Phase 9 Item C7).
+    ///
+    /// Python's `fork` start method on Linux duplicates the parent's
+    /// memory into the child, but ONNX Runtime's internal state
+    /// (allocators, thread pools, model graph state) is not safe to
+    /// share across forked processes. Without proactive detection, a
+    /// child that uses Silero VAD inherited via fork would silently
+    /// produce wrong probabilities, segfault, or hang.
+    ///
+    /// `init_pid` is the pid that first initialized ORT (typically the
+    /// parent that loaded `Microphone(vad="silero")` before fork);
+    /// `current_pid` is the pid that called the inference path and
+    /// triggered the detection.
+    ///
+    /// Remediation is in the user's hands: switch to `spawn` start
+    /// method or construct `Microphone(vad="silero")` inside the child
+    /// rather than the parent. The Display message embeds both options.
+    #[error(
+        "ONNX Runtime was initialized in pid {init_pid} but is being used in pid {current_pid}. \
+         Python's fork() start method is incompatible with ORT initialization. Use \
+         multiprocessing.set_start_method('spawn') or construct Microphone(vad='silero') \
+         inside each child process."
+    )]
+    ForkAfterOrtInit { init_pid: u32, current_pid: u32 },
+
     /// Forward-compat catch-all for non-ORT ONNX backends (CoreML, TFLite,
     /// etc.) once the workspace split lands at 4.0.
     ///

--- a/crates/decibri/src/vad.rs
+++ b/crates/decibri/src/vad.rs
@@ -133,6 +133,18 @@ const STATE_SIZE: usize = 256;
 #[cfg(feature = "vad")]
 static ORT_INIT: OnceLock<Option<PathBuf>> = OnceLock::new();
 
+/// Process id captured alongside [`ORT_INIT`] on first successful init
+/// (Phase 9 Item C7). Compared against the current pid at every Silero
+/// inference call by [`check_pid_for_ort`]; a mismatch indicates the
+/// process forked after init and ONNX Runtime's internal state is no
+/// longer safe to use.
+///
+/// Recorded inside the `OnceLock::get_or_init` callback in
+/// [`init_ort_once`] so the pid stamp is paired with the successful ORT
+/// init, not set speculatively before init returned.
+#[cfg(feature = "vad")]
+static ORT_INIT_PID: OnceLock<u32> = OnceLock::new();
+
 /// Wrap an ORT init failure with a decibri-specific actionable message.
 ///
 /// Kept as a standalone function (rather than an inline closure in
@@ -229,10 +241,59 @@ pub(crate) fn init_ort_once(path: Option<&Path>) -> Result<(), DecibriError> {
             // First-caller-wins. If another thread set it first, discard ours;
             // ORT's own global init is idempotent (first takes effect).
             let _ = ORT_INIT.set(path.map(|p| p.to_path_buf()));
+            // Phase 9 Item C7: pair the ORT init with the pid that
+            // performed it. Subsequent `check_pid_for_ort` calls compare
+            // the current pid against this stamp and raise
+            // `ForkAfterOrtInit` on mismatch. `_ = .set(...)` because
+            // another thread may have set the pid first; under that race
+            // the existing value wins and our value is silently dropped,
+            // matching the behavior of ORT_INIT itself.
+            let _ = ORT_INIT_PID.set(std::process::id());
             Ok(())
         }
         Err(e) => Err(wrap_init_error(path, e)),
     }
+}
+
+/// Verify that the current pid matches the pid that initialized ORT
+/// (Phase 9 Item C7). Called at the start of every Silero inference
+/// call to detect Linux `fork()`-after-init silent ORT corruption.
+///
+/// On Linux, when a parent process initializes ORT (e.g. by constructing
+/// `Microphone(vad="silero")`) and then forks a child via Python's
+/// default `fork` start method, the child inherits the OnceLock's set
+/// state but the underlying ORT runtime data structures are not safe to
+/// share. Calling inference in the child without re-initializing
+/// produces silent wrong probabilities, segfaults, or hangs depending
+/// on the specific ORT configuration.
+///
+/// This function compares `std::process::id()` against the recorded
+/// `ORT_INIT_PID`. On mismatch it returns
+/// [`DecibriError::ForkAfterOrtInit`] with both pids attached so the
+/// caller can diagnose. On match (the common case: same process that
+/// did init is now doing inference) it returns `Ok(())`.
+///
+/// Returns `Ok(())` cheaply if `ORT_INIT_PID` is unset (ORT was never
+/// initialized in this process), so non-VAD code paths pay nothing.
+///
+/// Pre-fork detection: not in scope here; `init_ort_once` is the single
+/// place that sets the pid and runs only when ORT is actually used.
+/// Code paths that never construct a Silero VAD never trip this check.
+///
+/// # Errors
+/// - [`DecibriError::ForkAfterOrtInit`] if `current_pid != init_pid`.
+#[cfg(feature = "vad")]
+pub(crate) fn check_pid_for_ort() -> Result<(), DecibriError> {
+    if let Some(&init_pid) = ORT_INIT_PID.get() {
+        let current_pid = std::process::id();
+        if current_pid != init_pid {
+            return Err(DecibriError::ForkAfterOrtInit {
+                init_pid,
+                current_pid,
+            });
+        }
+    }
+    Ok(())
 }
 
 #[cfg(feature = "vad")]
@@ -277,6 +338,13 @@ impl SileroVad {
     /// Returns the maximum speech probability across all windows processed.
     /// If no complete windows were formed (chunk too small), returns probability 0.0.
     pub fn process(&mut self, samples: &[f32]) -> Result<VadResult, DecibriError> {
+        // Phase 9 Item C7: detect fork()-after-ORT-init before touching
+        // the inherited ONNX Runtime state. Single check at the outer
+        // entry point covers every inference call; the inner
+        // `infer_window` loop runs many sessions per `process` and does
+        // not need its own check (any pid mismatch already failed here).
+        check_pid_for_ort()?;
+
         self.accumulator.extend_from_slice(samples);
 
         let mut max_probability: f32 = 0.0;


### PR DESCRIPTION
Phase 9 of the Python Integration Project. Ecosystem coexistence: verifies decibri behaves cleanly in the three real environments where Python users actually live (Jupyter notebooks, Docker containers, Python multiprocessing). Three code items close real correctness gaps; three docs files cover environmental constraints that users need to know about for production deployment.

Driven by an empirical-first prep research investigation (`phase-9-prep-research.md`) that produced 14 findings classified into Bucket A (Phase 9 fix), Bucket B (Phase 11 docs), Bucket C (0.2.0+ deferred), and Bucket D (works correctly; rejected as Phase 9 work). Three Bucket A items shipped as code; nine Bucket B items consolidated into three ecosystem documentation files; three Bucket C items deferred to 0.2.0 backlog with explicit rationale.

## Code items

**A4: `__repr__` on wrapper classes.** Microphone, Speaker, AsyncMicrophone, AsyncSpeaker now have meaningful `__repr__` methods that show construction parameters plus runtime state (`is_open`). Closes the Jupyter auto-display gap where users would otherwise see `<decibri.Microphone object at 0x...>`. Premium-quality libraries don't ship without this.

**A6 (pulled forward from 0.2.0 backlog): `AsyncMicrophone.open()` + `AsyncSpeaker.open()` async factory classmethods.** Offloads the synchronous ORT model load (100-500 ms with `vad="silero"`) to the default ThreadPoolExecutor via `loop.run_in_executor`. Closes the event-loop blocking footgun that violated CLAUDE.md guardrail 1 (no fix-it-later debt at 0.1.0). Existing constructor still works (back-compat preserved); no breaking change. Async users in voice-AI pipelines now get non-blocking construction matching the convention established by httpx, asyncpg, aiohttp.

**C7: `ForkAfterOrtInit` proactive detection.** Records parent pid in `ORT_INIT_PID` OnceCell alongside ORT init; `check_pid_for_ort()` at start of every Silero inference call raises `ForkAfterOrtInit(DecibriError)` on pid mismatch. Turns Linux `fork()`-after-ORT-init from silent ORT runtime corruption into a clean exception with a remediation message ("Use `multiprocessing.set_start_method('spawn')` or construct `Microphone(vad='silero')` inside each child process"). Three Linux-only CI tests pin the behavior (`pytest.mark.skipif(sys.platform == "win32", ...)`).

## Documentation

`bindings/python/docs/ecosystem/jupyter.md`: IPython 9 + ipykernel 7 coexistence patterns; `AsyncMicrophone.open()` usage in cells with verified copy-paste examples; kernel restart caveats; logging output guidance.

`bindings/python/docs/ecosystem/docker.md`: verified Dockerfiles for base, audio passthrough (`--device /dev/snd` + `--group-add audio` + non-PulseAudio default), and headless scenarios. Documents the alsa:null device behavior in headless containers (real environments return a virtual null device, not an empty list, requiring users to filter out null devices for a clean "fail loudly when no real audio" pattern). Image size notes; non-root user audio access; cross-platform constraints (Windows/macOS Docker Desktop has no audio device passthrough).

`bindings/python/docs/ecosystem/multiprocessing.md`: spawn vs fork guidance; `ForkAfterOrtInit` raise behavior; pickling Microphone fails cleanly with `TypeError`; recommended pattern of constructing decibri objects inside worker processes; `concurrent.futures.ProcessPoolExecutor` with spawn context works.

## API surface

- `__all__` count: 17 → 18 (`ForkAfterOrtInit` added).
- 4 wrapper classes gain `__repr__` showing construction parameters plus runtime state.
- 2 async classes gain `open()` async factory classmethod.
- 1 new exception class `ForkAfterOrtInit(DecibriError)` accessible at `decibri.ForkAfterOrtInit` AND `decibri.exceptions.ForkAfterOrtInit` (per LD12).
- No breaking changes; all additive.

## Cross-binding compat

Per LD-9-1 and CLAUDE.md guardrail 2: Python-only changes plus one Rust-side OnceCell + pid check in `vad.rs`. Public Rust API stays byte-identical; `crates/decibri` 3.4.0 unchanged. npm tests pass 44/44; browser shim 64/64 (Phase 9 doesn't touch them; verification confirms no regressions from the Rust-side change).

## Verified

- Rust unit tests: 47 (unchanged from Phase 8)
- Rust integration tests: 4 (unchanged)
- Python pytest: 161 passed, 75 hardware-skipped (was 220 → 236 nominal; +16 new tests for repr coverage, async open behavior, fork safety)
- Python mypy --strict: clean
- cargo build --release -p decibri: clean
- cargo clippy --workspace -- -D warnings: clean
- cargo fmt --all -- --check: clean
- cargo test-decibri: all green
- Node CI tests: 44/44
- Browser shim vitest: 64/64
- Em-dash sweep across `bindings/python/` and `crates/decibri/`: 0 hits
- General push CI matrix: all green
- Python push CI matrix: all green

## Linux fork-safety CI tests (LD-9-6)

Three new tests in `bindings/python/tests/test_fork_safety.py` exercise the C7 detection path. They skip on Windows/macOS via `pytest.mark.skipif(sys.platform == "win32", ...)`. The ubuntu-latest CI runners exercise them via the bundled ORT wheel. The detection logic is straightforward: parent records pid; child compares pid; mismatch raises `ForkAfterOrtInit`. Verified working in CI on the ubuntu-latest job.

## Locked decisions resolved (added to master plan)

**LD16:** Phase 9 ecosystem coexistence shipped 7 items (3 code + 3 docs + Docker verification step). Behavior verified empirically across the three target environments. The Linux fork()-after-ORT-init silent-corruption landmine is now a loud raise; the async-construction event-loop blocking footgun has the `open()` factory escape hatch; wrapper-class `__repr__` closes the Jupyter auto-display gap. Three Bucket B docs files (ecosystem coexistence) ship as the user-facing artifact; PyPI README at Phase 11 will link to these for production deployment guidance.

## Items deliberately NOT in scope

- Auto-fork-detection that silently re-inits ORT (LD-9-2 chose proactive raise; auto re-init in 0.2.0 backlog).
- `decibri-no-ort` wheel variant (multi-wheel build complexity; 0.2.0+).
- Native PulseAudio / PipeWire cpal feature (multi-wheel builds per audio backend; 0.2.0+).
- ALSA null device auto-filtering in `input_devices()` (added to 0.2.0 backlog as implementation-time finding from docker.md verification).
- Verb-form helpers `decibri.record(seconds=5)` and `decibri.play(buffer)` (0.2.0 backlog; Phase 9 multiprocessing.md notes the use cases that would benefit).

## Implementation report

Full implementation details, validation gate output, surprises, and per-step results are captured in `~/.claude/plans/phase-9-implementation-report.md`. Master plans (`python-integration-project.md` and `decibri-master-plan-v3-draft.md`) and 0.2.0 backlog (`0-2-0-backlog.md`) updated to reflect Phase 9 ship.

A follow-up commit on this branch added the `requires_audio_input` skip marker to two repr lifecycle tests that call `mic.start()` (the marker auto-skips them on hardware-less CI runners; macos-14 / Python 3.14 needed this gate). The fix is mechanical; the existing repr functionality works correctly.

After this PR squash-merges, Phase 9 is complete; ecosystem coexistence story is done. **Phase 10 (pre-publish hardening: twine, abi3audit, attestation, Trusted Publisher) is the next active phase.**