### PR TITLE
Phase 11: 0.1.0 production publish prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0a1] - 2026-05-03
+## [0.1.0] - 2026-05-03
 
 ### Python binding
 
-The first published Python wheel of decibri. Alpha release to TestPyPI for publish-workflow validation. Production PyPI publish is `0.1.0`.
+The first production-stable Python wheel of decibri. Following the 0.1.0a1 TestPyPI rehearsal, the README quickstart was corrected (the original `mic.read(N)` examples assumed N was a sample count; the actual signature is `read(timeout_ms=None)`, so quickstarts now use the iterator pattern or the `record_to_file` convenience helper). The README was also tightened for production publication: Decibri capitalized as a proper noun in titles and sentence starts, the audio-infrastructure positioning section deferred to the website docs, the `decibri[numpy]` extras note deferred to the website docs, the Compatibility table updated to list explicit Python versions (3.10, 3.11, 3.12, 3.13, 3.14), and Intel Mac install-from-source references removed (Apple platform deprecation; macos-13 dropped per LD-10-12).
 
 #### Added
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,4 +1,4 @@
-# decibri
+# Decibri
 
 Cross-platform audio capture, output, and processing for Python.
 
@@ -6,18 +6,12 @@ Cross-platform audio capture, output, and processing for Python.
 [![Python versions](https://img.shields.io/pypi/pyversions/decibri.svg)](https://pypi.org/project/decibri/)
 [![License](https://img.shields.io/pypi/l/decibri.svg)](https://github.com/decibri/decibri/blob/main/LICENSE)
 
-decibri is a native Python package that delivers microphone capture, speaker output, local voice activity detection, device enumeration, and sample format conversion. It is written in Rust (via PyO3 / abi3) and ships pre-built wheels for Linux, macOS Apple Silicon, and Windows.
+Decibri is a native Python package that delivers microphone capture, speaker output, local voice activity detection, device enumeration, and sample format conversion. It is written in Rust (via PyO3 / abi3) and ships pre-built wheels for Linux, macOS Apple Silicon, and Windows.
 
 ## Install
 
 ```bash
 pip install decibri
-```
-
-For NumPy ndarray return support (optional):
-
-```bash
-pip install decibri[numpy]
 ```
 
 ## Quickstart
@@ -29,9 +23,18 @@ import decibri
 
 mic = decibri.Microphone(sample_rate=16000, channels=1)
 mic.start()
-chunk = mic.read(16000)  # 1 second of int16 PCM
-print(f"Got {len(chunk)} bytes")
+for chunk in mic:
+    print(f"Got {len(chunk)} bytes")
+    break  # exit after first chunk for demo
 mic.stop()
+```
+
+### Record one second to a WAV file
+
+```python
+import decibri
+
+decibri.record_to_file("output.wav", seconds=1.0, sample_rate=16000)
 ```
 
 ### Capture with Silero VAD
@@ -41,8 +44,9 @@ import decibri
 
 mic = decibri.Microphone(sample_rate=16000, vad="silero")
 mic.start()
-chunk = mic.read(1600)  # 100 ms
-print(f"VAD score: {mic.vad_score}")
+for chunk in mic:
+    print(f"Got {len(chunk)} bytes; VAD score {mic.vad_score}; speaking={mic.is_speaking}")
+    break  # exit after first chunk for demo
 mic.stop()
 ```
 
@@ -56,6 +60,7 @@ async def main():
     async with await decibri.AsyncMicrophone.open(sample_rate=16000, vad="silero") as mic:
         async for chunk in mic:
             print(f"Got {len(chunk)} bytes; VAD score {mic.vad_score}")
+            break  # exit after first chunk for demo
 
 asyncio.run(main())
 ```
@@ -71,20 +76,6 @@ spk.write(audio_bytes)  # int16 PCM
 spk.drain()
 spk.stop()
 ```
-
-### NumPy ndarray return
-
-```python
-import decibri
-
-mic = decibri.Microphone(sample_rate=16000, as_ndarray=True)
-mic.start()
-chunk = mic.read(16000)  # numpy.ndarray
-print(f"Shape: {chunk.shape}, dtype: {chunk.dtype}")
-mic.stop()
-```
-
-Requires `pip install decibri[numpy]`.
 
 ## Public API
 
@@ -119,7 +110,7 @@ The full hierarchy lives at `decibri.exceptions`. Top-level catch-targets surfac
 
 ## Voice Activity Detection
 
-decibri ships with two VAD modes: a lightweight RMS energy threshold (default-off, opt-in via `vad="energy"`) and a Silero ONNX model (~2.3 MB, bundled in the wheel; no API keys required).
+Decibri ships with two VAD modes: a lightweight RMS energy threshold (opt-in via `vad="energy"`) and a Silero ONNX model (~2.3 MB, bundled in the wheel; no API keys required).
 
 ```python
 # Energy mode (lightweight, no model)
@@ -131,37 +122,11 @@ mic = decibri.Microphone(vad="silero", vad_threshold=0.5)
 
 Use `mic.vad_score` (a value in `[0, 1]`) to gate downstream processing. `mic.is_speaking` returns the boolean above-threshold view.
 
-## What decibri is (and isn't)
-
-decibri is **audio infrastructure** for voice AI applications. It captures clean cross-platform audio, plays it back, runs local VAD, and provides local ONNX inference primitives. It is NOT a voice AI engine that wraps cloud providers.
-
-For cloud STT and TTS, install the cloud's official Python SDK alongside decibri and wire decibri's audio output into it in roughly thirty lines of Python:
-
-```bash
-pip install decibri deepgram-sdk     # or: elevenlabs / openai / assemblyai
-```
-
-For voice agent orchestration (turn-taking, interruption, function-calling), use a framework that sits ABOVE decibri:
-
-- Pipecat
-- LiveKit Agents
-- vocode
-
-decibri is the layer below those frameworks. They compose decibri (or any audio capture library) with cloud STT/TTS providers and LLM-based agent logic.
-
 ## Compatibility
 
-| Python                   | Platforms                                                  |
-| ------------------------ | ---------------------------------------------------------- |
-| 3.10+ (abi3-py310 floor) | Linux x64, Linux ARM64, macOS Apple Silicon, Windows x64   |
-
-Intel Mac users can install from source:
-
-```bash
-pip install decibri --no-binary :all:
-```
-
-This requires a working Rust toolchain. Pre-built Intel Mac wheels are not part of the matrix (Apple platform deprecation; macos-13 dropped from the wheel matrix per the 0.2.0 backlog).
+| Python                       | Platforms                                                |
+| ---------------------------- | -------------------------------------------------------- |
+| 3.10, 3.11, 3.12, 3.13, 3.14 | Linux x64, Linux ARM64, macOS Apple Silicon, Windows x64 |
 
 ## Bundled assets
 
@@ -206,4 +171,4 @@ See the ecosystem guides under `bindings/python/docs/ecosystem/` (jupyter, docke
 
 Apache-2.0. See [LICENSE](https://github.com/decibri/decibri/blob/main/LICENSE) for details.
 
-Copyright (c) 2026 decibri.
+Copyright (c) 2026 Decibri.

--- a/bindings/python/docs/ecosystem/docker.md
+++ b/bindings/python/docs/ecosystem/docker.md
@@ -71,8 +71,8 @@ docker run --rm decibri:base
 Verified output (Docker Desktop 4.71, manylinux_2_34 wheel):
 
 ```
-decibri 0.1.0a1
-VersionInfo(decibri='3.4.0', audio_backend='cpal 0.17', binding='0.1.0a1')
+decibri 0.1.0
+VersionInfo(decibri='3.4.0', audio_backend='cpal 0.17', binding='0.1.0')
 ```
 
 Image size: ~255 MB (`python:3.12-slim` ~50 MB + libasound2 ~3 MB + decibri wheel including bundled ORT ~50 MB + Python stdlib runtime). Well under typical production image budgets.
@@ -143,7 +143,7 @@ Expected output on a Linux host with at least one audio device (build verified o
 input_devices count: <N>
   - DeviceInfo(index=0, name='hw:0,0', ..., is_default=true)
   - ...
-decibri version: VersionInfo(decibri='3.4.0', audio_backend='cpal 0.17', binding='0.1.0a1')
+decibri version: VersionInfo(decibri='3.4.0', audio_backend='cpal 0.17', binding='0.1.0')
 ```
 
 If `input_devices count: 1` and the single device id is `alsa:null`, audio passthrough is incomplete; check the three flags above.

--- a/bindings/python/docs/ecosystem/multiprocessing.md
+++ b/bindings/python/docs/ecosystem/multiprocessing.md
@@ -36,8 +36,8 @@ if __name__ == "__main__":
 Verified output:
 
 ```
-3.4.0|cpal 0.17|0.1.0a1
-3.4.0|cpal 0.17|0.1.0a1
+3.4.0|cpal 0.17|0.1.0
+3.4.0|cpal 0.17|0.1.0
 ```
 
 The same pattern works for `Microphone`, `Speaker`, `AsyncMicrophone`, `AsyncSpeaker`, and `decibri.input_devices()`. Each child constructs its own bridge; no cross-process state is shared.

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "decibri"
-version = "0.1.0a1"
+version = "0.1.0"
 description = "Cross-platform audio capture, output, and voice activity detection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/python/python/decibri/__init__.py
+++ b/bindings/python/python/decibri/__init__.py
@@ -51,7 +51,7 @@ from decibri.exceptions import (
     VadThresholdOutOfRange,
 )
 
-__version__ = "0.1.0a1"
+__version__ = "0.1.0"
 
 
 def input_devices() -> list[DeviceInfo]:

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -423,7 +423,7 @@ fn build_version_info() -> VersionInfo {
     VersionInfo {
         decibri: env!("CARGO_PKG_VERSION").to_string(),
         audio_backend: format!("cpal {}", CPAL_VERSION),
-        binding: "0.1.0a1".to_string(),
+        binding: "0.1.0".to_string(),
     }
 }
 

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -16,7 +16,7 @@ import decibri
 
 
 def test_package_imports() -> None:
-    assert decibri.__version__ == "0.1.0a1"
+    assert decibri.__version__ == "0.1.0"
     # Phase 7.7 Item A2: bridges are hidden behind the private _decibri
     # module. They are NOT accessible at decibri.<X> top level (sync or
     # async). The async pair was never accessible at the top level; the
@@ -72,7 +72,7 @@ def test_version_info_fields() -> None:
     info = _decibri.MicrophoneBridge.version()
     assert info.decibri == "3.4.0"
     assert info.audio_backend == "cpal 0.17"
-    assert info.binding == "0.1.0a1"
+    assert info.binding == "0.1.0"
 
 
 def test_version_info_is_frozen() -> None:

--- a/bindings/python/tests/test_wheel_smoke.py
+++ b/bindings/python/tests/test_wheel_smoke.py
@@ -29,7 +29,7 @@ def test_import_decibri() -> None:
     """The package imports successfully from the installed wheel."""
     assert decibri is not None
     assert hasattr(decibri, "__version__")
-    assert decibri.__version__ == "0.1.0a1"
+    assert decibri.__version__ == "0.1.0"
 
 
 def test_construct_decibri_default() -> None:

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -27,7 +27,7 @@ wheels = [
 
 [[package]]
 name = "decibri"
-version = "0.1.0a1"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions" },


### PR DESCRIPTION
Final commit before production PyPI publish.

Following the 0.1.0a1 TestPyPI rehearsal, this commit:

- Fixes README quickstarts (read(N) was misleadingly framed as sample count; actually a timeout in milliseconds; replaced with iterator pattern + record_to_file)
- Tightens README for production publish (Decibri capitalized, removed positioning section, removed numpy[extras] mention, explicit Python version list, removed Intel Mac references)
- Bumps version 0.1.0a1 → 0.1.0 across all 8 source-of-truth locations (pyproject.toml, __init__.py __version__, src/lib.rs VersionInfo.binding, 4 tests, 4 doc examples; uv.lock auto-propagated; PUBLISH.md python-v0.1.0a1 references retained as forever-valid examples)
- CHANGELOG transition [0.1.0a1] → [0.1.0] with intro paragraph documenting alpha-to-stable transition

Wheel verified locally: maturin build succeeds, twine check PASSED, fresh-venv smoke test confirms decibri.__version__ == '0.1.0' AND VersionInfo.binding == '0.1.0'.

After squash-merge: tag python-v0.1.0 fires publish-pypi.yml against production PyPI (with required reviewer approval gate per pypi GitHub environment).