### PR TITLE
phase 10 follow-up: install abi3audit without --no-deps flag

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -291,7 +291,7 @@ jobs:
       # README. Empirically verified passing on the existing wheel during
       # Phase 10 prep research.
       - name: Install abi3audit
-        run: pip install --no-deps 'abi3audit==0.0.26'
+        run: pip install 'abi3audit==0.0.26'
 
       - name: Verify abi3 compliance
         shell: bash


### PR DESCRIPTION
The Phase 10 workflow installed abi3audit with 'pip install --no-deps' which prevented its dependencies (abi3info, rich, requests) from being installed. abi3audit fails at runtime with 'ModuleNotFoundError: No module named abi3info' on every platform; macOS aarch64 was the first to fail and fail-fast killed the other 4 in-progress jobs.

Phase 10 prep research empirically verified abi3audit works against the decibri wheel; the prep research ran 'pip install abi3audit' without --no-deps. The workflow's --no-deps flag was incorrect and broke the abi3 compliance gate at validation time.

Fix: remove --no-deps so abi3audit's dependencies install correctly. abi3info, rich, and other transitive deps are required for abi3audit's CLI to function.

Verified by inspecting the runtime failure: 'ModuleNotFoundError on abi3info import in abi3audit/_cli.py:15'. Failed run: github.com/decibri/decibri/actions/runs/25253049231.