### PR TITLE
Phase 10: Pre-publish hardening (publish workflow + abi3audit + attestations)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -24,7 +24,7 @@ name: Publish to PyPI
 # Workflow filename is locked at TPP registration time; renaming requires
 # manual TPP delete + re-add on both registries (LD-10-1).
 
-on:
+"on":
   push:
     tags:
       - 'python-v*'

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,425 @@
+name: Publish to PyPI
+
+# Phase 10 (2026-05-02). Publishes the decibri Python wheel to TestPyPI
+# (prerelease tags: python-v*a*, python-v*b*, python-v*rc*) or production
+# PyPI (stable tags: python-v\d+.\d+.\d+) via Trusted Publisher OIDC.
+#
+# Tag namespacing per LD-10-11 (Option 1, approved 2026-05-02):
+#   python-v0.1.0a1, python-v0.1.0     -> this workflow
+#   v3.4.0, v3.5.0                     -> release.yml (npm + crates.io)
+# release.yml's tag filter excludes 'python-v*' so the two workflows
+# never fire on the same tag.
+#
+# Design adjudication: Option D from phase-10-design-adjudication.md.
+# Tag-routed publish workflow that mirrors python-ci.yml's existing
+# in-job install-verification pattern (polars-style), adds abi3audit,
+# and uploads validated wheels to the appropriate registry; install-test
+# happens in the same job that built each wheel so each platform's wheel
+# is verified on its own platform (cross-platform artifact handoff is
+# not viable for native wheels).
+#
+# Trusted Publisher records (configured by the maintainer before Phase 10 ship):
+#   PyPI:     decibri/decibri/publish-pypi.yml/pypi
+#   TestPyPI: decibri/decibri/publish-pypi.yml/testpypi
+# Workflow filename is locked at TPP registration time; renaming requires
+# manual TPP delete + re-add on both registries (LD-10-1).
+
+on:
+  push:
+    tags:
+      - 'python-v*'
+  # workflow_dispatch lets the maintainer run build-and-validate against the current
+  # branch without pushing a tag. The publish jobs skip cleanly because
+  # their if: conditions key on github.event_name == 'push'. Used for
+  # workflow YAML validation pre-tag (LD-10-8).
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write    # required for Trusted Publisher OIDC token issuance
+
+env:
+  # Single source of truth for the bundled ONNX Runtime version.
+  # MUST stay in sync with .github/workflows/python-ci.yml (line 52)
+  # and .github/workflows/release.yml (line 20). Updating ORT requires
+  # bumping all three workflows in lockstep per the workspace Cargo.toml
+  # maintainer comment.
+  ORT_VERSION: 1.24.4
+  # Required for maturin abi3 builds on Python 3.14 hosts targeting py310
+  # abi3. See PyO3 issue #5505. Workflow-level setting applies to every
+  # matrix entry; no-op on Python 3.10-3.13 hosts.
+  PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+
+jobs:
+  build-and-validate:
+    name: Build & validate (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      # fail-fast per LD-10-7: any platform failure blocks the publish.
+      # A partial wheel set is worse than no release.
+      fail-fast: true
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            ort_platform_slug: linux-x64
+            ort_ext: tgz
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            ort_platform_slug: linux-aarch64
+            ort_ext: tgz
+          - os: macos-14
+            target: aarch64-apple-darwin
+            ort_platform_slug: osx-arm64
+            ort_ext: tgz
+          - os: macos-13
+            target: x86_64-apple-darwin
+            ort_platform_slug: osx-x86_64
+            ort_ext: tgz
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            ort_platform_slug: win-x64
+            ort_ext: zip
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # ALSA dev headers are needed for cpal -> alsa-sys on Linux. macOS and
+      # Windows pull CoreAudio / WASAPI from system frameworks.
+      # Mirrors python-ci.yml line 137-146.
+      - name: Install libasound2-dev (Linux only)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+        with:
+          # Distinct shared-key from python-ci.yml's "rust-python" so
+          # publish builds reach steady state independently. Tag-trigger
+          # cadence is far rarer than push CI; sharing the cache would
+          # mostly serve cold-start hits.
+          shared-key: "rust-python-publish"
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "bindings/python/uv.lock"
+
+      - name: Install Python (3.10 floor)
+        # abi3 contract: a wheel built against Python 3.10 stable ABI loads
+        # cleanly on every CPython 3.10+. Building once at the floor is
+        # sufficient; python-ci.yml's nightly matrix verifies forward
+        # compatibility across 3.10-3.14.
+        run: uv python install 3.10
+
+      - name: Sync dev environment (locked)
+        working-directory: bindings/python
+        run: uv sync --dev --locked
+
+      # ORT dylib download. Linux uses the manylinux container build below
+      # (ORT downloaded inside the container); macOS and Windows download
+      # on the host and stage into bindings/python/python/decibri/_ort/
+      # before maturin packages it via the [tool.maturin] include directive.
+      # Mirrors python-ci.yml lines 178-305 for the host-build paths.
+      - name: Compute ORT URL
+        if: runner.os != 'Linux'
+        id: ort-meta
+        shell: bash
+        run: |
+          URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}.${{ matrix.ort_ext }}"
+          echo "url=${URL}" >> "$GITHUB_OUTPUT"
+          echo "Resolved: ${URL}"
+
+      - name: Download and extract ONNX Runtime (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        # cp -L dereferences the symlink chain so the bundled file is a real
+        # signed dylib, not a dangling link post-pip-install. Renamed to
+        # unversioned to match what _ort_resolver.py looks for.
+        run: |
+          mkdir -p bindings/python/python/decibri/_ort
+          curl -sL --retry 3 --retry-delay 2 -o ort.tgz "${{ steps.ort-meta.outputs.url }}"
+          tar -xzf ort.tgz
+          SRC="onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}"
+          cp -L "$SRC/lib/libonnxruntime.${ORT_VERSION}.dylib" bindings/python/python/decibri/_ort/libonnxruntime.dylib
+
+      - name: Download and extract ONNX Runtime (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ProgressPreference = 'SilentlyContinue'
+          New-Item -ItemType Directory -Force -Path bindings/python/python/decibri/_ort | Out-Null
+          Invoke-WebRequest -Uri "${{ steps.ort-meta.outputs.url }}" -OutFile ort.zip -MaximumRetryCount 3 -RetryIntervalSec 2
+          Expand-Archive -Path ort.zip -DestinationPath .
+          $src = "onnxruntime-${{ matrix.ort_platform_slug }}-$env:ORT_VERSION"
+          Copy-Item "$src/lib/onnxruntime.dll" bindings/python/python/decibri/_ort/
+
+      # macOS / Windows: build the release wheel on the host. Linux uses the
+      # manylinux container step further down. Mirrors python-ci.yml line 335.
+      - name: Build release wheel (macOS / Windows host build)
+        if: runner.os != 'Linux'
+        working-directory: bindings/python
+        shell: bash
+        run: |
+          rm -rf "${GITHUB_WORKSPACE}/target/wheels/"
+          uv run maturin build --release
+
+      - name: Clean target/ before Linux container build
+        if: runner.os == 'Linux'
+        shell: bash
+        # Wipe target/ before the manylinux_2_28 container build so cached
+        # host-built artifacts (linked against ubuntu-latest's glibc 2.38)
+        # do not leak into the container's glibc 2.28 build context.
+        # Mirrors python-ci.yml line 366-391.
+        run: rm -rf "${GITHUB_WORKSPACE}/target/"
+
+      - name: Build Linux wheel in manylinux_2_28 container
+        if: runner.os == 'Linux'
+        # Mirrors python-ci.yml lines 393-472. manylinux_2_28 is the glibc
+        # floor compatible with ONNX Runtime 1.24's documented requirements.
+        # PyO3/maturin-action provides the container; before-script-linux
+        # installs alsa-lib-devel + downloads + stages the ORT dylib before
+        # maturin runs.
+        uses: PyO3/maturin-action@3e2bdf6ba6453a61e649744019b8a2d906c7eb38 # v1.51.0
+        with:
+          manylinux: 2_28
+          target: ${{ matrix.target }}
+          working-directory: bindings/python
+          args: --release --compatibility pypi --out ${{ github.workspace }}/target/wheels
+          before-script-linux: |
+            set -euo pipefail
+            dnf install -y alsa-lib-devel
+            ORT_VERSION="${{ env.ORT_VERSION }}"
+            ARCH=$(uname -m)
+            case "$ARCH" in
+              x86_64)  ORT_ARCH="linux-x64"     ;;
+              aarch64) ORT_ARCH="linux-aarch64" ;;
+              *)
+                echo "ERROR: unsupported container architecture: $ARCH"
+                exit 1
+                ;;
+            esac
+            ORT_TARBALL="onnxruntime-${ORT_ARCH}-${ORT_VERSION}.tgz"
+            ORT_URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/${ORT_TARBALL}"
+            echo "Downloading ORT inside container: $ORT_URL"
+            mkdir -p bindings/python/python/decibri/_ort
+            curl -sL --retry 3 --retry-delay 2 -o /tmp/ort.tgz "$ORT_URL"
+            tar -xzf /tmp/ort.tgz -C /tmp
+            SRC="/tmp/onnxruntime-${ORT_ARCH}-${ORT_VERSION}"
+            cp -L "$SRC/lib/libonnxruntime.so" bindings/python/python/decibri/_ort/libonnxruntime.so
+            cp    "$SRC/lib/libonnxruntime_providers_shared.so" bindings/python/python/decibri/_ort/
+            ls -la bindings/python/python/decibri/_ort/
+
+      # auditwheel / delocate: bundle external deps + rewrite RPATH /
+      # install-name. Required for PyPI manylinux compliance + macOS
+      # @loader_path. Mirrors python-ci.yml lines 474-601.
+      - name: Install auditwheel (Linux only)
+        if: runner.os == 'Linux'
+        working-directory: bindings/python
+        run: uv pip install 'auditwheel>=6.0,<7.0'
+
+      - name: Run auditwheel repair (Linux only)
+        if: runner.os == 'Linux'
+        working-directory: bindings/python
+        shell: bash
+        run: |
+          set -euo pipefail
+          WHEEL=$(ls "${GITHUB_WORKSPACE}/target/wheels/decibri-"*.whl | head -1)
+          if [ -z "$WHEEL" ]; then
+            echo "ERROR: no wheel found for auditwheel"
+            exit 1
+          fi
+          echo "Auditing wheel (pre-repair): $WHEEL"
+          uv run auditwheel show "$WHEEL"
+          ARCH=$(uname -m)
+          case "$ARCH" in
+            x86_64)  PLAT="manylinux_2_28_x86_64" ;;
+            aarch64) PLAT="manylinux_2_28_aarch64" ;;
+            *)
+              echo "ERROR: unsupported architecture for auditwheel: $ARCH"
+              exit 1
+              ;;
+          esac
+          mkdir -p "${GITHUB_WORKSPACE}/target/wheels/repaired"
+          uv run auditwheel repair --plat "$PLAT" \
+            -w "${GITHUB_WORKSPACE}/target/wheels/repaired/" "$WHEEL"
+          rm "$WHEEL"
+          mv "${GITHUB_WORKSPACE}/target/wheels/repaired/decibri-"*.whl \
+             "${GITHUB_WORKSPACE}/target/wheels/"
+          rmdir "${GITHUB_WORKSPACE}/target/wheels/repaired"
+          NEW_WHEEL=$(ls "${GITHUB_WORKSPACE}/target/wheels/decibri-"*.whl | head -1)
+          echo "Repaired wheel: $NEW_WHEEL"
+          uv run auditwheel show "$NEW_WHEEL"
+
+      - name: Install delocate (macOS only)
+        if: runner.os == 'macOS'
+        working-directory: bindings/python
+        run: uv pip install 'delocate>=0.13.0,<0.14.0'
+
+      - name: Run delocate repair (macOS only)
+        if: runner.os == 'macOS'
+        working-directory: bindings/python
+        shell: bash
+        # -L _ort keeps bundled dylibs in the existing _ort/ directory
+        # (rather than delocate's default .dylibs/) so _ort_resolver.py's
+        # glob pattern continues to find the dylib.
+        run: |
+          set -euo pipefail
+          WHEEL=$(ls "${GITHUB_WORKSPACE}/target/wheels/decibri-"*.whl | head -1)
+          if [ -z "$WHEEL" ]; then
+            echo "ERROR: no wheel found for delocate"
+            exit 1
+          fi
+          echo "Delocating wheel (pre-repair): $WHEEL"
+          uv run delocate-listdeps --depending "$WHEEL"
+          mkdir -p "${GITHUB_WORKSPACE}/target/wheels/repaired"
+          uv run delocate-wheel \
+            -w "${GITHUB_WORKSPACE}/target/wheels/repaired/" \
+            -L _ort \
+            -v "$WHEEL"
+          rm "$WHEEL"
+          mv "${GITHUB_WORKSPACE}/target/wheels/repaired/decibri-"*.whl \
+             "${GITHUB_WORKSPACE}/target/wheels/"
+          rmdir "${GITHUB_WORKSPACE}/target/wheels/repaired"
+          NEW_WHEEL=$(ls "${GITHUB_WORKSPACE}/target/wheels/decibri-"*.whl | head -1)
+          uv run delocate-listdeps --depending "$NEW_WHEEL"
+
+      # abi3 compliance gate (LD-10-4). Hard fail via --strict; --assume-
+      # minimum-abi3 3.10 pins to decibri's abi3 floor and avoids the
+      # documented bare-.so abi3-cp32 false-positive case from abi3audit's
+      # README. Empirically verified passing on the existing wheel during
+      # Phase 10 prep research.
+      - name: Install abi3audit
+        run: pip install --no-deps 'abi3audit==0.0.26'
+
+      - name: Verify abi3 compliance
+        shell: bash
+        run: |
+          set -euo pipefail
+          WHEEL=$(ls "${GITHUB_WORKSPACE}/target/wheels/decibri-"*.whl | head -1)
+          if [ -z "$WHEEL" ]; then
+            echo "ERROR: no wheel found for abi3audit"
+            exit 1
+          fi
+          abi3audit --strict --verbose --assume-minimum-abi3 3.10 "$WHEEL"
+
+      # Wheel install-test gate (LD-10-3). Mirrors python-ci.yml lines
+      # 603-670. Polars-style in-job verification: install the just-built
+      # wheel into a fresh venv on the same platform that built it, run
+      # smoke tests with CI=true so hardware-gated tests skip via the
+      # Phase 9 conftest auto-skip policy.
+      - name: Wheel install-test in clean venv
+        working-directory: bindings/python
+        shell: bash
+        env:
+          CI: 'true'
+        run: |
+          set -euo pipefail
+          WHEEL=$(ls "${GITHUB_WORKSPACE}/target/wheels/decibri-"*.whl | head -1)
+          if [ -z "$WHEEL" ]; then
+            echo "ERROR: no wheel found in ${GITHUB_WORKSPACE}/target/wheels/"
+            exit 1
+          fi
+          echo "Install-test target: $WHEEL"
+          uv venv .install-test
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            VENV_PY=".install-test/Scripts/python.exe"
+          else
+            VENV_PY=".install-test/bin/python"
+          fi
+          uv pip install --python "$VENV_PY" "$WHEEL" pytest
+          # Same test surface as python-ci.yml's canonical install gate
+          # (line 670): test_ort_bundling.py + test_wheel_smoke.py cover
+          # bundled ORT layout, import, sync construct, async construct,
+          # numpy=True, resolver-finds-bundled. test_smoke.py adds the
+          # public surface count + version assertions.
+          "$VENV_PY" -m pytest \
+              tests/test_wheel_smoke.py \
+              tests/test_smoke.py \
+              tests/test_ort_bundling.py \
+              -v
+
+      - name: Upload validated wheel artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: wheel-${{ matrix.target }}
+          path: target/wheels/decibri-*.whl
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    # Prerelease tags (PEP 440 a / b / rc segments) route to TestPyPI.
+    # The github.event_name == 'push' guard ensures workflow_dispatch
+    # validation runs (LD-10-8) never publish; build-and-validate runs
+    # the matrix and the publish jobs skip cleanly.
+    if: |
+      github.event_name == 'push' && (
+        contains(github.ref_name, 'a') ||
+        contains(github.ref_name, 'b') ||
+        contains(github.ref_name, 'rc')
+      )
+    needs: [build-and-validate]
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/decibri/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: dist/
+          merge-multiple: true
+          pattern: wheel-*
+
+      - name: List artifacts (diagnostic)
+        run: ls -la dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          repository-url: https://test.pypi.org/legacy/
+          # attestations: true is the v1.14 default for Trusted Publishing
+          # flows; explicit per LD-10-5 to protect against future v2
+          # default flips.
+          attestations: true
+          verbose: true
+          print-hash: true
+
+  publish-pypi:
+    name: Publish to PyPI
+    # Stable tags (no PEP 440 a / b / rc segments) route to production
+    # PyPI. github.event_name == 'push' guard mirrors publish-testpypi.
+    if: |
+      github.event_name == 'push' && !(
+        contains(github.ref_name, 'a') ||
+        contains(github.ref_name, 'b') ||
+        contains(github.ref_name, 'rc')
+      )
+    needs: [build-and-validate]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/decibri/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: dist/
+          merge-multiple: true
+          pattern: wheel-*
+
+      - name: List artifacts (diagnostic)
+        run: ls -la dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          attestations: true
+          verbose: true
+          print-hash: true

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -24,7 +24,7 @@ name: Publish to PyPI
 # Workflow filename is locked at TPP registration time; renaming requires
 # manual TPP delete + re-add on both registries (LD-10-1).
 
-"on":
+on:
   push:
     tags:
       - 'python-v*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,18 @@ name: Release
 on:
   push:
     tags:
+      # Rust core / npm release tags. Phase 10 (2026-05-02) added the
+      # 'python-v*' negative pattern to exclude Python wheel tags
+      # (python-v0.1.0a1, python-v0.1.0, ...) which now route exclusively
+      # to publish-pypi.yml. Tag namespacing per LD-10-11 keeps both
+      # workflows' preflight gates intact: this workflow asserts the
+      # tag matches the workspace Cargo.toml + npm package.json versions
+      # (job below); publish-pypi.yml has its own Trusted Publisher
+      # OIDC trust chain. Without this exclusion, a Python tag would fire
+      # both workflows and release.yml's preflight would hard-fail on the
+      # version mismatch.
       - 'v*'
+      - '!python-v*'
 
 permissions:
   contents: write
@@ -324,7 +335,7 @@ jobs:
       # Copy README into npm package directory before publish. Relocated
       # upward from its previous position (between platform-package and
       # main-package publishes) so the `Verify npm package contents` gate
-      # below sees the main package fully staged — otherwise verify_pack
+      # below sees the main package fully staged. Otherwise verify_pack
       # would fail on the main package with ":README.md missing".
       - name: Copy README for npm package
         run: cp README.md npm/decibri/README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `DecibriError::ForkAfterOrtInit { init_pid: u32, current_pid: u32 }` variant. Permitted by `#[non_exhaustive]`; existing variants unchanged.
 - New `bindings/python/tests/test_repr.py` (8 tests) and `bindings/python/tests/test_fork_safety.py` (3 Linux-only tests gated by `pytest.mark.skipif(sys.platform != "linux")` + `requires_bundled_ort`). 5 new tests appended to `tests/test_async.py` for `AsyncMicrophone.open` / `AsyncSpeaker.open` behavior.
 
+### Python binding (0.1.0a1) - Phase 10 pre-publish hardening
+
+#### Internal
+
+- Phase 10: pre-publish hardening. New publish workflow at [`.github/workflows/publish-pypi.yml`](.github/workflows/publish-pypi.yml) routes prerelease tags (`python-v0.1.0a1`, `python-v0.1.0b1`, `python-v0.1.0rc1`) to TestPyPI and stable tags (`python-v0.1.0`) to production PyPI via Trusted Publisher OIDC (no API tokens). Build-and-validate matrix across 5 platforms (ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-13, windows-latest) gated by abi3audit (`--strict --assume-minimum-abi3 3.10`) and an in-job wheel install-test in a clean venv with `CI=true` (Phase 9 conftest auto-skips hardware-gated tests). PEP 740 attestations generated automatically via Sigstore + OIDC (`pypa/gh-action-pypi-publish v1` default for OIDC publishes; explicit `attestations: true` for clarity).
+- Tag namespacing per LD-10-11 (Option 1): Python wheel tags use the `python-v*` prefix to disambiguate from Rust core / npm tags (`v3.4.0`, `v3.5.0`, ...). [`.github/workflows/release.yml`](.github/workflows/release.yml) tag filter updated to exclude `python-v*` (`'!python-v*'` negative pattern) so the npm + crates.io workflow does not fire on Python wheel tags. Both workflows keep their preflight gates intact.
+- New [`bindings/python/docs/PUBLISH.md`](bindings/python/docs/PUBLISH.md) documents tag patterns, the end-to-end publish flow, the Trusted Publisher setup (already configured), the `workflow_dispatch` dry-run procedure, and failure recovery for abi3audit / install-test / OIDC rejection cases.
+- No source code changes; no Rust core changes; no Python binding changes; no test additions. Phase 10 is CI infrastructure only.
+
 ## [3.4.0] - 2026-05-02
 
 ### Added

--- a/bindings/python/docs/PUBLISH.md
+++ b/bindings/python/docs/PUBLISH.md
@@ -1,0 +1,161 @@
+# Publishing decibri to PyPI
+
+This document describes how decibri Python wheels are published to PyPI and TestPyPI via the [`publish-pypi.yml`](../../../.github/workflows/publish-pypi.yml) GitHub Actions workflow. The workflow uses Trusted Publisher OIDC (no API tokens) and produces PEP 740 attestations via Sigstore.
+
+Phase 10 (2026-05-02) shipped this workflow. The first publish (decibri 0.1.0a1 to TestPyPI) is Phase 11 work.
+
+## Tag patterns
+
+decibri's repository is polyglot: the Rust core, npm package, and Python wheel each have their own version cadences. Tag namespacing keeps each registry's publish workflow scoped to its own tags.
+
+| Tag pattern              | Workflow                                                          | Registry                  |
+| ------------------------ | ----------------------------------------------------------------- | ------------------------- |
+| `python-v0.1.0a1`        | [`publish-pypi.yml`](../../../.github/workflows/publish-pypi.yml) | TestPyPI (alpha)          |
+| `python-v0.1.0b1`        | [`publish-pypi.yml`](../../../.github/workflows/publish-pypi.yml) | TestPyPI (beta)           |
+| `python-v0.1.0rc1`       | [`publish-pypi.yml`](../../../.github/workflows/publish-pypi.yml) | TestPyPI (release candidate) |
+| `python-v0.1.0`          | [`publish-pypi.yml`](../../../.github/workflows/publish-pypi.yml) | PyPI (stable)             |
+| `v3.4.0`, `v3.5.0`, etc. | [`release.yml`](../../../.github/workflows/release.yml)           | npm + crates.io           |
+
+All `python-v*` patterns are PEP 440 compliant (the `python-v` prefix is workflow-routing only; the `v0.1.0a1` portion is what PyPI sees as the version after the wheel filename strips the namespace). Detection of TestPyPI vs PyPI is done via `contains(github.ref_name, 'a' | 'b' | 'rc')` inside the workflow `if:` conditions.
+
+`release.yml`'s tag filter explicitly excludes `python-v*` (`'!python-v*'` in its trigger), so the npm + crates.io workflow does not fire on Python wheel tags.
+
+## End-to-end publish flow
+
+1. Bump the wheel version in [`bindings/python/Cargo.toml`](../Cargo.toml) (the binding crate version becomes the wheel version via maturin).
+2. Update [`bindings/python/CHANGELOG.md`](../CHANGELOG.md) with the new version's entry.
+3. Commit and push to `main` (typically via squash-merge from `development`).
+4. Create and push the tag:
+   ```bash
+   git tag python-v0.1.0a1
+   git push origin python-v0.1.0a1
+   ```
+5. CI runs `publish-pypi.yml`:
+   - `build-and-validate` matrix builds wheels across 5 platforms (ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-13, windows-latest)
+   - Each platform: maturin build, auditwheel/delocate repair, abi3audit gate, install-test in clean venv with `CI=true`, upload artifact
+   - `fail-fast: true` means any platform failure blocks both publish jobs
+6. Tag-pattern routing kicks in:
+   - Prerelease tags (`python-v*a*`, `python-v*b*`, `python-v*rc*`): `publish-testpypi` job runs after `build-and-validate` succeeds. The `testpypi` GitHub environment has a 1-minute wait timer.
+   - Stable tags (`python-v\d+.\d+.\d+`): `publish-pypi` job runs after `build-and-validate` succeeds. The `pypi` GitHub environment requires reviewer approval. Production PyPI publish blocks until approved.
+7. PyPI / TestPyPI receives the wheel via Trusted Publisher OIDC. Sigstore attestations generated automatically.
+8. The project page on PyPI / TestPyPI shows the new version with the attestation badge.
+
+## Trusted Publisher setup (already configured)
+
+For future-maintainer reference; do NOT need to redo unless the workflow filename changes. TPP records key on the workflow filename and the GitHub environment name; they survive all other workflow edits.
+
+**PyPI** (`https://pypi.org/manage/project/decibri/settings/publishing/`):
+
+| Field | Value |
+| ----- | ----- |
+| Owner | `decibri` |
+| Repository | `decibri` |
+| Workflow | `publish-pypi.yml` |
+| Environment | `pypi` |
+
+**TestPyPI** (`https://test.pypi.org/manage/project/decibri/settings/publishing/`):
+
+| Field | Value |
+| ----- | ----- |
+| Owner | `decibri` |
+| Repository | `decibri` |
+| Workflow | `publish-pypi.yml` |
+| Environment | `testpypi` |
+
+**GitHub `pypi` environment** (repo Settings -> Environments):
+- Required reviewer: `rossarmstrong`
+- Deployment tag rule: `python-v*.*.*` (stable tags only; prereleases blocked)
+
+**GitHub `testpypi` environment**:
+- Wait timer: 1 minute
+- Deployment tag rule: `python-v*` (all tags including prereleases)
+
+If the workflow filename ever changes from `publish-pypi.yml`, the TPP records on BOTH registries must be deleted and re-added. The OIDC trust chain breaks otherwise.
+
+## Dry-run procedure (workflow_dispatch)
+
+For workflow file changes pre-tag, run the workflow manually from the Actions UI:
+
+1. Push the workflow file change to `development` (or `main`).
+2. Navigate to `https://github.com/decibri/decibri/actions/workflows/publish-pypi.yml`.
+3. Click "Run workflow" -> select the branch -> confirm.
+4. The `build-and-validate` matrix runs across all 5 platforms.
+5. The `publish-testpypi` and `publish-pypi` jobs both skip cleanly because their `if:` conditions key on `github.event_name == 'push'`.
+
+If `build-and-validate` passes on all 5 platforms during a manual dispatch, the workflow file is wired correctly. If a platform fails, fix before tagging.
+
+## Failure recovery
+
+### abi3audit fails
+
+Symptom: `build-and-validate` matrix entry fails on the "Verify abi3 compliance" step with output like `1 ABI version mismatches and N ABI violations found`.
+
+Cause: a Rust dependency added a non-abi3 export that ended up in the compiled extension. Phase 10 prep research empirically verified the existing wheel passes; a regression here is from a Phase 8 / Phase 9 / later change.
+
+Recovery: inspect `Cargo.lock` for new dependencies since the last successful publish; check whether the new dep links a non-abi3 symbol (`pyo3-build-config` output is the usual diagnostic). Pin the dep to a known-good version or remove the offending export.
+
+### Install-test fails on a specific platform
+
+Symptom: `build-and-validate` matrix entry fails on "Wheel install-test in clean venv" for a single platform (commonly macOS due to rpath, or Linux due to manylinux compatibility).
+
+Recovery: check the platform-specific build logs:
+- **macOS:** look for `LC_LOAD_DYLIB` / install-name issues; verify `delocate-listdeps` output shows only `/System/Library/Frameworks/...` deps. A new external dep slipping into the wheel needs a delocate rerun.
+- **Linux:** look for auditwheel violations; run `auditwheel show` on the failing wheel to see what symbol versioning broke. If a new glibc symbol crept in, the manylinux floor needs to bump (currently `manylinux_2_28`).
+- **Windows:** look for missing CRT or Windows SDK DLLs in the import table; `dumpbin /imports` output during build shows what's pulled in.
+
+### Trusted Publisher rejects OIDC token
+
+Symptom: `publish-testpypi` or `publish-pypi` fails with an error like `the OIDC token itself is well-formed... but doesn't match any known (pending) OIDC publisher`.
+
+Cause: workflow filename in the TPP record does not match the running workflow's filename. This is the documented contract per [PyPI's troubleshooting docs](https://docs.pypi.org/trusted-publishers/troubleshooting/).
+
+Recovery: verify the TPP record on PyPI / TestPyPI matches:
+- Owner: `decibri`
+- Repository: `decibri`
+- Workflow: `publish-pypi.yml` (basename, not full path)
+- Environment: `pypi` or `testpypi` matching the failing job
+
+If the workflow file was renamed, delete the TPP record and add a new one with the new filename. Same on the other registry.
+
+### Required reviewer block on `pypi` environment
+
+Symptom: `publish-pypi` job sits in "Waiting for review" state.
+
+This is intentional gating per the GitHub `pypi` environment configuration. The required reviewer approves via the Actions UI's reviewer prompt before the publish proceeds.
+
+To remove the gate (e.g., at 0.2.0+ when the workflow is proven), edit the `pypi` environment in repo Settings -> Environments and remove the required reviewer or replace with a wait timer.
+
+### Tag pushed to wrong workflow
+
+Symptom: tag does not match the expected `python-v*` namespace, so `publish-pypi.yml` does not fire (or `release.yml` fires when it shouldn't).
+
+Recovery: delete the tag locally and remotely, push the correctly-namespaced tag:
+```bash
+git tag -d python-v0.1.0a1
+git push origin --delete python-v0.1.0a1
+git tag python-v0.1.0a1 <correct-sha>
+git push origin python-v0.1.0a1
+```
+
+Note: deleting a tag does NOT undo a successful PyPI publish. If the wheel already uploaded, you must bump the version (PyPI does not allow re-uploading the same version).
+
+## Phase 11 alpha cycle expectations
+
+Phase 11 (next phase) ships the first real publishes:
+
+1. Push `python-v0.1.0a1`. CI runs build-and-validate (5 platforms); abi3audit + install-test gate; `publish-testpypi` runs. Wheel lands on TestPyPI.
+2. Manual validation: in a fresh local venv, run `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ decibri==0.1.0a1` and exercise the public API (sync construct, async construct, VAD path).
+3. If issues surface: fix on `main`, bump to `python-v0.1.0a2`, push, repeat.
+4. When the alpha is clean and the user-facing surface is finalized, push `python-v0.1.0`. CI runs build-and-validate; the `publish-pypi` job blocks on reviewer approval; on approval, the wheel ships to production PyPI.
+
+The alpha cycle's purpose is to catch issues that the install-test gate cannot reproduce: real-world `pip install` from a registry, dependency resolution conflicts with user environments, missing classifiers in the project metadata, README rendering on the PyPI project page, and so on.
+
+## Implementation references
+
+- Workflow file: [`.github/workflows/publish-pypi.yml`](../../../.github/workflows/publish-pypi.yml)
+- Existing matrix patterns mirrored: [`.github/workflows/python-ci.yml`](../../../.github/workflows/python-ci.yml) lines 393-601 (manylinux container build, auditwheel, delocate) and lines 603-670 (install-test gate)
+- Tag-routing rationale: `~/.claude/plans/phase-10-design-adjudication.md` (Option D verdict; cohort survey of ruff, uv, polars, tokenizers, pydantic-core)
+- abi3audit empirical verification: `~/.claude/plans/phase-10-prep-research.md` Section 2.3 (existing decibri wheel passes `abi3audit --strict --assume-minimum-abi3 3.10` with 0 violations and 0 mismatches)
+- PEP 740 attestation specification: https://peps.python.org/pep-0740/
+- pypa/gh-action-pypi-publish v1.14: https://github.com/pypa/gh-action-pypi-publish (attestations on by default for OIDC publishes)
+- PyPI Trusted Publisher docs: https://docs.pypi.org/trusted-publishers/


### PR DESCRIPTION
Phase 10 of the Python Integration Project. Builds the publish workflow that Phase 11 will use to ship 0.1.0a1 to TestPyPI and 0.1.0 to PyPI. Phase 10 itself does not publish to PyPI; it ships the workflow and the documentation, with end-to-end validation deferred to post-merge `workflow_dispatch` from `main`.

Driven by the Phase 10 prep research (`phase-10-prep-research.md`) which confirmed outcome (i) clean across six tracks: abi3audit empirically passes on the existing decibri wheel; pypa/gh-action-pypi-publish v1.14.0 has attestations on by default; PyPI/TestPyPI Trusted Publisher setup flow is current; workflow filename `publish-pypi.yml` matches astral-sh convention for polyglot Rust+Python projects.

Design adjudication (`phase-10-design-adjudication.md`) selected Option D after surveying 5 cohort projects (ruff, uv, polars, tokenizers, pydantic-core): tag-routed publish workflow that mirrors `python-ci.yml`'s existing in-job install-verification pattern (polars-style), adds abi3audit, and uploads validated wheels to the appropriate registry. All in the same job that built each wheel so each platform's wheel is verified on its own platform.

## What ships

### `.github/workflows/publish-pypi.yml`

New publish workflow file. Triggers on git tags matching `python-v*` (Rust core / npm tags continue to use `release.yml` per LD-10-11 tag namespacing). Includes `workflow_dispatch:` trigger for design-validation runs without a tag.

Build-and-validate matrix: ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-13, windows-latest. Per platform: build wheel via maturin/manylinux, auditwheel/delocate repair, abi3audit gate (`--strict --verbose --assume-minimum-abi3 3.10`), install-test in clean venv with `CI=true` so hardware-gated tests skip per the Phase 9 conftest.

Two mutually-exclusive publish jobs gated on `github.event_name == 'push'`:
- `publish-testpypi`: prerelease tags (PEP 440 a/b/rc segments) -> TestPyPI
- `publish-pypi`: stable tags (no prerelease segment) -> PyPI

Trusted Publisher OIDC chain (no API tokens). PEP 740 attestations via Sigstore + Fulcio (`attestations: true` explicit per LD-10-5 to protect against future v2 default flip). `fail-fast: true` matrix per LD-10-7. ORT_VERSION pinned at 1.24.4 per LD-10-9.

### `.github/workflows/release.yml`

Tag filter updated to add `'!python-v*'` exclusion so the npm + crates.io workflow does not fire on Python wheel tags. One-line change plus inline rationale comment.

Plus a one-character cleanup of a pre-existing em-dash on line 338 (mechanical; zero semantic change; bundled because the file was already being touched).

### `bindings/python/docs/PUBLISH.md`

User-facing publish documentation. Tag patterns table (`python-v0.1.0a1` -> TestPyPI; `python-v0.1.0` -> PyPI; PEP 440-compliant prerelease detection). End-to-end publish flow. Trusted Publisher setup reference (already configured by the maintainer pre-Phase-10). Dry-run procedure via `workflow_dispatch`. Failure recovery for abi3audit / install-test / OIDC rejection cases. Phase 11 alpha cycle expectations.

### `CHANGELOG.md`

Phase 10 entry under `[Unreleased]` Internal section.

## Cross-binding compat

Per LD-9-1 (Phase 9 prep) and CLAUDE.md guardrail 2: Phase 10 is publish-workflow-only. Rust core 3.4.0 unchanged. Node binding unchanged. Browser shim unchanged. No source code changes; no test additions; no API changes.

## Pre-Phase-10 manual setup (completed by the maintainer before this commit)

- **PyPI:** `decibri 0.0.0` placeholder version registered. Trusted Publisher configured for `decibri/decibri/publish-pypi.yml/pypi`. No API tokens.
- **TestPyPI:** `decibri 0.0.0` placeholder version registered. Trusted Publisher configured for `decibri/decibri/publish-pypi.yml/testpypi`. No API tokens.
- **GitHub `pypi` environment:** required reviewer; deployment tag rule `python-v*.*.*` (stable releases only).
- **GitHub `testpypi` environment:** 1-minute wait timer; deployment tag rule `python-v*` (all tags including prereleases).
- **Workflow filename locked:** `publish-pypi.yml` (cannot be renamed without manual TPP reconfiguration on both registries; LD-10-1).

## Verified

- Rust unit tests: 47 (unchanged from Phase 9)
- Rust integration tests: 4 (unchanged)
- Python pytest: 161 passed, 75 hardware-skipped (regression-free; Phase 10 doesn't touch source)
- Python mypy --strict: clean
- cargo build --release -p decibri: clean
- cargo clippy --workspace -- -D warnings: clean
- cargo fmt --all -- --check: clean
- Node CI tests: 44/44
- Browser shim vitest: 64/64
- Em-dash sweep across `bindings/python/`, `crates/decibri/`, `.github/workflows/`: 0 hits
- Standard CI matrix: all green on `development`
- actionlint v1.7.7: clean exit 0 on `publish-pypi.yml`, `python-ci.yml`, `release.yml`
- yamllint default ruleset: only cosmetic warnings (consistent with existing workflows)
- Workflow file integrity verified: ASCII text, LF line endings, no BOM, byte-identical local + remote (SHA-1 `6c6afac8...`)

## End-to-end validation deferred to post-merge

Phase 10 plan Section 7.2 originally recommended validating via `workflow_dispatch` trigger before squash-merge to `main`. After implementation, Claude Code's diagnostic investigation (`phase-10-workflow-diagnostic.md`) confirmed via GitHub's official documentation that `workflow_dispatch` triggers from the Actions UI require the workflow file to be on the repository's default branch (`main`). The pre-merge validation is therefore not possible from `development`.

Decision: squash-merge Phase 10 first, then run `workflow_dispatch` from `main` to validate. The workflow is structurally valid (actionlint clean; YAML parses correctly; all referenced action versions exist). If validation reveals platform-specific build issues, those land as a Phase 10 follow-up commit. The implementation report at `~/.claude/plans/phase-10-implementation-report.md` and the workflow diagnostic at `~/.claude/plans/phase-10-workflow-diagnostic.md` capture the full investigation.

## Locked decisions resolved (added to master plan)

**LD-10-1** workflow filename `publish-pypi.yml` (externally locked by Trusted Publisher registration).

**LD-10-2** tag-pattern routing per PEP 440 (prerelease segments -> TestPyPI; stable -> PyPI).

**LD-10-3** install-test gate mandatory before publish.

**LD-10-4** abi3audit hard fail.

**LD-10-5** attestations explicit `true`.

**LD-10-6** single workflow with two mutually-exclusive jobs (one workflow, not two; matches PyPA official guide pattern).

**LD-10-7** `fail-fast: true` on the matrix.

**LD-10-8** `workflow_dispatch` trigger included for design-validation runs.

**LD-10-9** ORT_VERSION pinned at 1.24.4 in workflow env (must stay in sync with python-ci.yml + release.yml).

**LD-10-10** environment URLs in workflow YAML (not Settings).

**LD-10-11** tag namespacing per Option 1: Python wheel tags use `python-v*` prefix; Rust core / npm tags keep `v*` prefix; `release.yml` tag filter excludes `python-v*` via negative pattern. Both workflows keep their preflight gates intact.

## Items deliberately NOT in scope

- Reusable build-wheels workflow extraction (defer to 0.2.0+ once duplication burden is felt; Phase 10 inlines the manylinux pattern from `python-ci.yml`).
- abi3audit gate on `python-ci.yml` push events (defer to 0.2.0+ defense-in-depth).
- pip install verification gate post-publish (Phase 11 follow-up workflow that pulls the just-published wheel from PyPI/TestPyPI and validates it loads cleanly).
- pyroma / check-wheel-contents metadata gates (0.2.0+).

## Implementation report

Full implementation details, validation gate output, surprises, and per-step results are captured in `~/.claude/plans/phase-10-implementation-report.md`. Workflow visibility diagnostic in `~/.claude/plans/phase-10-workflow-diagnostic.md`. Master plans (`python-integration-project.md` and `decibri-master-plan-v3-draft.md`) and 0.2.0 backlog (`0-2-0-backlog.md`) updated to reflect Phase 10 ship.

After this PR squash-merges, Phase 10 is complete. **Phase 11 (TestPyPI alpha cycle: `python-v0.1.0a1` first publish + validate + `python-v0.1.0a2` if needed + `python-v0.1.0` production publish) is the next active phase.**