### PR TITLE
chore: CHANGELOG fossil edit + PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+<!--
+Style: technical and structural, not narrative. Cite specific files and symbols.
+Delete sections that don't apply (e.g., a typo fix doesn't need a Validation block).
+-->
+
+## Summary
+
+<One sentence: what does this PR do, and why?>
+
+## Changes
+
+<Per-file or per-area list. Cite specific files and symbols.
+
+Example:
+- `crates/decibri/src/vad.rs`: `SileroVad::process()` now returns `Result<VadResult, DecibriError>` (was `Option<VadResult>`); callers updated in `bindings/python/src/lib.rs:142` and `bindings/node/src/lib.rs:88`.
+- `bindings/python/CHANGELOG.md`: new entry under `[Unreleased]`.
+-->
+
+## Validation
+
+<List the gates that ran green. Drop the ones that don't apply.
+
+- `cargo build --release --workspace`
+- `cargo clippy --workspace -- -D warnings`
+- `cargo fmt --all -- --check`
+- `cargo test-decibri`
+- `cd bindings/python && uv run mypy --strict && uv run pytest`
+- `cd bindings/python && uv run maturin develop --uv` (if Rust changes touch the wheel)
+- `node tests/test-ci.js`
+- `npx vitest run` (if browser sources changed)
+- Em-dash sweep: 0 hits across modified files
+-->
+
+## Related
+
+<Link to issue, master plan section, or backlog entry. Optional.>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Decibri Changelog
 
-This file tracks changes to the **decibri Rust core** (`crates/decibri`, published to crates.io) and the **decibri npm binding** (`npm/decibri`, published to npm). These two ship together at the same version under the `v*` tag pattern (e.g., `v3.4.0` publishes both `decibri 3.4.0` to crates.io and `@analyticsinmotion/decibri 3.4.0` to npm).
+This file tracks changes to the **decibri Rust core** (`crates/decibri`, published to crates.io) and the **decibri npm binding** (`npm/decibri`, published to npm). These two ship together at the same version under the `v*` tag pattern (e.g., `v3.4.0` publishes both `decibri 3.4.0` to crates.io and `decibri 3.4.0` to npm).
 
 For decibri Python wheel changes, see [bindings/python/CHANGELOG.md](bindings/python/CHANGELOG.md). The Python wheel has its own version trajectory (currently `0.1.x`) and ships under the `python-v*` tag pattern.
 


### PR DESCRIPTION
chore: CHANGELOG fossil edit + PR template

.github/pull_request_template.md: new file (49 lines). PR descriptions
now auto-populate with sections for Summary, Changes (file + symbol
citations), Validation (drop-in gate enumeration), and Related. Style
matches handover doc convention: technical and structural, not
narrative.

No source code changes; no version bump; no release.