### PR TITLE
Release: decibri 0.1.1 (record_to_file duration fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-05-04
+
+### Python binding
+
+Patch release fixing a duration bug in `record_to_file` and `async_record_to_file`.
+
+#### Fixed
+
+- `record_to_file` and `async_record_to_file` now produce WAV files with the correct duration. The 0.1.0 implementation computed `chunks_needed = duration_seconds * sample_rate / frames_per_buffer` and ran the loop that many times. On Windows WASAPI (and likely other backends), each `mic.read()` chunk delivers ~160 frames (one cpal callback's worth at default settings), not the 1600 frames implied by `frames_per_buffer`. The result was WAV files capturing ~10% of the requested duration. The fix counts actual frames written rather than chunks read, removing the dependency on `frames_per_buffer` matching the platform's actual callback size. `record_to_file(path, duration_seconds=1.0)` now produces a ~1.0s WAV file as documented (0.1.0: 0.098s; 0.1.1: ~1.008s; documented as "at most one chunk longer than requested").
+- The internal `mic.read()` call in both helpers no longer passes `timeout_ms=2000`. The loop is now bounded by the frame count, so a deadline is unnecessary; matches the iterator pattern (`for chunk in mic`) which uses `timeout_ms=None` and works correctly for arbitrary durations.
+
+#### Internal
+
+- New regression test at `bindings/python/tests/test_record_to_file_duration.py`. Six test cases verify the WAV file's actual duration matches the `duration_seconds` parameter (within the documented "at most one chunk longer" tolerance). The test fails on 0.1.0 (capturing the bug); passes on 0.1.1 (confirming the fix).
+
 ## [0.1.0] - 2026-05-03
 
 ### Python binding

--- a/bindings/python/docs/ecosystem/docker.md
+++ b/bindings/python/docs/ecosystem/docker.md
@@ -71,8 +71,8 @@ docker run --rm decibri:base
 Verified output (Docker Desktop 4.71, manylinux_2_34 wheel):
 
 ```
-decibri 0.1.0
-VersionInfo(decibri='3.4.0', audio_backend='cpal 0.17', binding='0.1.0')
+decibri 0.1.1
+VersionInfo(decibri='3.4.0', audio_backend='cpal 0.17', binding='0.1.1')
 ```
 
 Image size: ~255 MB (`python:3.12-slim` ~50 MB + libasound2 ~3 MB + decibri wheel including bundled ORT ~50 MB + Python stdlib runtime). Well under typical production image budgets.
@@ -143,7 +143,7 @@ Expected output on a Linux host with at least one audio device (build verified o
 input_devices count: <N>
   - DeviceInfo(index=0, name='hw:0,0', ..., is_default=true)
   - ...
-decibri version: VersionInfo(decibri='3.4.0', audio_backend='cpal 0.17', binding='0.1.0')
+decibri version: VersionInfo(decibri='3.4.0', audio_backend='cpal 0.17', binding='0.1.1')
 ```
 
 If `input_devices count: 1` and the single device id is `alsa:null`, audio passthrough is incomplete; check the three flags above.

--- a/bindings/python/docs/ecosystem/multiprocessing.md
+++ b/bindings/python/docs/ecosystem/multiprocessing.md
@@ -36,8 +36,8 @@ if __name__ == "__main__":
 Verified output:
 
 ```
-3.4.0|cpal 0.17|0.1.0
-3.4.0|cpal 0.17|0.1.0
+3.4.0|cpal 0.17|0.1.1
+3.4.0|cpal 0.17|0.1.1
 ```
 
 The same pattern works for `Microphone`, `Speaker`, `AsyncMicrophone`, `AsyncSpeaker`, and `decibri.input_devices()`. Each child constructs its own bridge; no cross-process state is shared.

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "maturin"
 
 [project]
 name = "decibri"
-version = "0.1.0"
+version = "0.1.1"
 description = "Cross-platform audio capture, output, and voice activity detection"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 authors = [
-    { name = "Ross Armstrong", email = "hello@decibri.com" },
+    { name = "Decibri", email = "hello@decibri.com" },
 ]
 keywords = ["audio", "microphone", "capture", "sound", "voice", "vad"]
 classifiers = [

--- a/bindings/python/python/decibri/__init__.py
+++ b/bindings/python/python/decibri/__init__.py
@@ -99,10 +99,9 @@ def record_to_file(
         Output WAV file path. Parent directory must exist; the file is
         created or overwritten.
     duration_seconds : float
-        Approximate recording duration. Actual duration is rounded up to
-        the nearest ``frames_per_buffer`` chunk (1600 frames = 100ms at
-        16kHz by default), so the file is at most ~100ms longer than
-        requested.
+        Approximate recording duration. The loop accumulates audio until
+        the captured frame count meets or exceeds the requested amount,
+        so the file is at most one chunk longer than requested.
     sample_rate : int, optional
         Capture sample rate in Hz. Default 16000.
     channels : int, optional
@@ -122,9 +121,7 @@ def record_to_file(
 
     bytes_per_sample = 2  # int16
     frames_per_buffer = 1600  # 100ms at 16kHz; cross-binding default
-    chunks_needed = max(
-        1, int((duration_seconds * sample_rate + frames_per_buffer - 1) // frames_per_buffer)
-    )
+    total_frames_needed = max(1, int(duration_seconds * sample_rate))
 
     with wave.open(path, "wb") as wav, Microphone(
         sample_rate=sample_rate,
@@ -137,13 +134,20 @@ def record_to_file(
         wav.setsampwidth(bytes_per_sample)
         wav.setframerate(sample_rate)
 
-        for _ in range(chunks_needed):
-            chunk = mic.read(timeout_ms=2000)
+        # Frame-count termination, not chunk-count: the cpal callback's
+        # actual buffer size depends on the platform audio backend (on
+        # Windows WASAPI it is typically the device period, not the
+        # requested frames_per_buffer), so a chunk-count loop captures
+        # the wrong duration on backends that ignore the buffer hint.
+        total_frames_written = 0
+        while total_frames_written < total_frames_needed:
+            chunk = mic.read()
             if chunk is None:
                 break
             # int16 mode + numpy=False guarantees bytes from read().
             assert isinstance(chunk, bytes)
             wav.writeframes(chunk)
+            total_frames_written += len(chunk) // (bytes_per_sample * channels)
 
 
 async def async_record_to_file(
@@ -163,9 +167,7 @@ async def async_record_to_file(
 
     bytes_per_sample = 2  # int16
     frames_per_buffer = 1600
-    chunks_needed = max(
-        1, int((duration_seconds * sample_rate + frames_per_buffer - 1) // frames_per_buffer)
-    )
+    total_frames_needed = max(1, int(duration_seconds * sample_rate))
 
     mic = AsyncMicrophone(
         sample_rate=sample_rate,
@@ -179,12 +181,16 @@ async def async_record_to_file(
         wav.setsampwidth(bytes_per_sample)
         wav.setframerate(sample_rate)
         async with mic as d:
-            for _ in range(chunks_needed):
-                chunk = await d.read(timeout_ms=2000)
+            # Frame-count termination, not chunk-count: see record_to_file
+            # for the rationale (cpal callback size is platform-dependent).
+            total_frames_written = 0
+            while total_frames_written < total_frames_needed:
+                chunk = await d.read()
                 if chunk is None:
                     break
                 assert isinstance(chunk, bytes)
                 wav.writeframes(chunk)
+                total_frames_written += len(chunk) // (bytes_per_sample * channels)
 
 
 __all__ = [

--- a/bindings/python/python/decibri/__init__.py
+++ b/bindings/python/python/decibri/__init__.py
@@ -51,7 +51,7 @@ from decibri.exceptions import (
     VadThresholdOutOfRange,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 
 def input_devices() -> list[DeviceInfo]:

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -423,7 +423,7 @@ fn build_version_info() -> VersionInfo {
     VersionInfo {
         decibri: env!("CARGO_PKG_VERSION").to_string(),
         audio_backend: format!("cpal {}", CPAL_VERSION),
-        binding: "0.1.0".to_string(),
+        binding: "0.1.1".to_string(),
     }
 }
 

--- a/bindings/python/tests/test_record_to_file_duration.py
+++ b/bindings/python/tests/test_record_to_file_duration.py
@@ -1,0 +1,151 @@
+"""Regression tests for the 0.1.0 ``record_to_file`` duration bug.
+
+decibri 0.1.0 produced WAV files of only ~10% of the requested duration:
+the chunk-count loop assumed each cpal callback delivered ``frames_per_buffer``
+frames, but on Windows WASAPI each callback delivers far fewer (the device
+period, typically ~10ms = ~160 frames at 16kHz). 0.1.1 switches both helpers
+to a frame-counting loop that accumulates audio until the requested frame
+count is met regardless of the platform's actual chunk size.
+
+These tests assert the correct contract from the helper docstrings: a
+WAV produced by ``record_to_file(duration_seconds=N)`` should contain
+approximately ``N * sample_rate`` frames, within a tolerance that allows
+for cpal callback timing imprecision and the documented "rounded up"
+upper bound.
+
+All hardware-touching tests are marked ``requires_audio_input`` so they
+auto-skip in CI per ``conftest.py`` policy. Run locally before publish.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import wave
+from pathlib import Path
+
+import pytest
+
+import decibri
+
+
+def _read_wav_actual_duration_seconds(path: str) -> float:
+    """Return the WAV file's actual duration in seconds via the WAV header."""
+    with wave.open(path, "rb") as w:
+        frames = w.getnframes()
+        rate = w.getframerate()
+        return frames / rate
+
+
+def _assert_duration_in_range(actual: float, requested: float, label: str = "") -> None:
+    """Assert the actual WAV duration is within the documented contract.
+
+    The helper accumulates audio until at least ``requested * sample_rate``
+    frames are written, then exits at the next chunk boundary. Actual
+    duration is therefore in ``[requested, requested + one_chunk]``. We
+    use a 0.95 lower bound for cpal callback timing imprecision and a
+    0.2 upper bound for the rounding plus headroom.
+
+    A WAV with actual ~10% of requested (the 0.1.0 bug) falls far below
+    the lower bound and triggers a clear failure message that names the
+    bug pattern explicitly.
+    """
+    lower = requested * 0.95
+    upper = requested + 0.2
+    bug_floor = requested * 0.05
+    bug_ceiling = requested * 0.15
+
+    bug_match = bug_floor <= actual <= bug_ceiling
+    bug_hint = (
+        " (this matches the 0.1.0 bug where ~10% of requested duration is captured)"
+        if bug_match
+        else ""
+    )
+
+    assert lower <= actual <= upper, (
+        f"{label}duration_seconds={requested:.1f} produced WAV with actual "
+        f"duration {actual:.3f}s; expected in [{lower:.3f}, {upper:.3f}]"
+        f"{bug_hint}"
+    )
+
+
+@pytest.mark.requires_audio_input
+def test_record_to_file_actual_duration_1_second(tmp_path: Path) -> None:
+    """``record_to_file(duration_seconds=1.0)`` produces ~1s of audio."""
+    wav_path = str(tmp_path / "rec_1s.wav")
+    decibri.record_to_file(wav_path, duration_seconds=1.0, sample_rate=16000)
+    actual = _read_wav_actual_duration_seconds(wav_path)
+    _assert_duration_in_range(actual, 1.0, "record_to_file: ")
+
+
+@pytest.mark.requires_audio_input
+def test_record_to_file_actual_duration_2_seconds(tmp_path: Path) -> None:
+    """``record_to_file(duration_seconds=2.0)`` produces ~2s of audio."""
+    wav_path = str(tmp_path / "rec_2s.wav")
+    decibri.record_to_file(wav_path, duration_seconds=2.0, sample_rate=16000)
+    actual = _read_wav_actual_duration_seconds(wav_path)
+    _assert_duration_in_range(actual, 2.0, "record_to_file: ")
+
+
+@pytest.mark.requires_audio_input
+def test_record_to_file_actual_duration_3_seconds(tmp_path: Path) -> None:
+    """``record_to_file(duration_seconds=3.0)`` produces ~3s of audio."""
+    wav_path = str(tmp_path / "rec_3s.wav")
+    decibri.record_to_file(wav_path, duration_seconds=3.0, sample_rate=16000)
+    actual = _read_wav_actual_duration_seconds(wav_path)
+    _assert_duration_in_range(actual, 3.0, "record_to_file: ")
+
+
+@pytest.mark.requires_audio_input
+def test_async_record_to_file_actual_duration_1_second(tmp_path: Path) -> None:
+    """``async_record_to_file(duration_seconds=1.0)`` produces ~1s of audio."""
+    wav_path = str(tmp_path / "rec_async_1s.wav")
+    asyncio.run(
+        decibri.async_record_to_file(
+            wav_path, duration_seconds=1.0, sample_rate=16000
+        )
+    )
+    actual = _read_wav_actual_duration_seconds(wav_path)
+    _assert_duration_in_range(actual, 1.0, "async_record_to_file: ")
+
+
+@pytest.mark.requires_audio_input
+def test_async_record_to_file_actual_duration_2_seconds(tmp_path: Path) -> None:
+    """``async_record_to_file(duration_seconds=2.0)`` produces ~2s of audio."""
+    wav_path = str(tmp_path / "rec_async_2s.wav")
+    asyncio.run(
+        decibri.async_record_to_file(
+            wav_path, duration_seconds=2.0, sample_rate=16000
+        )
+    )
+    actual = _read_wav_actual_duration_seconds(wav_path)
+    _assert_duration_in_range(actual, 2.0, "async_record_to_file: ")
+
+
+@pytest.mark.requires_audio_input
+def test_record_to_file_proportional_scaling(tmp_path: Path) -> None:
+    """``record_to_file`` scales linearly with duration_seconds.
+
+    Catches a different failure mode than the absolute-duration tests:
+    if scaling itself broke (e.g., duration_seconds was ignored entirely
+    and produced a fixed-size file regardless), the ratio would not
+    match. Even on the 0.1.0 bug the ratio held (1s -> 0.098s,
+    3s -> 0.298s, ratio 3.04), so this test passes on both 0.1.0 and
+    0.1.1 and is a sanity check against future regressions to the
+    scaling shape rather than the magnitude.
+    """
+    path1 = str(tmp_path / "scale_1s.wav")
+    path3 = str(tmp_path / "scale_3s.wav")
+
+    decibri.record_to_file(path1, duration_seconds=1.0, sample_rate=16000)
+    decibri.record_to_file(path3, duration_seconds=3.0, sample_rate=16000)
+
+    dur1 = _read_wav_actual_duration_seconds(path1)
+    dur3 = _read_wav_actual_duration_seconds(path3)
+    ratio = dur3 / dur1
+
+    assert 2.4 <= ratio <= 3.6, (
+        f"record_to_file ratio dur(3s)/dur(1s) = {ratio:.3f}, expected ~3:1. "
+        f"dur1={dur1:.3f}, dur3={dur3:.3f}. "
+        f"This indicates the duration scaling itself is broken, not just the magnitude."
+    )

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -16,7 +16,7 @@ import decibri
 
 
 def test_package_imports() -> None:
-    assert decibri.__version__ == "0.1.0"
+    assert decibri.__version__ == "0.1.1"
     # Phase 7.7 Item A2: bridges are hidden behind the private _decibri
     # module. They are NOT accessible at decibri.<X> top level (sync or
     # async). The async pair was never accessible at the top level; the
@@ -72,7 +72,7 @@ def test_version_info_fields() -> None:
     info = _decibri.MicrophoneBridge.version()
     assert info.decibri == "3.4.0"
     assert info.audio_backend == "cpal 0.17"
-    assert info.binding == "0.1.0"
+    assert info.binding == "0.1.1"
 
 
 def test_version_info_is_frozen() -> None:

--- a/bindings/python/tests/test_wheel_smoke.py
+++ b/bindings/python/tests/test_wheel_smoke.py
@@ -29,7 +29,7 @@ def test_import_decibri() -> None:
     """The package imports successfully from the installed wheel."""
     assert decibri is not None
     assert hasattr(decibri, "__version__")
-    assert decibri.__version__ == "0.1.0"
+    assert decibri.__version__ == "0.1.1"
 
 
 def test_construct_decibri_default() -> None:

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -27,7 +27,7 @@ wheels = [
 
 [[package]]
 name = "decibri"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions" },


### PR DESCRIPTION
## Summary

Patch release fixing a duration bug in `record_to_file` and `async_record_to_file`, plus a project identity update for PyPI metadata.

## Commits

1. `fix: record_to_file duration counts frames, not chunks`
2. `release: 0.1.1 version bump + CHANGELOG`

## The bug

decibri 0.1.0 shipped a duration bug in `record_to_file` and `async_record_to_file`: WAV files captured only ~10% of the requested `duration_seconds`. Empirical evidence from post-publish hardware testing on Windows:

- `duration_seconds=1.0` produced a 0.098s WAV
- `duration_seconds=3.0` produced a 0.298s WAV

## Root cause

The implementation computed `chunks_needed = duration_seconds * sample_rate / frames_per_buffer` and ran the loop that many times. On Windows WASAPI, each `mic.read()` chunk delivers ~160 frames (one cpal callback's worth), not the 1600 frames implied by `frames_per_buffer`. The loop ran `chunks_needed` iterations correctly but each iteration captured 10x less audio than the math assumed.

## The fix

Count actual frames written rather than chunks read. Removes the dependency on `frames_per_buffer` matching the platform's actual callback size. Empirically validated: `duration_seconds=1.0` now produces a 1.008s WAV file.

## Validation

- New regression test at `bindings/python/tests/test_record_to_file_duration.py` with 6 cases (3 sync + 2 async + 1 proportional scaling). FAILS on 0.1.0; PASSES on 0.1.1.
- All existing tests pass (mypy strict + cargo clippy + cargo fmt all green).
- Local wheel build verified: filename, METADATA Version, twine check, fresh-venv smoke test all green.
- End-to-end version consistency: wheel `0.1.1` → `decibri.__version__ == '0.1.1'` → `VersionInfo.binding == '0.1.1'`.

## Backlog items surfaced

- Windows WASAPI `BufferSize::Fixed` not honored (the underlying mechanism that caused this bug; affects other code paths too)
- Mock-Microphone pattern for CI testing (would close the test coverage gap that allowed this bug to ship)
- Doc-tense cleanup (the "Until 0.1.0 ships" stale prose in docker.md and Dockerfile.base)
