### PR TITLE
Phase 10 follow-up: drop deprecated Intel Mac platform + bump Node-20 actions

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -73,10 +73,13 @@ jobs:
             target: aarch64-apple-darwin
             ort_platform_slug: osx-arm64
             ort_ext: tgz
-          - os: macos-13
-            target: x86_64-apple-darwin
-            ort_platform_slug: osx-x86_64
-            ort_ext: tgz
+          # x86_64-apple-darwin (macos-13) dropped 2026-05-03. Apple shipped
+          # the last Intel Macs between 2020-2022; macOS 26 (2025) dropped
+          # support for many Intel models. Phase 10's first workflow_dispatch
+          # validation showed the macos-13 GitHub-hosted runner pool is
+          # severely under-provisioned (12+ minute queue times). Intel Mac
+          # users (a vanishing population) can install from source via
+          # `pip install decibri --no-binary :all:`.
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             ort_platform_slug: win-x64
@@ -341,7 +344,7 @@ jobs:
               -v
 
       - name: Upload validated wheel artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: wheel-${{ matrix.target }}
           path: target/wheels/decibri-*.whl

--- a/bindings/python/docs/PUBLISH.md
+++ b/bindings/python/docs/PUBLISH.md
@@ -31,7 +31,7 @@ All `python-v*` patterns are PEP 440 compliant (the `python-v` prefix is workflo
    git push origin python-v0.1.0a1
    ```
 5. CI runs `publish-pypi.yml`:
-   - `build-and-validate` matrix builds wheels across 5 platforms (ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-13, windows-latest)
+   - `build-and-validate` matrix builds wheels across 4 platforms (ubuntu-latest, ubuntu-24.04-arm, macos-14, windows-latest). x86_64-apple-darwin (macos-13) was dropped 2026-05-03 because the Intel Mac platform is deprecated (last shipped 2020-2022; macOS 26 dropped support for many Intel models) and the macos-13 GitHub-hosted runner pool is severely under-provisioned. Intel Mac users can install from source via `pip install decibri --no-binary :all:`.
    - Each platform: maturin build, auditwheel/delocate repair, abi3audit gate, install-test in clean venv with `CI=true`, upload artifact
    - `fail-fast: true` means any platform failure blocks both publish jobs
 6. Tag-pattern routing kicks in:
@@ -79,10 +79,10 @@ For workflow file changes pre-tag, run the workflow manually from the Actions UI
 1. Push the workflow file change to `development` (or `main`).
 2. Navigate to `https://github.com/decibri/decibri/actions/workflows/publish-pypi.yml`.
 3. Click "Run workflow" -> select the branch -> confirm.
-4. The `build-and-validate` matrix runs across all 5 platforms.
+4. The `build-and-validate` matrix runs across all 4 platforms.
 5. The `publish-testpypi` and `publish-pypi` jobs both skip cleanly because their `if:` conditions key on `github.event_name == 'push'`.
 
-If `build-and-validate` passes on all 5 platforms during a manual dispatch, the workflow file is wired correctly. If a platform fails, fix before tagging.
+If `build-and-validate` passes on all 4 platforms during a manual dispatch, the workflow file is wired correctly. If a platform fails, fix before tagging.
 
 ## Failure recovery
 
@@ -143,7 +143,7 @@ Note: deleting a tag does NOT undo a successful PyPI publish. If the wheel alrea
 
 Phase 11 (next phase) ships the first real publishes:
 
-1. Push `python-v0.1.0a1`. CI runs build-and-validate (5 platforms); abi3audit + install-test gate; `publish-testpypi` runs. Wheel lands on TestPyPI.
+1. Push `python-v0.1.0a1`. CI runs build-and-validate (4 platforms); abi3audit + install-test gate; `publish-testpypi` runs. Wheel lands on TestPyPI.
 2. Manual validation: in a fresh local venv, run `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ decibri==0.1.0a1` and exercise the public API (sync construct, async construct, VAD path).
 3. If issues surface: fix on `main`, bump to `python-v0.1.0a2`, push, repeat.
 4. When the alpha is clean and the user-facing surface is finalized, push `python-v0.1.0`. CI runs build-and-validate; the `publish-pypi` job blocks on reviewer approval; on approval, the wheel ships to production PyPI.


### PR DESCRIPTION
Phase 10 follow-up combining two cleanups identified during the first `workflow_dispatch` validation run on `main`:

1. Drop x86_64-apple-darwin (macos-13) from the build matrix
2. Bump `actions/upload-artifact@v5` to `@v7` (Node 20 deprecation)

Plus an empirical cohort survey audit confirming the resulting 4-platform matrix is appropriate for Phase 11 first publish.

## What ships

### `.github/workflows/publish-pypi.yml`

**Matrix change:** dropped the `macos-13` / `x86_64-apple-darwin` entry from the `build-and-validate` matrix. Build matrix is now 4 platforms:

- `ubuntu-latest` / `x86_64-unknown-linux-gnu`
- `ubuntu-24.04-arm` / `aarch64-unknown-linux-gnu`
- `macos-14` / `aarch64-apple-darwin` (Apple Silicon)
- `windows-latest` / `x86_64-pc-windows-msvc`

Rationale: x86_64-apple-darwin is platform-deprecated. Apple shipped the last Intel Macs between 2020-2022; macOS 26 (released 2025) dropped support for many Intel Mac models. Phase 10's first `workflow_dispatch` validation revealed the macos-13 GitHub-hosted runner pool is severely under-provisioned (12+ minute queue times) and the platform itself has no future. Intel Mac users (a vanishing population) can install from source via `pip install decibri --no-binary :all:`.

**Action version bump:** `actions/upload-artifact@v5` to `@v7`. GitHub deprecates Node.js 20 in actions runtime starting June 2nd 2026 (see [GitHub blog announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Phase 10 validation surfaced the deprecation warning. v6+ runs on Node 24; no breaking changes for the inputs decibri uses. This bump aligns `publish-pypi.yml` with `release-dryrun.yml` and `release.yml` which already use `@v7`.

### `bindings/python/docs/PUBLISH.md`

Updated to reflect the 4-platform matrix throughout. Added a brief paragraph noting the macos-13 removal rationale.

## Cohort matrix audit

Empirical-first verification that the resulting 4-platform matrix is the right choice for Phase 11 first publish. Surveyed 5 polyglot Rust+Python projects (the same cohort used in Phase 10 prep research):

| Capability | ruff | uv | polars | tokenizers | pydantic-core | decibri |
|------------|------|-----|--------|------------|---------------|---------|
| Intel Mac (x86_64-apple-darwin) | ✓ | ✓ | ✓ | ✓ | ✓ | dropped 2026-05-03 |
| musllinux | ✓ | ✓ | ✓ | ✓ | ✓ | No (defer to 0.2.0+) |
| Windows ARM64 | ✓ | ✓ | ✓ | ✓ | No | No (defer to 0.2.0+) |
| Free-threaded Python (3.13t / 3.14t) | No | No | No | ✓ | ✓ | No (defer to 0.2.0+) |

Verdict: decibri's 4-platform matrix is the most conservative in the cohort, justified for a 0.1.0 voice-AI library targeting recent hardware. Three deferral candidates surface for 0.2.0+ (musllinux, Windows ARM64, macOS Intel revisit if demand emerges). All three captured in `~/.claude/plans/0-2-0-backlog.md`.

## Action sweep summary

11 distinct actions inventoried across all 6 workflow files via WebFetch verification of release pages. Only one bump was needed:

| Action | Pre-bump | Post-bump | Files affected | Breaking changes? |
|--------|----------|-----------|-----------------|-------------------|
| `actions/upload-artifact` | `@v5` | `@v7` | `publish-pypi.yml` | None for our inputs |

The other 10 actions verified Node 24-compatible already:
- `actions/checkout@v6.0.2` (Node 24)
- `actions/download-artifact@v8` (Node 24)
- `astral-sh/setup-uv@v8.1.0` (Node 24)
- `dtolnay/rust-toolchain@stable` (Node 24)
- `Swatinem/rust-cache@v2.9.1` (Node 24)
- `PyO3/maturin-action@v1.51.0` (Node 24)
- `pypa/gh-action-pypi-publish@release/v1` (Node 24)
- And 3 others used in `release.yml` and `release-dryrun.yml` already verified

## Verified

- YAML parse: clean across all 6 workflow files
- Em-dash sweep: 0 hits across `.github/workflows/` and modified docs
- No Rust core changes; no Python source changes; no test additions
- Matrix change is mechanical removal; no logic adjustment needed
- Action version bump validated against `actions/upload-artifact` v5 to v7 release notes; no breaking input changes for our usage

## Locked decisions added (master plan)

**LD-10-12:** Drop x86_64-apple-darwin (macos-13) from the build matrix. Apple platform deprecation; runner pool scarcity; cohort following will likely catch up in 2026-2027. Intel Mac users (a vanishing population) can install from source.

**LD-10-13:** Build matrix shrinks from 5 platforms to 4 platforms. fail-fast still applies (LD-10-7); just one less platform to fail.

Both LDs added to `~/.claude/plans/phase-10-pre-publish-hardening.md`. Phase 10 implementation report at `~/.claude/plans/phase-10-implementation-report.md` updated with the matrix-size change.

## Items deliberately NOT in scope

Three platform additions surfaced by the cohort audit are deferred to 0.2.0+:

- **musllinux (Alpine / minimal Docker):** all 5 cohort projects ship; decibri does not. Useful for Kubernetes / minimal Docker deployments. Backlog entry added to `0-2-0-backlog.md`.
- **Windows ARM64 (win-arm64):** 4 of 5 cohort projects ship; decibri does not. Microsoft Surface Pro ARM has growing presence in 2026. Backlog entry added.
- **macOS Intel (x86_64-apple-darwin) revisit:** cohort still ships (5/5); decibri dropped in this commit. Revisit only if real user demand surfaces. Apple platform deprecation makes this unlikely. Backlog entry added.

Each addition is independently shippable post-0.1.0.

## Implementation report

Full implementation details in `~/.claude/plans/phase-10-matrix-and-actions-cleanup-report.md`. The empirical-first track record now stands at 9/9 across the Python Integration Project; this follow-up cycle adds a 10th: cohort matrix audit confirmed the 4-platform choice against current 2026 best practice.

## After this PR squash-merges

1. Local cleanup (`git checkout main && git pull && git branch -D development`).
2. Retrigger `workflow_dispatch` from the Actions UI on `main`.
3. Verify all 4 build-and-validate jobs go green; both publish jobs show as skipped (no tag context); abi3audit + install-test pass on every platform.
4. Total expected wall-clock: 15-20 minutes (no macos-13 queue blocker).
5. If pass: Phase 10 validation complete; Phase 11 (TestPyPI alpha cycle with `python-v0.1.0a1`) becomes the active phase.