### PR TITLE
Release: decibri 0.1.2 (README fix + CHANGELOG split)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,62 +1,14 @@
 <!-- markdownlint-disable MD024 -->
 
-# Changelog
+# Decibri Changelog
 
-All notable changes to this project will be documented in this file.
+This file tracks changes to the **decibri Rust core** (`crates/decibri`, published to crates.io) and the **decibri npm binding** (`npm/decibri`, published to npm). These two ship together at the same version under the `v*` tag pattern (e.g., `v3.4.0` publishes both `decibri 3.4.0` to crates.io and `@analyticsinmotion/decibri 3.4.0` to npm).
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+For decibri Python wheel changes, see [bindings/python/CHANGELOG.md](bindings/python/CHANGELOG.md). The Python wheel has its own version trajectory (currently `0.1.x`) and ships under the `python-v*` tag pattern.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [0.1.1] - 2026-05-04
-
-### Python binding
-
-Patch release fixing a duration bug in `record_to_file` and `async_record_to_file`.
-
-#### Fixed
-
-- `record_to_file` and `async_record_to_file` now produce WAV files with the correct duration. The 0.1.0 implementation computed `chunks_needed = duration_seconds * sample_rate / frames_per_buffer` and ran the loop that many times. On Windows WASAPI (and likely other backends), each `mic.read()` chunk delivers ~160 frames (one cpal callback's worth at default settings), not the 1600 frames implied by `frames_per_buffer`. The result was WAV files capturing ~10% of the requested duration. The fix counts actual frames written rather than chunks read, removing the dependency on `frames_per_buffer` matching the platform's actual callback size. `record_to_file(path, duration_seconds=1.0)` now produces a ~1.0s WAV file as documented (0.1.0: 0.098s; 0.1.1: ~1.008s; documented as "at most one chunk longer than requested").
-- The internal `mic.read()` call in both helpers no longer passes `timeout_ms=2000`. The loop is now bounded by the frame count, so a deadline is unnecessary; matches the iterator pattern (`for chunk in mic`) which uses `timeout_ms=None` and works correctly for arbitrary durations.
-
-#### Internal
-
-- New regression test at `bindings/python/tests/test_record_to_file_duration.py`. Six test cases verify the WAV file's actual duration matches the `duration_seconds` parameter (within the documented "at most one chunk longer" tolerance). The test fails on 0.1.0 (capturing the bug); passes on 0.1.1 (confirming the fix).
-
-## [0.1.0] - 2026-05-03
-
-### Python binding
-
-The first production-stable Python wheel of decibri. Following the 0.1.0a1 TestPyPI rehearsal, the README quickstart was corrected (the original `mic.read(N)` examples assumed N was a sample count; the actual signature is `read(timeout_ms=None)`, so quickstarts now use the iterator pattern or the `record_to_file` convenience helper). The README was also tightened for production publication: Decibri capitalized as a proper noun in titles and sentence starts, the audio-infrastructure positioning section deferred to the website docs, the `decibri[numpy]` extras note deferred to the website docs, the Compatibility table updated to list explicit Python versions (3.10, 3.11, 3.12, 3.13, 3.14), and Intel Mac install-from-source references removed (Apple platform deprecation; macos-13 dropped per LD-10-12).
-
-#### Added
-
-- Public API: `Microphone`, `Speaker`, `AsyncMicrophone`, `AsyncSpeaker` classes (Phase 7.5 class rename; Phase 9 async-open factories).
-- Module-level helpers: `input_devices()`, `output_devices()`, `version()`, `record_to_file()`, `async_record_to_file()`.
-- Value types: `DeviceInfo`, `OutputDeviceInfo`, `VersionInfo`, `Chunk`.
-- Exception hierarchy at `decibri.exceptions` (32 classes; 5 catch-target intermediates surfaced at `decibri.<X>`: `DecibriError`, `DeviceError`, `OrtError`, `OrtPathError`, `ForkAfterOrtInit`).
-- VAD support: `vad="energy"` (RMS threshold) and `vad="silero"` (Silero ONNX, bundled). `vad_score` property returns a `[0, 1]` value mode-agnostically; `is_speaking` returns the boolean above-threshold view.
-- NumPy ndarray return support via `as_ndarray=True` (install with `pip install decibri[numpy]`).
-- Bundled Silero VAD ONNX model (~2.3 MB) shipped in the wheel. No downloads or API keys required.
-- Bundled ONNX Runtime dylib per platform (~15-20 MB; Linux x64, Linux ARM64, macOS Apple Silicon, Windows x64). No system dependency on `pip install onnxruntime`.
-- Async `AsyncMicrophone.open()` and `AsyncSpeaker.open()` factories that dispatch synchronous ORT init off the event loop via `loop.run_in_executor`. Recommended for `vad="silero"` in async contexts (Phase 9).
-- `__repr__` on `Microphone`, `Speaker`, `AsyncMicrophone`, `AsyncSpeaker` showing construction parameters plus runtime state (Phase 9; closes the Jupyter auto-display gap).
-- `ForkAfterOrtInit` exception raised on Linux when `Microphone(vad="silero")` is constructed in a parent process and then used in a forked child (Phase 9). Carries a remediation message pointing at `multiprocessing.set_start_method('spawn')`.
-- `Chunk` dataclass and `Microphone.read_with_metadata()` / `iter_with_metadata()` returning a frozen `Chunk` with `.data`, `.timestamp`, `.sequence`, `.is_speaking`, `.vad_score`. Additive; `read()` keeps its current signature.
-- Re-entry contract on `start()` / `stop()` / `close()` for all four wrapper classes pinned by tests. Calling `start()` after `stop()` reconstructs the stream cleanly; VAD state resets per `start()`. `close()` is a permanent alias for `stop()`.
-- Ecosystem coexistence docs at `bindings/python/docs/ecosystem/{jupyter,docker,multiprocessing}.md` plus three reference Dockerfiles under `docker/` (Phase 9).
-
-#### Internal
-
-- 4-platform wheel matrix: Linux x64 (manylinux_2_28 container build), Linux ARM64, macOS Apple Silicon, Windows x64 (Phase 10; `macos-13` Intel Mac dropped per LD-10-12 Apple platform deprecation).
-- Trusted Publisher OIDC publish workflow at `.github/workflows/publish-pypi.yml` (Phase 10). Prerelease tags (`python-v*a*`, `python-v*b*`, `python-v*rc*`) route to TestPyPI; stable tags (`python-v\d+.\d+.\d+`) route to production PyPI.
-- abi3audit (`--strict --assume-minimum-abi3 3.10`), auditwheel, and delocate gates in the publish pipeline (Phase 10 LD-10-3 / LD-10-4).
-- PEP 740 attestations generated via Sigstore + Fulcio in the publish job (Phase 10 LD-10-5).
-- In-job wheel install-test in a clean venv on each matrix platform with `CI=true` (Phase 7 install gate; Phase 9 conftest auto-skips hardware-gated tests).
-- `OnnxSession` trait abstraction in Rust core (Phase 8). `crates/decibri` 3.4.0 introduces `pub(crate) trait OnnxSession`; `SileroVad` consumes it through `Box<dyn OnnxSession>`. Future backends (CoreML, TFLite, GPU EPs) plug in additively at the `decibri-onnx` workspace split planned for 4.0.
-- New `DecibriError::ForkAfterOrtInit { init_pid, current_pid }` variant in `crates/decibri/src/error.rs` (Phase 9). Permitted by `#[non_exhaustive]`; existing variants unchanged.
-- `bindings/python/docs/PUBLISH.md` documents the publish flow, Trusted Publisher setup, `workflow_dispatch` dry-run procedure, and failure recovery for abi3audit / install-test / OIDC rejection cases.
 
 ## [3.4.0] - 2026-05-02
 

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -1,0 +1,80 @@
+<!-- markdownlint-disable MD024 -->
+
+# Decibri Python Wheel Changelog
+
+This file tracks changes to the decibri Python wheel published to PyPI (`pip install decibri`).
+
+For Rust core (`crates/decibri`) and npm binding (`bindings/node`) changes, see [the root CHANGELOG.md](../../CHANGELOG.md). The Rust core and npm binding ship together at the same version under the `v*` tag pattern; the Python wheel has its own version trajectory aligned with API surface stability and ships under the `python-v*` tag pattern.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2] - 2026-05-06
+
+### Python binding
+
+Patch release fixing a user-facing README bug, refreshing a dev-only transitive dependency flagged by Dependabot, cleaning up stale documentation prose, and splitting the Python wheel changelog out of the root `CHANGELOG.md`.
+
+#### Fixed
+
+- README quickstart example: `record_to_file()` parameter name is `duration_seconds=`, not `seconds=`. Three occurrences corrected in `bindings/python/README.md` (line 37 quickstart code block, lines 94-95 function summary list). Anyone copying the previous PyPI quickstart received `TypeError: record_to_file() got an unexpected keyword argument 'seconds'` on the first example.
+- Stale documentation prose: "Until 0.1.0 ships to PyPI" rewritten to past tense in `bindings/python/docs/ecosystem/docker.md` and `bindings/python/docs/ecosystem/docker/Dockerfile.base`. decibri 0.1.0+ has shipped to PyPI; the multi-stage build-from-source variant is now framed as a fallback for custom toolchain or air-gapped builds, not the default path.
+
+#### Internal
+
+- `postcss` dev dependency refreshed from 8.5.9 to 8.5.14 via `npm audit fix`. Resolves Dependabot alert (GHSA-qx2v-qp2m-jg93: PostCSS XSS via unescaped `</style>` in CSS stringify output). Transitive dependency through `vitest` -> `vite` -> `postcss`; only present in `package-lock.json`, not shipped in production wheels or the npm binding.
+- Added `Changelog` URL to `bindings/python/pyproject.toml` `[project.urls]` pointing to this file. PyPI Meta sidebar now shows a Changelog link that resolves to the per-binding changelog rather than the Rust+npm root changelog.
+
+#### Architecture
+
+- Python wheel CHANGELOG split from root `CHANGELOG.md`. Python entries (`[0.1.0]`, `[0.1.1]`, `[0.1.2]`) now live in this file at `bindings/python/CHANGELOG.md`. Root `CHANGELOG.md` continues to track the Rust core (`crates/decibri`) and npm binding (`bindings/node`), which ship together at the same version under the `v*` tag pattern. Aligns with cohort polyglot projects (tokenizers, polars, swc, rspack) where each binding maintains its own changelog. Rationale: PyPI release notes show only Python-relevant changes; same applies to crates.io and npm. Cross-link added to the root `CHANGELOG.md` header.
+
+## [0.1.1] - 2026-05-04
+
+### Python binding
+
+Patch release fixing a duration bug in `record_to_file` and `async_record_to_file`.
+
+#### Fixed
+
+- `record_to_file` and `async_record_to_file` now produce WAV files with the correct duration. The 0.1.0 implementation computed `chunks_needed = duration_seconds * sample_rate / frames_per_buffer` and ran the loop that many times. On Windows WASAPI (and likely other backends), each `mic.read()` chunk delivers ~160 frames (one cpal callback's worth at default settings), not the 1600 frames implied by `frames_per_buffer`. The result was WAV files capturing ~10% of the requested duration. The fix counts actual frames written rather than chunks read, removing the dependency on `frames_per_buffer` matching the platform's actual callback size. `record_to_file(path, duration_seconds=1.0)` now produces a ~1.0s WAV file as documented (0.1.0: 0.098s; 0.1.1: ~1.008s; documented as "at most one chunk longer than requested").
+- The internal `mic.read()` call in both helpers no longer passes `timeout_ms=2000`. The loop is now bounded by the frame count, so a deadline is unnecessary; matches the iterator pattern (`for chunk in mic`) which uses `timeout_ms=None` and works correctly for arbitrary durations.
+
+#### Internal
+
+- New regression test at `bindings/python/tests/test_record_to_file_duration.py`. Six test cases verify the WAV file's actual duration matches the `duration_seconds` parameter (within the documented "at most one chunk longer" tolerance). The test fails on 0.1.0 (capturing the bug); passes on 0.1.1 (confirming the fix).
+
+## [0.1.0] - 2026-05-03
+
+### Python binding
+
+The first production-stable Python wheel of decibri. Following the 0.1.0a1 TestPyPI rehearsal, the README quickstart was corrected (the original `mic.read(N)` examples assumed N was a sample count; the actual signature is `read(timeout_ms=None)`, so quickstarts now use the iterator pattern or the `record_to_file` convenience helper). The README was also tightened for production publication: Decibri capitalized as a proper noun in titles and sentence starts, the audio-infrastructure positioning section deferred to the website docs, the `decibri[numpy]` extras note deferred to the website docs, the Compatibility table updated to list explicit Python versions (3.10, 3.11, 3.12, 3.13, 3.14), and Intel Mac install-from-source references removed (Apple platform deprecation; macos-13 dropped per LD-10-12).
+
+#### Added
+
+- Public API: `Microphone`, `Speaker`, `AsyncMicrophone`, `AsyncSpeaker` classes (Phase 7.5 class rename; Phase 9 async-open factories).
+- Module-level helpers: `input_devices()`, `output_devices()`, `version()`, `record_to_file()`, `async_record_to_file()`.
+- Value types: `DeviceInfo`, `OutputDeviceInfo`, `VersionInfo`, `Chunk`.
+- Exception hierarchy at `decibri.exceptions` (32 classes; 5 catch-target intermediates surfaced at `decibri.<X>`: `DecibriError`, `DeviceError`, `OrtError`, `OrtPathError`, `ForkAfterOrtInit`).
+- VAD support: `vad="energy"` (RMS threshold) and `vad="silero"` (Silero ONNX, bundled). `vad_score` property returns a `[0, 1]` value mode-agnostically; `is_speaking` returns the boolean above-threshold view.
+- NumPy ndarray return support via `as_ndarray=True` (install with `pip install decibri[numpy]`).
+- Bundled Silero VAD ONNX model (~2.3 MB) shipped in the wheel. No downloads or API keys required.
+- Bundled ONNX Runtime dylib per platform (~15-20 MB; Linux x64, Linux ARM64, macOS Apple Silicon, Windows x64). No system dependency on `pip install onnxruntime`.
+- Async `AsyncMicrophone.open()` and `AsyncSpeaker.open()` factories that dispatch synchronous ORT init off the event loop via `loop.run_in_executor`. Recommended for `vad="silero"` in async contexts (Phase 9).
+- `__repr__` on `Microphone`, `Speaker`, `AsyncMicrophone`, `AsyncSpeaker` showing construction parameters plus runtime state (Phase 9; closes the Jupyter auto-display gap).
+- `ForkAfterOrtInit` exception raised on Linux when `Microphone(vad="silero")` is constructed in a parent process and then used in a forked child (Phase 9). Carries a remediation message pointing at `multiprocessing.set_start_method('spawn')`.
+- `Chunk` dataclass and `Microphone.read_with_metadata()` / `iter_with_metadata()` returning a frozen `Chunk` with `.data`, `.timestamp`, `.sequence`, `.is_speaking`, `.vad_score`. Additive; `read()` keeps its current signature.
+- Re-entry contract on `start()` / `stop()` / `close()` for all four wrapper classes pinned by tests. Calling `start()` after `stop()` reconstructs the stream cleanly; VAD state resets per `start()`. `close()` is a permanent alias for `stop()`.
+- Ecosystem coexistence docs at `bindings/python/docs/ecosystem/{jupyter,docker,multiprocessing}.md` plus three reference Dockerfiles under `docker/` (Phase 9).
+
+#### Internal
+
+- 4-platform wheel matrix: Linux x64 (manylinux_2_28 container build), Linux ARM64, macOS Apple Silicon, Windows x64 (Phase 10; `macos-13` Intel Mac dropped per LD-10-12 Apple platform deprecation).
+- Trusted Publisher OIDC publish workflow at `.github/workflows/publish-pypi.yml` (Phase 10). Prerelease tags (`python-v*a*`, `python-v*b*`, `python-v*rc*`) route to TestPyPI; stable tags (`python-v\d+.\d+.\d+`) route to production PyPI.
+- abi3audit (`--strict --assume-minimum-abi3 3.10`), auditwheel, and delocate gates in the publish pipeline (Phase 10 LD-10-3 / LD-10-4).
+- PEP 740 attestations generated via Sigstore + Fulcio in the publish job (Phase 10 LD-10-5).
+- In-job wheel install-test in a clean venv on each matrix platform with `CI=true` (Phase 7 install gate; Phase 9 conftest auto-skips hardware-gated tests).
+- `OnnxSession` trait abstraction in Rust core (Phase 8). `crates/decibri` 3.4.0 introduces `pub(crate) trait OnnxSession`; `SileroVad` consumes it through `Box<dyn OnnxSession>`. Future backends (CoreML, TFLite, GPU EPs) plug in additively at the `decibri-onnx` workspace split planned for 4.0.
+- New `DecibriError::ForkAfterOrtInit { init_pid, current_pid }` variant in `crates/decibri/src/error.rs` (Phase 9). Permitted by `#[non_exhaustive]`; existing variants unchanged.
+- `bindings/python/docs/PUBLISH.md` documents the publish flow, Trusted Publisher setup, `workflow_dispatch` dry-run procedure, and failure recovery for abi3audit / install-test / OIDC rejection cases.

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -34,7 +34,7 @@ mic.stop()
 ```python
 import decibri
 
-decibri.record_to_file("output.wav", seconds=1.0, sample_rate=16000)
+decibri.record_to_file("output.wav", duration_seconds=1.0, sample_rate=16000)
 ```
 
 ### Capture with Silero VAD
@@ -91,8 +91,8 @@ spk.stop()
 - `decibri.input_devices()`: enumerate available input devices
 - `decibri.output_devices()`: enumerate available output devices
 - `decibri.version()`: version + audio backend info
-- `decibri.record_to_file(path, seconds, ...)`: record N seconds to a WAV file
-- `decibri.async_record_to_file(path, seconds, ...)`: async equivalent
+- `decibri.record_to_file(path, duration_seconds, ...)`: record N seconds to a WAV file
+- `decibri.async_record_to_file(path, duration_seconds, ...)`: async equivalent
 
 ### Value types
 

--- a/bindings/python/docs/ecosystem/docker.md
+++ b/bindings/python/docs/ecosystem/docker.md
@@ -12,7 +12,7 @@ The base and headless scenarios in this document are verified on Docker Desktop 
 
 ## Base scenario: minimal install + version smoke check
 
-Until 0.1.0 ships to PyPI, the minimal Dockerfile is multi-stage: a builder stage that compiles the wheel from source via maturin, and a slim runtime stage that pip-installs the wheel. After PyPI publish (Phase 11), the runtime stage is reduced to a single `pip install decibri` line.
+decibri 0.1.0+ is on PyPI, so the minimal Dockerfile is a single stage that runs `pip install decibri` against a slim runtime base. The multi-stage build-from-source variant below is retained for environments that need to build the wheel locally (custom Rust toolchain configurations, air-gapped builds, or pre-publish development against an unreleased commit).
 
 [Dockerfile.base](docker/Dockerfile.base):
 
@@ -71,8 +71,8 @@ docker run --rm decibri:base
 Verified output (Docker Desktop 4.71, manylinux_2_34 wheel):
 
 ```
-decibri 0.1.1
-VersionInfo(decibri='3.4.0', audio_backend='cpal 0.17', binding='0.1.1')
+decibri 0.1.2
+VersionInfo(decibri='3.4.0', audio_backend='cpal 0.17', binding='0.1.2')
 ```
 
 Image size: ~255 MB (`python:3.12-slim` ~50 MB + libasound2 ~3 MB + decibri wheel including bundled ORT ~50 MB + Python stdlib runtime). Well under typical production image budgets.
@@ -143,7 +143,7 @@ Expected output on a Linux host with at least one audio device (build verified o
 input_devices count: <N>
   - DeviceInfo(index=0, name='hw:0,0', ..., is_default=true)
   - ...
-decibri version: VersionInfo(decibri='3.4.0', audio_backend='cpal 0.17', binding='0.1.1')
+decibri version: VersionInfo(decibri='3.4.0', audio_backend='cpal 0.17', binding='0.1.2')
 ```
 
 If `input_devices count: 1` and the single device id is `alsa:null`, audio passthrough is incomplete; check the three flags above.

--- a/bindings/python/docs/ecosystem/docker/Dockerfile.base
+++ b/bindings/python/docs/ecosystem/docker/Dockerfile.base
@@ -1,8 +1,10 @@
 # Dockerfile.base: minimal decibri install + version smoke check.
 #
-# Multi-stage: stage 1 builds the wheel from source (until 0.1.0 ships to
-# PyPI; after that, the runtime stage simply runs `pip install decibri`).
-# Stage 2 is the slim runtime image users would actually deploy.
+# Multi-stage: stage 1 builds the wheel from source (retained for
+# environments that need to build the wheel locally, e.g., custom Rust
+# toolchain configurations or air-gapped builds; for the standard install,
+# the runtime stage simply runs `pip install decibri`). Stage 2 is the
+# slim runtime image users would actually deploy.
 #
 # Build context: project root (the directory containing crates/, bindings/,
 # Cargo.toml). Run from project root:

--- a/bindings/python/docs/ecosystem/multiprocessing.md
+++ b/bindings/python/docs/ecosystem/multiprocessing.md
@@ -36,8 +36,8 @@ if __name__ == "__main__":
 Verified output:
 
 ```
-3.4.0|cpal 0.17|0.1.1
-3.4.0|cpal 0.17|0.1.1
+3.4.0|cpal 0.17|0.1.2
+3.4.0|cpal 0.17|0.1.2
 ```
 
 The same pattern works for `Microphone`, `Speaker`, `AsyncMicrophone`, `AsyncSpeaker`, and `decibri.input_devices()`. Each child constructs its own bridge; no cross-process state is shared.

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "decibri"
-version = "0.1.1"
+version = "0.1.2"
 description = "Cross-platform audio capture, output, and voice activity detection"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -58,7 +58,7 @@ numpy = ["numpy>=1.20"]
 Homepage = "https://github.com/decibri/decibri"
 Repository = "https://github.com/decibri/decibri"
 Issues = "https://github.com/decibri/decibri/issues"
-Changelog = "https://github.com/decibri/decibri/blob/main/CHANGELOG.md"
+Changelog = "https://github.com/decibri/decibri/blob/main/bindings/python/CHANGELOG.md"
 
 [dependency-groups]
 dev = [

--- a/bindings/python/python/decibri/__init__.py
+++ b/bindings/python/python/decibri/__init__.py
@@ -51,7 +51,7 @@ from decibri.exceptions import (
     VadThresholdOutOfRange,
 )
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 
 def input_devices() -> list[DeviceInfo]:

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -423,7 +423,7 @@ fn build_version_info() -> VersionInfo {
     VersionInfo {
         decibri: env!("CARGO_PKG_VERSION").to_string(),
         audio_backend: format!("cpal {}", CPAL_VERSION),
-        binding: "0.1.1".to_string(),
+        binding: "0.1.2".to_string(),
     }
 }
 

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -16,7 +16,7 @@ import decibri
 
 
 def test_package_imports() -> None:
-    assert decibri.__version__ == "0.1.1"
+    assert decibri.__version__ == "0.1.2"
     # Phase 7.7 Item A2: bridges are hidden behind the private _decibri
     # module. They are NOT accessible at decibri.<X> top level (sync or
     # async). The async pair was never accessible at the top level; the
@@ -72,7 +72,7 @@ def test_version_info_fields() -> None:
     info = _decibri.MicrophoneBridge.version()
     assert info.decibri == "3.4.0"
     assert info.audio_backend == "cpal 0.17"
-    assert info.binding == "0.1.1"
+    assert info.binding == "0.1.2"
 
 
 def test_version_info_is_frozen() -> None:

--- a/bindings/python/tests/test_wheel_smoke.py
+++ b/bindings/python/tests/test_wheel_smoke.py
@@ -29,7 +29,7 @@ def test_import_decibri() -> None:
     """The package imports successfully from the installed wheel."""
     assert decibri is not None
     assert hasattr(decibri, "__version__")
-    assert decibri.__version__ == "0.1.1"
+    assert decibri.__version__ == "0.1.2"
 
 
 def test_construct_decibri_default() -> None:

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -27,7 +27,7 @@ wheels = [
 
 [[package]]
 name = "decibri"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "decibri",
       "devDependencies": {
         "vitest": "^4.0.0"
       }
@@ -924,9 +925,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Decibri 0.1.2 - Python patch release

Six changes to the Python wheel surface. Rust core and npm binding unaffected.

### Changes

**bindings/python/README.md** — `record_to_file()` keyword argument is `duration_seconds=`, not `seconds=`. Three occurrences corrected (line 37 quickstart example + lines 94-95 function summary). Following the previous quickstart raised `TypeError: record_to_file() got an unexpected keyword argument 'seconds'`.

**package-lock.json** — postcss bumped from 8.5.9 to 8.5.14 to address GHSA XSS via unescaped `</style>` in CSS stringify output (Dependabot alert #1). Dev-only transitive dependency through vitest → vite → postcss; not shipped in production wheels.

**bindings/python/docs/ecosystem/docker.md and Dockerfile.base** — "Until 0.1.0 ships to PyPI" rewritten to past tense; 0.1.0+ has shipped.

**CHANGELOG architecture refactor** — Python wheel entries (`[0.1.0]` through `[0.1.2]`) now live in `bindings/python/CHANGELOG.md`. Root `CHANGELOG.md` continues to track Rust core (`crates/decibri`) and npm binding (`bindings/node`) which ship together at the same version. Aligns with cohort polyglot projects (tokenizers, polars, swc) which maintain per-binding CHANGELOGs.

**bindings/python/pyproject.toml** — added `Changelog` URL under `[project.urls]` pointing to `bindings/python/CHANGELOG.md`. PyPI Meta sidebar now shows a Changelog link.

**Version bump** — 0.1.1 → 0.1.2 across the 8 source-of-truth locations (pyproject.toml, `__init__.py` `__version__`, `src/lib.rs` `VersionInfo.binding`, 4 test/doc-example assertions, `uv.lock` auto-propagation).