### PR TITLE
docs: rewrite root README and add per-package READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD033 MD041 -->
+<!-- markdownlint-disable MD033 MD041 MD059 -->
 <div align="center">
   <img width="100" height="100" alt="decibri" src="https://github.com/user-attachments/assets/a1a7aa23-6954-4cac-9490-76354f0865ee" />
 
@@ -19,15 +19,16 @@ Cross-platform audio capture, playback, and voice activity detection for Python,
 
 ## What is decibri?
 
-decibri is a cross-platform audio library for capture, playback, and voice activity detection. A single Rust core (using [cpal](https://github.com/RustAudio/cpal) for audio I/O and the [Silero VAD](https://github.com/snakers4/silero-vad) ONNX model for speech detection) ships through three first-class bindings: a Python wheel via PyO3, a Node.js native addon via napi-rs, and a browser AudioWorklet implementation under the same npm package.
+decibri is an audio library for real-time speech and voice applications. It is designed to be fast, cross-platform, and consistent across languages. Key features are:
 
-## Features
+- Microphone capture and speaker playback
+- Voice activity detection (Silero or energy modes)
+- Async and streaming APIs
+- Cross-platform: Windows, macOS, Linux, browsers
+- Available in Python, Node.js, and Rust
+- Cloud and local speech-to-text integrations
 
-- Microphone capture and speaker playback for Windows, macOS, Linux, and modern browsers
-- Voice activity detection in two modes: lightweight RMS energy threshold or Silero ONNX (~2.3 MB; bundled, no API keys required)
-- Async and streaming APIs in each binding (async iterators in Python, `Readable` streams in Node.js, channels in Rust)
-- Pre-built binaries for Windows x64, macOS arm64, Linux x64, and Linux arm64; no system audio toolkit required on macOS or Windows; libasound2 only on Linux
-- Cloud and local STT/TTS integration guides at [decibri.com/docs/integrations](https://decibri.com/docs/integrations) covering OpenAI Realtime, Deepgram, AssemblyAI, AWS Transcribe, Google Speech, Azure Speech, Sherpa-ONNX, Whisper.cpp, and more
+To learn more, visit [decibri.com/docs/](https://decibri.com/docs/).
 
 ## Quick Start
 
@@ -40,11 +41,11 @@ mic = decibri.Microphone(sample_rate=16000, vad="silero")
 mic.start()
 for chunk in mic:
     print(f"Got {len(chunk)} bytes; speaking={mic.is_speaking}")
-    break  # exit after first chunk for demo
+    break
 mic.stop()
 ```
 
-Full Python guide: [bindings/python/README.md](bindings/python/README.md).
+Full Python guide: [here](bindings/python/README.md).
 
 ### Node.js
 
@@ -57,7 +58,7 @@ mic.on('speech', () => console.log('speaking'));
 setTimeout(() => mic.stop(), 5000);
 ```
 
-Full Node.js and browser guide: [npm/decibri/README.md](npm/decibri/README.md).
+Full Node.js and browser guide: [here](npm/decibri/README.md).
 
 ### Rust
 
@@ -81,41 +82,43 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-Full Rust API: [crates/decibri/README.md](crates/decibri/README.md) and [docs.rs/decibri](https://docs.rs/decibri/).
+Full Rust API: [here](crates/decibri/README.md).
 
 ## Installation
 
+**Python:**
+
 ```bash
-# Python
 pip install decibri
+```
 
-# Node.js (and browsers)
+**Node.js:**
+
+```bash
 npm install decibri
+```
 
-# Rust
+**Rust:**
+
+```bash
 cargo add decibri
 ```
 
-Each binding ships pre-built binaries for the supported platforms below. No additional system audio libraries are required on Windows or macOS; Linux requires `libasound2` (preinstalled on most desktop distributions).
-
 ## Platform Support
 
-| Platform | Architecture | Audio Backend | Python wheel | npm native | Rust crate |
-| --- | --- | --- | --- | --- | --- |
-| Windows | x64 | WASAPI | yes | yes | yes |
-| macOS | arm64 (Apple Silicon) | CoreAudio | yes | yes | yes |
-| Linux | x64 (gnu) | ALSA | yes | yes | yes |
-| Linux | arm64 (gnu) | ALSA | yes | yes | yes |
-| Browser | n/a | Web Audio API (AudioWorklet) | n/a | yes | n/a |
+Supports:
 
-Intel macOS and Windows arm64 are not currently shipped as pre-built binaries. Source builds via `cargo build` work on those targets but are not part of the release matrix.
+- Windows x64
+- macOS arm64
+- Linux x64
+- Linux arm64
 
 ## Voice Activity Detection
 
 decibri ships two VAD modes:
 
-- **Energy mode** (`vad="energy"` / `vadMode: 'energy'`): lightweight RMS threshold; no model required.
-- **Silero mode** (`vad="silero"` / `vadMode: 'silero'`): ML-based detection using the Silero VAD v5 ONNX model (~2.3 MB, bundled in every binding's distribution; no downloads or API keys required). More accurate than energy mode, especially in noisy environments.
+- **Energy mode**: lightweight RMS threshold.
+- **Silero mode**: ML-based detection using the Silero VAD v5 ONNX model. More accurate, especially in noisy environments. The model (~2.3 MB) is bundled; no downloads or API keys required.
 
 ```python
 import decibri
@@ -125,34 +128,42 @@ mic.start()
 for chunk in mic:
     if mic.is_speaking:
         print(f"speech (score={mic.vad_score:.2f})")
-    if some_stop_condition:
-        break
+    break  # demo: exit after first chunk
 mic.stop()
 ```
 
 Language-specific VAD examples and tuning advice live in each binding's README.
 
+## Integrations
+
+decibri pipes microphone audio directly into cloud and local speech services. Full guides at [decibri.com/docs/integrations](https://decibri.com/docs/integrations).
+
+| Provider | Capability | Supported |
+| --- | --- | --- |
+| OpenAI Realtime | STT (cloud) | ✓ |
+| Deepgram | STT (cloud) | ✓ |
+| AssemblyAI | STT (cloud) | ✓ |
+| Mistral Voxtral | STT (cloud) | ✓ |
+| AWS Transcribe | STT (cloud) | ✓ |
+| Google Speech | STT (cloud) | ✓ |
+| Azure Speech | STT (cloud) | ✓ |
+| Sherpa-ONNX | STT (local) | ✓ |
+| Whisper.cpp | STT (local) | ✓ |
+
 ## Architecture
 
-The Rust core in [`crates/decibri`](crates/decibri/) handles audio I/O via [cpal](https://github.com/RustAudio/cpal) and Silero VAD inference via the [`ort`](https://crates.io/crates/ort) crate (ONNX Runtime). Three bindings expose this core to their respective ecosystems:
-
-- The **Python wheel** ([`bindings/python`](bindings/python/)) is a PyO3 / abi3 binding compiled to a shared library; `pip install decibri` ships pre-built wheels for the four supported platforms.
-- The **Node.js native addon** ([`bindings/node`](bindings/node/)) is a napi-rs binding compiled to a `.node` cdylib; the [`decibri`](npm/decibri/) npm package ships per-platform binaries via optional dependencies.
-- The **browser implementation** ([`npm/decibri/src/browser`](npm/decibri/src/browser/)) is a parallel pure-JavaScript port using `getUserMedia` and `AudioWorklet`. It loads automatically from the same `decibri` npm package via conditional exports when the build target is a browser.
-
-The Silero ONNX model is bundled inside every binding's distribution. ONNX Runtime is loaded dynamically (the `ort-load-dynamic` feature flag) by default; the npm and Python bindings ship the ORT shared library alongside the model.
+decibri is built on a single Rust core with bindings for Python, Node.js, and Rust. Browsers run the same API via a JavaScript implementation in the npm package.
 
 ## Documentation
 
-- **Python guide**: [bindings/python/README.md](bindings/python/README.md) and [decibri.com/docs/](https://decibri.com/docs/)
-- **Rust guide**: [crates/decibri/README.md](crates/decibri/README.md) and [docs.rs/decibri](https://docs.rs/decibri/)
-- **Node.js and browser guide**: [npm/decibri/README.md](npm/decibri/README.md) and [decibri.com/docs/node/](https://decibri.com/docs/node/)
-- **Integration guides** (cloud and local STT/TTS providers): [decibri.com/docs/integrations](https://decibri.com/docs/integrations)
-- **Changelogs**: [CHANGELOG.md](CHANGELOG.md) (Rust core and npm), [bindings/python/CHANGELOG.md](bindings/python/CHANGELOG.md) (Python wheel)
+- Python guide: [here](bindings/python/README.md)
+- Rust guide: [here](crates/decibri/README.md) (full API at [docs.rs/decibri](https://docs.rs/decibri/))
+- Node.js and browser guide: [here](npm/decibri/README.md)
+- Integration guides: [decibri.com/docs/integrations](https://decibri.com/docs/integrations)
 
 ## Contributing
 
-Contributions, issue reports, and feature requests are welcome at [github.com/decibri/decibri/issues](https://github.com/decibri/decibri/issues). See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code style, and how to run the cross-platform test suite.
+Issues and PRs welcome at [github.com/decibri/decibri/issues](https://github.com/decibri/decibri/issues). See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,335 +4,158 @@
 
 # decibri
 
-  Cross-platform audio capture, output, and processing for Node.js and browsers.
+Cross-platform audio capture, playback, and voice activity detection for Python, Rust, and Node.js.
 
-  <!-- badges: start -->
-  <table>
-    <tr>
-      <td><strong>Meta</strong></td>
-      <td>
-        <a href="https://pypi.org/project/decibri/"><img src="https://img.shields.io/pypi/v/decibri" alt="PyPI version"></a>&nbsp;
-        <a href="https://www.npmjs.com/package/decibri"><img src="https://img.shields.io/npm/v/decibri" alt="npm version"></a>&nbsp;
-        <a href="https://crates.io/crates/decibri"><img src="https://img.shields.io/crates/v/decibri" alt="crates.io version"></a>&nbsp;
-        <a href="https://github.com/decibri/decibri/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="Apache 2.0 License"></a>&nbsp;
-        <a href="https://decibri.com"><img src="https://img.shields.io/badge/Website-decibri.com-blue" alt="decibri.com"></a>&nbsp;
-        <a href="https://decibri.com/docs/"><img src="https://img.shields.io/badge/docs-passing-brightgreen" alt="Docs"></a>
-      </td>
-    </tr>
-    <tr>
-    <td><strong>Binaries</strong></td>
-    <td>
-      <a href="https://github.com/decibri/decibri/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/decibri/decibri/release.yml?job=Build%20x86_64-pc-windows-msvc&label=Windows%20x64&logo=microsoft&logoColor=white" alt="Windows x64"></a>&nbsp;
-      <a href="https://github.com/decibri/decibri/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/decibri/decibri/release.yml?job=Build%20aarch64-apple-darwin&label=macOS%20ARM64&logo=apple" alt="macOS ARM64"></a>&nbsp;
-      <a href="https://github.com/decibri/decibri/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/decibri/decibri/release.yml?job=Build%20x86_64-unknown-linux-gnu&label=Linux%20x64&logo=linux&logoColor=white" alt="Linux x64"></a>&nbsp;
-      <a href="https://github.com/decibri/decibri/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/decibri/decibri/release.yml?job=Build%20aarch64-unknown-linux-gnu&label=Linux%20ARM64&logo=linux&logoColor=white" alt="Linux ARM64"></a>
-    </td>
-  </tr>
-  <tr>
-    <tr>
-      <td><strong>Integrations</strong></td>
-      <td>
-        <a href="https://decibri.com/docs/node/integrations/openai-realtime"><img src="https://img.shields.io/badge/OpenAI-cloud-blue" alt="OpenAI"></a>&nbsp;
-        <a href="https://decibri.com/docs/node/integrations/deepgram"><img src="https://img.shields.io/badge/Deepgram-cloud-blue" alt="Deepgram"></a>&nbsp;
-        <a href="https://decibri.com/docs/node/integrations/assemblyai"><img src="https://img.shields.io/badge/AssemblyAI-cloud-blue" alt="AssemblyAI"></a>&nbsp;
-        <a href="https://decibri.com/docs/node/integrations/mistral-voxtral"><img src="https://img.shields.io/badge/Mistral-cloud-blue" alt="Mistral"></a>&nbsp;
-        <a href="https://decibri.com/docs/node/integrations/aws-transcribe"><img src="https://img.shields.io/badge/AWS_Transcribe-cloud-blue" alt="AWS Transcribe"></a>&nbsp;
-        <a href="https://decibri.com/docs/node/integrations/google-speech"><img src="https://img.shields.io/badge/Google_Speech-cloud-blue" alt="Google Speech-to-Text"></a>&nbsp;
-        <a href="https://decibri.com/docs/node/integrations/azure-speech"><img src="https://img.shields.io/badge/Azure_Speech-cloud-blue" alt="Azure Speech-to-Text"></a>&nbsp;
-        <a href="https://decibri.com/docs/node/integrations/sherpa-onnx-stt"><img src="https://img.shields.io/badge/Sherpa--ONNX-local-brightgreen" alt="Sherpa-ONNX"></a>&nbsp;
-        <a href="https://decibri.com/docs/node/integrations/whisper-cpp"><img src="https://img.shields.io/badge/Whisper.cpp-local-brightgreen" alt="Whisper.cpp"></a>
-      </td>
-    </tr>
-  </table>
-  <!-- badges: end -->
+<a href="https://pypi.org/project/decibri/"><img src="https://img.shields.io/pypi/v/decibri" alt="PyPI version"></a>&nbsp;
+<a href="https://www.npmjs.com/package/decibri"><img src="https://img.shields.io/npm/v/decibri" alt="npm version"></a>&nbsp;
+<a href="https://crates.io/crates/decibri"><img src="https://img.shields.io/crates/v/decibri" alt="crates.io version"></a>&nbsp;
+<a href="https://github.com/decibri/decibri/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="Apache 2.0 License"></a>&nbsp;
+<a href="https://decibri.com"><img src="https://img.shields.io/badge/Website-decibri.com-blue" alt="decibri.com"></a>&nbsp;
+<a href="https://decibri.com/docs/"><img src="https://img.shields.io/badge/docs-passing-brightgreen" alt="Docs"></a>
+
 </div>
 
 ---
 
-## Installation
+## What is decibri?
 
-```bash
-npm install decibri
-```
+decibri is a cross-platform audio library for capture, playback, and voice activity detection. A single Rust core (using [cpal](https://github.com/RustAudio/cpal) for audio I/O and the [Silero VAD](https://github.com/snakers4/silero-vad) ONNX model for speech detection) ships through three first-class bindings: a Python wheel via PyO3, a Node.js native addon via napi-rs, and a browser AudioWorklet implementation under the same npm package.
 
-One package for Node.js and browsers. Node.js gets a native addon (Rust via napi-rs). Browsers get a JavaScript AudioWorklet implementation. Platform-specific binaries are installed automatically.
+## Features
 
-Requires Node.js >= 18. TypeScript definitions are bundled.
-
----
-
-## Using from Rust
-
-Most users want the npm package above. If you're building a Rust
-application directly against the [`decibri`](https://crates.io/crates/decibri) crate on crates.io:
-
-```bash
-cargo add decibri
-```
-
-The `vad` feature (enabled by default) uses ONNX Runtime via the
-[`ort`](https://crates.io/crates/ort) crate. From 3.1.0 onwards, `ort` is
-configured with `load-dynamic` by default, meaning ONNX Runtime is loaded
-from a shared library at runtime. Choose one of:
-
-- **Zero-config builds.** Opt into the download-binaries mode:
-
-  ```toml
-  decibri = { version = "3.1", features = ["ort-download-binaries"], default-features = false }
-  ```
-
-  Add back any other features you need (`capture`, `output`, `vad`,
-  `denoise`, `gain`). ORT is downloaded during `cargo build` and embedded
-  in your binary (the 3.0.x behaviour).
-
-- **Production deployments with bundled ORT.** Take default features,
-  then either set `ORT_DYLIB_PATH=/path/to/libonnxruntime.{so,dylib,dll}`
-  before first use, or call `ort::init_from(path).commit()` at startup.
-  ONNX Runtime is initialized once per process. If your app creates
-  multiple `SileroVad` instances with different paths, the first one
-  wins and later paths are silently ignored. Pick one path and reuse it.
-
-If you only need capture, output, or DSP (no Silero VAD), you won't pull
-in `ort` at all:
-
-```toml
-decibri = { version = "3.1", features = ["capture", "output"], default-features = false }
-```
-
-See the [`ort` crate linking docs](https://ort.pyke.io/setup/linking)
-for runtime-loading details.
-
----
+- Microphone capture and speaker playback for Windows, macOS, Linux, and modern browsers
+- Voice activity detection in two modes: lightweight RMS energy threshold or Silero ONNX (~2.3 MB; bundled, no API keys required)
+- Async and streaming APIs in each binding (async iterators in Python, `Readable` streams in Node.js, channels in Rust)
+- Pre-built binaries for Windows x64, macOS arm64, Linux x64, and Linux arm64; no system audio toolkit required on macOS or Windows; libasound2 only on Linux
+- Cloud and local STT/TTS integration guides at [decibri.com/docs/integrations](https://decibri.com/docs/integrations) covering OpenAI Realtime, Deepgram, AssemblyAI, AWS Transcribe, Google Speech, Azure Speech, Sherpa-ONNX, Whisper.cpp, and more
 
 ## Quick Start
 
-### Capture audio
+### Python
+
+```python
+import decibri
+
+mic = decibri.Microphone(sample_rate=16000, vad="silero")
+mic.start()
+for chunk in mic:
+    print(f"Got {len(chunk)} bytes; speaking={mic.is_speaking}")
+    break  # exit after first chunk for demo
+mic.stop()
+```
+
+Full Python guide: [bindings/python/README.md](bindings/python/README.md).
+
+### Node.js
 
 ```javascript
 const Decibri = require('decibri');
 
-const mic = new Decibri({ sampleRate: 16000, channels: 1 });
-mic.on('data', (chunk) => { /* Buffer of Int16 PCM samples */ });
+const mic = new Decibri({ sampleRate: 16000, vad: true, vadMode: 'silero' });
+mic.on('data', (chunk) => console.log(`Got ${chunk.length} bytes`));
+mic.on('speech', () => console.log('speaking'));
 setTimeout(() => mic.stop(), 5000);
 ```
 
-### Play audio
+Full Node.js and browser guide: [npm/decibri/README.md](npm/decibri/README.md).
 
-```javascript
-const { DecibriOutput } = require('decibri');
+### Rust
 
-const speaker = new DecibriOutput({ sampleRate: 16000, channels: 1 });
-speaker.write(pcmBuffer);
-speaker.end();
+```rust
+use std::time::Duration;
+use decibri::capture::{AudioCapture, CaptureConfig};
+use decibri::vad::{SileroVad, VadConfig};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let capture = AudioCapture::new(CaptureConfig::default())?;
+    let stream = capture.start()?;
+    let mut vad = SileroVad::new(VadConfig::default())?;
+
+    while let Ok(Some(chunk)) = stream.next_chunk(Some(Duration::from_millis(100))) {
+        let result = vad.process(&chunk.data)?;
+        if result.is_speech {
+            println!("speech @ p={:.2}", result.probability);
+        }
+    }
+    Ok(())
+}
 ```
 
-### Browser capture
+Full Rust API: [crates/decibri/README.md](crates/decibri/README.md) and [docs.rs/decibri](https://docs.rs/decibri/).
 
-```javascript
-import { Decibri } from 'decibri'; // browser entry via conditional export
-
-const mic = new Decibri({ sampleRate: 16000 });
-mic.on('data', (chunk) => { /* Int16Array of PCM samples */ });
-await mic.start(); // requires user gesture in Safari
-```
-
-### Pipe capture to playback (echo)
-
-```javascript
-const mic = new Decibri({ sampleRate: 16000, channels: 1 });
-const speaker = new DecibriOutput({ sampleRate: 16000, channels: 1 });
-mic.pipe(speaker);
-```
-
----
-
-## API: Decibri (Capture)
-
-### `new Decibri(options?)`
-
-Creates a `Readable` stream that captures from the microphone.
-
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `sampleRate` | number | `16000` | Samples per second (1000–384000) |
-| `channels` | number | `1` | Input channels (1–32) |
-| `framesPerBuffer` | number | `1600` | Frames per chunk (64–65536). At 16kHz mono, 1600 = 100ms = 3200 bytes |
-| `device` | number \| string | system default | Device index or case-insensitive name substring |
-| `format` | `'int16'` \| `'float32'` | `'int16'` | Sample encoding |
-| `vad` | boolean | `false` | Enable voice activity detection |
-| `vadMode` | `'energy'` \| `'silero'` | `'energy'` | VAD engine: RMS threshold or Silero ML model |
-| `vadThreshold` | number | `0.01` / `0.5` | Speech threshold. Default depends on vadMode |
-| `vadHoldoff` | number | `300` | Silence holdoff in ms |
-
-Standard `ReadableOptions` (e.g. `highWaterMark`) are also accepted.
-
-### Methods
-
-| Method | Description |
-| --- | --- |
-| `mic.stop()` | Stop capture and end stream. Safe to call multiple times |
-| `Decibri.devices()` | List available input devices |
-| `Decibri.version()` | Version info: `{ decibri: '3.0.0', portaudio: 'cpal 0.17' }` |
-
-### Properties
-
-| Property | Type | Description |
-| --- | --- | --- |
-| `mic.isOpen` | boolean | `true` while capturing |
-
-### Events
-
-| Event | Payload | Description |
-| --- | --- | --- |
-| `'data'` | `Buffer` | Audio chunk (Int16 LE or Float32 LE) |
-| `'backpressure'` | - | Internal buffer full, consumer too slow |
-| `'speech'` | - | VAD: audio crosses threshold |
-| `'silence'` | - | VAD: audio below threshold for `vadHoldoff` ms |
-| `'end'` | - | Stream ended |
-| `'error'` | `Error` | An error occurred |
-
----
-
-## API: DecibriOutput (Playback)
-
-### `new DecibriOutput(options?)`
-
-Creates a `Writable` stream for speaker playback.
-
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `sampleRate` | number | `16000` | Playback sample rate (1000–384000) |
-| `channels` | number | `1` | Output channels (1–32) |
-| `format` | `'int16'` \| `'float32'` | `'int16'` | Sample encoding of incoming data |
-| `device` | number \| string | system default | Output device index or name substring |
-
-Standard `WritableOptions` (e.g. `highWaterMark`) are also accepted.
-
-| Method / Property | Description |
-| --- | --- |
-| `speaker.write(chunk)` | Write PCM data for playback |
-| `speaker.end()` | Signal end. Drains remaining audio, then emits `'finish'` |
-| `speaker.stop()` | Immediate stop. Discards remaining audio |
-| `speaker.isPlaying` | `true` while audio is being output |
-| `DecibriOutput.devices()` | List available output devices |
-| `DecibriOutput.version()` | Same as `Decibri.version()` |
-
----
-
-## API: Browser
-
-The browser API uses `getUserMedia` and `AudioWorklet`. It differs from the Node.js API because browser audio is fundamentally async.
-
-### `new Decibri(options?)`
-
-Same options as Node.js, plus:
-
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `device` | string | system default | Device ID from `Decibri.devices()` (not index) |
-| `echoCancellation` | boolean | `true` | Browser echo cancellation |
-| `noiseSuppression` | boolean | `true` | Browser noise suppression |
-| `workletUrl` | string | inline blob | Custom worklet URL for strict CSP |
-
-### Key differences from Node.js
-
-| Aspect | Node.js | Browser |
-| --- | --- | --- |
-| Start | Automatic on first read | `await mic.start()` |
-| Base class | `Readable` stream | Custom `Emitter` |
-| Data type | `Buffer` | `Int16Array` / `Float32Array` |
-| `devices()` | Sync, returns array | Async, returns `Promise` |
-| Sample rate | Direct via cpal | Resampled from native rate |
-
----
-
-## Voice Activity Detection
-
-### Energy mode (default)
-
-Lightweight RMS energy threshold. No model required.
-
-```javascript
-const mic = new Decibri({ vad: true, vadThreshold: 0.01 });
-mic.on('speech', () => console.log('speaking'));
-mic.on('silence', () => console.log('silent'));
-```
-
-### Silero mode
-
-ML-based detection using the Silero VAD v5 ONNX model. More accurate than energy mode, especially in noisy environments.
-
-```javascript
-const mic = new Decibri({ vad: true, vadMode: 'silero', vadThreshold: 0.5 });
-mic.on('speech', () => console.log('speaking'));
-mic.on('silence', () => console.log('silent'));
-```
-
-The Silero model (~2MB) ships inside the npm package. No downloads or API keys required.
-
----
-
-## Device Selection
-
-```javascript
-// System default
-const mic = new Decibri();
-
-// By name (case-insensitive substring match)
-const mic = new Decibri({ device: 'USB' });
-
-// By index
-const devices = Decibri.devices();
-const mic = new Decibri({ device: devices[1].index });
-```
-
-```javascript
-Decibri.devices();
-// [
-//   { index: 0, name: 'Microphone', maxInputChannels: 2, defaultSampleRate: 48000, isDefault: true },
-//   { index: 1, name: 'USB Headset', maxInputChannels: 1, defaultSampleRate: 44100, isDefault: false }
-// ]
-```
-
----
-
-## Examples
-
-Runnable examples are in [`examples/`](examples/).
+## Installation
 
 ```bash
-# Capture to WAV file (no dependencies)
-node examples/wav-capture.js
+# Python
+pip install decibri
 
-# Stream to WebSocket (requires: npm install ws)
-node examples/websocket-server.js   # terminal 1
-node examples/websocket-stream.js   # terminal 2
+# Node.js (and browsers)
+npm install decibri
+
+# Rust
+cargo add decibri
 ```
 
-Integration guides for OpenAI, Deepgram, AssemblyAI, and other providers are at [decibri.com/docs](https://decibri.com/docs/).
-
----
+Each binding ships pre-built binaries for the supported platforms below. No additional system audio libraries are required on Windows or macOS; Linux requires `libasound2` (preinstalled on most desktop distributions).
 
 ## Platform Support
 
-| Platform | Architecture | Audio Backend |
-| --- | --- | --- |
-| Windows | x64 | WASAPI |
-| macOS | arm64 | CoreAudio |
-| Linux | x64 | ALSA |
-| Linux | arm64 | ALSA |
-| Browser | - | Web Audio API (AudioWorklet) |
+| Platform | Architecture | Audio Backend | Python wheel | npm native | Rust crate |
+| --- | --- | --- | --- | --- | --- |
+| Windows | x64 | WASAPI | yes | yes | yes |
+| macOS | arm64 (Apple Silicon) | CoreAudio | yes | yes | yes |
+| Linux | x64 (gnu) | ALSA | yes | yes | yes |
+| Linux | arm64 (gnu) | ALSA | yes | yes | yes |
+| Browser | n/a | Web Audio API (AudioWorklet) | n/a | yes | n/a |
 
----
+Intel macOS and Windows arm64 are not currently shipped as pre-built binaries. Source builds via `cargo build` work on those targets but are not part of the release matrix.
 
-## How It Works
+## Voice Activity Detection
 
-decibri is a Rust library using [cpal](https://github.com/RustAudio/cpal) for cross-platform audio I/O. The Rust core compiles to a Node.js native addon via [napi-rs](https://napi.rs/) and ships pre-built binaries for each platform. Browser support uses a JavaScript AudioWorklet implementation with the same event-driven API.
+decibri ships two VAD modes:
 
-Audio flows from the OS audio device through cpal's callback, into a crossbeam channel, through frame-exact buffering (guarantees consistent chunk sizes), and into Node.js via a threadsafe function. The JavaScript layer wraps this in a standard `Readable` stream.
+- **Energy mode** (`vad="energy"` / `vadMode: 'energy'`): lightweight RMS threshold; no model required.
+- **Silero mode** (`vad="silero"` / `vadMode: 'silero'`): ML-based detection using the Silero VAD v5 ONNX model (~2.3 MB, bundled in every binding's distribution; no downloads or API keys required). More accurate than energy mode, especially in noisy environments.
 
----
+```python
+import decibri
+
+mic = decibri.Microphone(sample_rate=16000, vad="silero", vad_threshold=0.5)
+mic.start()
+for chunk in mic:
+    if mic.is_speaking:
+        print(f"speech (score={mic.vad_score:.2f})")
+    if some_stop_condition:
+        break
+mic.stop()
+```
+
+Language-specific VAD examples and tuning advice live in each binding's README.
+
+## Architecture
+
+The Rust core in [`crates/decibri`](crates/decibri/) handles audio I/O via [cpal](https://github.com/RustAudio/cpal) and Silero VAD inference via the [`ort`](https://crates.io/crates/ort) crate (ONNX Runtime). Three bindings expose this core to their respective ecosystems:
+
+- The **Python wheel** ([`bindings/python`](bindings/python/)) is a PyO3 / abi3 binding compiled to a shared library; `pip install decibri` ships pre-built wheels for the four supported platforms.
+- The **Node.js native addon** ([`bindings/node`](bindings/node/)) is a napi-rs binding compiled to a `.node` cdylib; the [`decibri`](npm/decibri/) npm package ships per-platform binaries via optional dependencies.
+- The **browser implementation** ([`npm/decibri/src/browser`](npm/decibri/src/browser/)) is a parallel pure-JavaScript port using `getUserMedia` and `AudioWorklet`. It loads automatically from the same `decibri` npm package via conditional exports when the build target is a browser.
+
+The Silero ONNX model is bundled inside every binding's distribution. ONNX Runtime is loaded dynamically (the `ort-load-dynamic` feature flag) by default; the npm and Python bindings ship the ORT shared library alongside the model.
+
+## Documentation
+
+- **Python guide**: [bindings/python/README.md](bindings/python/README.md) and [decibri.com/docs/](https://decibri.com/docs/)
+- **Rust guide**: [crates/decibri/README.md](crates/decibri/README.md) and [docs.rs/decibri](https://docs.rs/decibri/)
+- **Node.js and browser guide**: [npm/decibri/README.md](npm/decibri/README.md) and [decibri.com/docs/node/](https://decibri.com/docs/node/)
+- **Integration guides** (cloud and local STT/TTS providers): [decibri.com/docs/integrations](https://decibri.com/docs/integrations)
+- **Changelogs**: [CHANGELOG.md](CHANGELOG.md) (Rust core and npm), [bindings/python/CHANGELOG.md](bindings/python/CHANGELOG.md) (Python wheel)
+
+## Contributing
+
+Contributions, issue reports, and feature requests are welcome at [github.com/decibri/decibri/issues](https://github.com/decibri/decibri/issues). See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code style, and how to run the cross-platform test suite.
 
 ## License
 
-Apache-2.0 © [decibri](https://github.com/decibri)
+Apache-2.0. See [LICENSE](LICENSE) for details.
+
+Copyright (c) 2026 Decibri.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Cross-platform audio capture, playback, and voice activity detection for Python,
 
 ## What is decibri?
 
-decibri is an audio library for real-time speech and voice applications. It is designed to be fast, cross-platform, and consistent across languages. Key features are:
+Decibri is a cross-platform audio engine for real-time speech and voice applications. One unified API across Python, Rust, Node.js, and browsers.
+
+Key features:
 
 - Microphone capture and speaker playback
 - Voice activity detection (Silero or energy modes)
@@ -30,67 +32,21 @@ decibri is an audio library for real-time speech and voice applications. It is d
 
 To learn more, visit [decibri.com/docs/](https://decibri.com/docs/).
 
-## Quick Start
-
-### Python
-
-```python
-import decibri
-
-mic = decibri.Microphone(sample_rate=16000, vad="silero")
-mic.start()
-for chunk in mic:
-    print(f"Got {len(chunk)} bytes; speaking={mic.is_speaking}")
-    break
-mic.stop()
-```
-
-Full Python guide: [here](bindings/python/README.md).
-
-### Node.js
-
-```javascript
-const Decibri = require('decibri');
-
-const mic = new Decibri({ sampleRate: 16000, vad: true, vadMode: 'silero' });
-mic.on('data', (chunk) => console.log(`Got ${chunk.length} bytes`));
-mic.on('speech', () => console.log('speaking'));
-setTimeout(() => mic.stop(), 5000);
-```
-
-Full Node.js and browser guide: [here](npm/decibri/README.md).
-
-### Rust
-
-```rust
-use std::time::Duration;
-use decibri::capture::{AudioCapture, CaptureConfig};
-use decibri::vad::{SileroVad, VadConfig};
-
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let capture = AudioCapture::new(CaptureConfig::default())?;
-    let stream = capture.start()?;
-    let mut vad = SileroVad::new(VadConfig::default())?;
-
-    while let Ok(Some(chunk)) = stream.next_chunk(Some(Duration::from_millis(100))) {
-        let result = vad.process(&chunk.data)?;
-        if result.is_speech {
-            println!("speech @ p={:.2}", result.probability);
-        }
-    }
-    Ok(())
-}
-```
-
-Full Rust API: [here](crates/decibri/README.md).
-
 ## Installation
 
-**Python:**
+**Python** (recommended with [uv](https://docs.astral.sh/uv/)):
+
+```bash
+uv pip install decibri
+```
+
+Or with pip:
 
 ```bash
 pip install decibri
 ```
+
+<br/>
 
 **Node.js:**
 
@@ -98,11 +54,66 @@ pip install decibri
 npm install decibri
 ```
 
+<br/>
+
 **Rust:**
 
 ```bash
 cargo add decibri
 ```
+
+<br/>
+
+## Quick Start
+
+### Python
+
+```python
+import decibri
+
+mic = decibri.Microphone(sample_rate=16000)
+mic.start()
+for chunk in mic:
+    print(f"Got {len(chunk)} bytes")
+mic.stop()
+```
+
+Full Python guide: [here](bindings/python/README.md).
+
+<br/>
+
+### Node.js
+
+```javascript
+const Decibri = require('decibri');
+
+const mic = new Decibri({ sampleRate: 16000 });
+mic.on('data', (chunk) => console.log(`Got ${chunk.length} bytes`));
+setTimeout(() => mic.stop(), 5000);
+```
+
+Full Node.js and browser guide: [here](npm/decibri/README.md).
+
+<br/>
+
+### Rust
+
+```rust
+use decibri::capture::{AudioCapture, CaptureConfig};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let capture = AudioCapture::new(CaptureConfig::default())?;
+    let stream = capture.start()?;
+    while let Ok(Some(chunk)) = stream.next_chunk(None) {
+        println!("Got {} bytes", chunk.data.len());
+    }
+    Ok(())
+}
+```
+
+Full Rust guide: [here](crates/decibri/README.md).
+
+<br/>
 
 ## Platform Support
 
@@ -113,9 +124,11 @@ Supports:
 - Linux x64
 - Linux arm64
 
+<br/>
+
 ## Voice Activity Detection
 
-decibri ships two VAD modes:
+Decibri ships two VAD modes:
 
 - **Energy mode**: lightweight RMS threshold.
 - **Silero mode**: ML-based detection using the Silero VAD v5 ONNX model. More accurate, especially in noisy environments. The model (~2.3 MB) is bundled; no downloads or API keys required.
@@ -128,45 +141,45 @@ mic.start()
 for chunk in mic:
     if mic.is_speaking:
         print(f"speech (score={mic.vad_score:.2f})")
-    break  # demo: exit after first chunk
 mic.stop()
 ```
 
-Language-specific VAD examples and tuning advice live in each binding's README.
+The same VAD API is available in Node.js and Rust. Language-specific examples and tuning advice live in each binding's README.
+
+<br/>
 
 ## Integrations
 
-decibri pipes microphone audio directly into cloud and local speech services. Full guides at [decibri.com/docs/integrations](https://decibri.com/docs/integrations).
+Decibri pipes microphone audio directly into cloud and local speech services. Full guides at [decibri.com/docs/integrations](https://decibri.com/docs/integrations).
 
-| Provider | Capability | Supported |
-| --- | --- | --- |
-| OpenAI Realtime | STT (cloud) | ✓ |
-| Deepgram | STT (cloud) | ✓ |
-| AssemblyAI | STT (cloud) | ✓ |
-| Mistral Voxtral | STT (cloud) | ✓ |
-| AWS Transcribe | STT (cloud) | ✓ |
-| Google Speech | STT (cloud) | ✓ |
-| Azure Speech | STT (cloud) | ✓ |
-| Sherpa-ONNX | STT (local) | ✓ |
-| Whisper.cpp | STT (local) | ✓ |
+| Provider | Environment | STT | TTS | VAD | KWS |
+| :--- | :---: | :---: | :---: | :---: | :---: |
+| OpenAI Realtime | Cloud | ✅ | ✅ | | |
+| Deepgram | Cloud | ✅ | ✅ | | |
+| AssemblyAI | Cloud | ✅ | | | |
+| Mistral Voxtral | Cloud | ✅ | | | |
+| AWS Transcribe | Cloud | ✅ | | | |
+| Google Speech | Cloud | ✅ | ✅ | | |
+| Azure Speech | Cloud | ✅ | ✅ | | |
+| Sherpa-ONNX | Local | ✅ | ✅ | ✅ | ✅ |
+| Whisper.cpp | Local | ✅ | | | |
+
+<br/>
 
 ## Architecture
 
-decibri is built on a single Rust core with bindings for Python, Node.js, and Rust. Browsers run the same API via a JavaScript implementation in the npm package.
+Decibri is built on a single Rust core. The same audio engine powers all three language bindings, ensuring consistent behavior regardless of which language you use.
 
-## Documentation
+Python and Node.js install pre-built native binaries for your platform. Browsers run the same API via a JavaScript implementation that ships inside the npm package.
 
-- Python guide: [here](bindings/python/README.md)
-- Rust guide: [here](crates/decibri/README.md) (full API at [docs.rs/decibri](https://docs.rs/decibri/))
-- Node.js and browser guide: [here](npm/decibri/README.md)
-- Integration guides: [decibri.com/docs/integrations](https://decibri.com/docs/integrations)
+<br/>
 
 ## Contributing
 
-Issues and PRs welcome at [github.com/decibri/decibri/issues](https://github.com/decibri/decibri/issues). See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup.
+[Issues](https://github.com/decibri/decibri/issues) and PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup.
+
+<br/>
 
 ## License
 
-Apache-2.0. See [LICENSE](LICENSE) for details.
-
-Copyright (c) 2026 Decibri.
+Apache-2.0 © 2026 [Decibri](https://github.com/decibri).

--- a/crates/decibri/Cargo.toml
+++ b/crates/decibri/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Cross-platform audio capture, output, and processing"
-readme = "../../README.md"
+readme = "README.md"
 keywords = ["audio", "microphone", "capture", "sound", "voice"]
 categories = ["multimedia::audio"]
 

--- a/crates/decibri/README.md
+++ b/crates/decibri/README.md
@@ -1,0 +1,163 @@
+# decibri (Rust)
+
+Cross-platform audio capture, playback, and voice activity detection for Rust applications.
+
+[![crates.io](https://img.shields.io/crates/v/decibri)](https://crates.io/crates/decibri)
+[![docs.rs](https://img.shields.io/docsrs/decibri)](https://docs.rs/decibri/)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/decibri/decibri/blob/main/LICENSE)
+
+This is the Rust core of decibri. The same crate powers decibri's Python wheel (via PyO3) and Node.js native addon (via napi-rs); see the [main README](https://github.com/decibri/decibri) for the polyglot project context.
+
+## Add to Cargo.toml
+
+```bash
+cargo add decibri
+```
+
+Or directly:
+
+```toml
+[dependencies]
+decibri = "3"
+```
+
+The default feature set (`capture`, `output`, `vad`, `denoise`, `gain`, `ort-load-dynamic`) covers most use cases. See [Feature flags](#feature-flags) below for opt-in or trimmed configurations.
+
+## Quick Start
+
+### Capture and run VAD
+
+```rust
+use std::time::Duration;
+use decibri::capture::{AudioCapture, CaptureConfig};
+use decibri::vad::{SileroVad, VadConfig};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let capture = AudioCapture::new(CaptureConfig::default())?;
+    let stream = capture.start()?;
+    let mut vad = SileroVad::new(VadConfig::default())?;
+
+    while let Ok(Some(chunk)) = stream.next_chunk(Some(Duration::from_millis(100))) {
+        let result = vad.process(&chunk.data)?;
+        if result.is_speech {
+            println!("speech @ p={:.2}", result.probability);
+        }
+    }
+    Ok(())
+}
+```
+
+`CaptureStream::next_chunk` returns a three-state `Result`: `Ok(Some(chunk))` on data, `Ok(None)` on timeout (stream still open), and `Err(DecibriError::CaptureStreamClosed)` once the stream ends.
+
+### Speaker output
+
+```rust
+use decibri::output::{AudioOutput, OutputConfig};
+
+let output = AudioOutput::new(OutputConfig::default())?;
+let stream = output.start()?;
+stream.send(&pcm_int16_bytes)?;
+stream.drain()?;
+stream.stop()?;
+```
+
+`OutputStream::send` accepts byte slices in the format declared by `OutputConfig` (default: int16 LE). `drain` blocks until the device has finished playing; `stop` is immediate.
+
+### Energy-mode VAD without ONNX Runtime
+
+If you do not need Silero, the lightweight RMS energy mode in `vad` does not require ORT. You can also disable the `vad` feature entirely to avoid the `ort` dependency.
+
+## Feature flags
+
+| Flag | Default | Purpose |
+| --- | --- | --- |
+| `capture` | on | Microphone input stream support |
+| `output` | on | Speaker output stream support |
+| `vad` | on | Silero VAD ONNX inference |
+| `denoise` | on | Reserved (stub) |
+| `gain` | on | Reserved (stub) |
+| `ort-load-dynamic` | on | ORT loaded at runtime from a user-supplied path |
+| `ort-download-binaries` | off | ORT downloaded at build time and embedded in the binary |
+
+`ort-load-dynamic` and `ort-download-binaries` are mutually exclusive; selecting both is a compile error.
+
+Execution-provider passthrough features (off by default; opt in for GPU acceleration on specific platforms): `coreml`, `cuda`, `directml`, `rocm`. See [`docs/features.md`](https://github.com/decibri/decibri/blob/main/docs/features.md) for the full reference.
+
+### Common configurations
+
+**Zero-config builds** (ORT downloaded at `cargo build`, embedded):
+
+```toml
+decibri = { version = "3", features = ["ort-download-binaries"], default-features = false }
+```
+
+Add back the other features you want (`capture`, `output`, `vad`, `denoise`, `gain`).
+
+**Production deployments with bundled ORT** (default; ORT loaded at runtime from a path you control):
+
+```toml
+decibri = "3"
+```
+
+Then either set `ORT_DYLIB_PATH=/path/to/libonnxruntime.{so,dylib,dll}` before first use, or call `ort::init_from(path).commit()` at startup. ORT initializes exactly once per process; the first successful path wins and later constructions silently reuse it.
+
+**Capture and output without VAD** (no `ort` dependency at all):
+
+```toml
+decibri = { version = "3", features = ["capture", "output"], default-features = false }
+```
+
+## ONNX Runtime configuration
+
+Under `ort-load-dynamic` (default), the `ort` crate locates the ONNX Runtime shared library at runtime via either a `VadConfig::ort_library_path`, the `ORT_DYLIB_PATH` environment variable, or a process-wide `ort::init_from(...).commit()` call. decibri performs a filesystem-level path check before handing the path to `ort::init_from`, so a missing or wrong-arch dylib surfaces as `DecibriError::OrtPathInvalid` rather than hanging on dynamic load.
+
+See the [`ort` crate linking docs](https://ort.pyke.io/setup/linking) for the full runtime-loading reference.
+
+### Fork safety (Linux)
+
+ORT initialized in a parent process does not survive `fork()` cleanly: internal threads, memory pools, and device handles belonging to the parent may misbehave in the child. Python consumers should use `multiprocessing.set_start_method('spawn', force=True)` before importing decibri. Node.js consumers using `child_process` or `worker_threads` are unaffected.
+
+## Public API surface
+
+The 3.x stable surface includes:
+
+- [`capture::AudioCapture`](https://docs.rs/decibri/latest/decibri/capture/struct.AudioCapture.html), [`capture::CaptureConfig`](https://docs.rs/decibri/latest/decibri/capture/struct.CaptureConfig.html), [`capture::CaptureStream`](https://docs.rs/decibri/latest/decibri/capture/struct.CaptureStream.html) (`try_next_chunk`, `next_chunk`, `is_open`, `stop`)
+- [`output::AudioOutput`](https://docs.rs/decibri/latest/decibri/output/struct.AudioOutput.html), [`output::OutputConfig`](https://docs.rs/decibri/latest/decibri/output/struct.OutputConfig.html), [`output::OutputStream`](https://docs.rs/decibri/latest/decibri/output/struct.OutputStream.html) (`send`, `drain`, `is_playing`, `stop`)
+- [`vad::SileroVad`](https://docs.rs/decibri/latest/decibri/vad/struct.SileroVad.html), [`vad::VadConfig`](https://docs.rs/decibri/latest/decibri/vad/struct.VadConfig.html), [`vad::VadResult`](https://docs.rs/decibri/latest/decibri/vad/struct.VadResult.html)
+- [`device`](https://docs.rs/decibri/latest/decibri/device/index.html) module: device enumeration and selection by index, case-insensitive name substring, or stable per-host ID
+- [`error::DecibriError`](https://docs.rs/decibri/latest/decibri/error/enum.DecibriError.html): `#[non_exhaustive]` enum covering capture, output, device, ORT, and fork-detection error variants
+
+The `OnnxSession` trait abstracting ONNX Runtime is `pub(crate)` in 3.x and graduates to public at the planned 4.0 / `decibri-onnx` workspace split.
+
+Full API reference: [docs.rs/decibri](https://docs.rs/decibri/).
+
+## Thread safety
+
+All public types are `Send` and suitable for cross-thread handoff. `CaptureStream` and `OutputStream` are `!Sync` because they hold a `cpal::Stream` internally; wrap them in a mutex or move them into a dedicated thread for shared access.
+
+## Platform Support
+
+| Platform | Architecture | Audio Backend |
+| --- | --- | --- |
+| Windows | x64 | WASAPI |
+| macOS | arm64 (Apple Silicon) | CoreAudio |
+| Linux | x64 (gnu) | ALSA |
+| Linux | arm64 (gnu) | ALSA |
+
+Source builds work on additional targets (Intel macOS, Windows arm64, musl Linux) but are not part of the npm and PyPI binary release matrix. The Rust crate itself has no per-target restriction beyond cpal's host support.
+
+## Cross-references
+
+- **Polyglot project context**: [github.com/decibri/decibri](https://github.com/decibri/decibri)
+- **Python wheel**: [bindings/python/README.md](https://github.com/decibri/decibri/blob/main/bindings/python/README.md)
+- **Node.js and browser package**: [npm/decibri/README.md](https://github.com/decibri/decibri/blob/main/npm/decibri/README.md)
+- **Full Rust API**: [docs.rs/decibri](https://docs.rs/decibri/)
+- **Feature flag reference**: [docs/features.md](https://github.com/decibri/decibri/blob/main/docs/features.md)
+- **CHANGELOG**: [CHANGELOG.md](https://github.com/decibri/decibri/blob/main/CHANGELOG.md)
+- **ORT linking docs**: [ort.pyke.io/setup/linking](https://ort.pyke.io/setup/linking)
+
+## License
+
+Apache-2.0. See [LICENSE](https://github.com/decibri/decibri/blob/main/LICENSE) for details.
+
+Copyright (c) 2026 Decibri.

--- a/npm/decibri/README.md
+++ b/npm/decibri/README.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable MD024 -->
 
-# decibri (Node.js and browsers)
+# decibri
 
 Cross-platform audio capture, playback, and voice activity detection for Node.js applications and modern browsers.
 
@@ -8,7 +8,7 @@ Cross-platform audio capture, playback, and voice activity detection for Node.js
 [![npm downloads](https://img.shields.io/npm/dm/decibri)](https://www.npmjs.com/package/decibri)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/decibri/decibri/blob/main/LICENSE)
 
-This is the Node.js and browser binding of decibri. The same Rust core powers decibri's Python wheel and Rust crate; see the [main README](https://github.com/decibri/decibri) for the polyglot project context.
+This is the Node.js and browser binding of decibri. The same audio engine powers decibri's Python and Rust bindings; see the [Main Project Readme](https://github.com/decibri/decibri) for the full project context.
 
 ## Installation
 
@@ -16,7 +16,7 @@ This is the Node.js and browser binding of decibri. The same Rust core powers de
 npm install decibri
 ```
 
-One package serves both Node.js and browsers via conditional exports. Node.js gets a native addon (Rust via [napi-rs](https://napi.rs/)). Browsers get a JavaScript [AudioWorklet](https://developer.mozilla.org/en-US/docs/Web/API/AudioWorklet) implementation. Platform-specific binaries are installed automatically through optional dependencies.
+One package serves both Node.js and browsers via conditional exports. Node.js gets a native addon. Browsers get a JavaScript [AudioWorklet](https://developer.mozilla.org/en-US/docs/Web/API/AudioWorklet) implementation. Platform-specific binaries are installed automatically through optional dependencies.
 
 Requires Node.js >= 18 for Node.js consumers. TypeScript definitions are bundled.
 
@@ -129,7 +129,7 @@ Standard `WritableOptions` (e.g. `highWaterMark`) are also accepted.
 | `DecibriOutput.devices()` | List available output devices |
 | `DecibriOutput.version()` | Same as `Decibri.version()` |
 
-## Browser API
+## API: Browser
 
 The browser API uses `getUserMedia` and `AudioWorklet`. It differs from the Node.js API because browser audio is fundamentally async.
 
@@ -152,31 +152,28 @@ Same options as Node.js, plus:
 | Base class | `Readable` stream | Custom `Emitter` |
 | Data type | `Buffer` | `Int16Array` / `Float32Array` |
 | `devices()` | Sync, returns array | Async, returns `Promise` |
-| Sample rate | Direct via cpal | Resampled from native rate |
+| Sample rate | Direct | Resampled from native rate |
 
 ## Voice Activity Detection
 
-### Energy mode (default)
+Decibri ships two VAD modes:
 
-Lightweight RMS energy threshold. No model required.
+- **Energy mode** (default): lightweight RMS energy threshold. No model required.
+- **Silero mode**: ML-based detection using the Silero VAD v5 ONNX model. More accurate, especially in noisy environments. The model (~2.3 MB) ships inside the npm package; no downloads or API keys required.
 
 ```javascript
+// Energy mode
 const mic = new Decibri({ vad: true, vadThreshold: 0.01 });
 mic.on('speech', () => console.log('speaking'));
 mic.on('silence', () => console.log('silent'));
-```
 
-### Silero mode
-
-ML-based detection using the Silero VAD v5 ONNX model. More accurate than energy mode, especially in noisy environments.
-
-```javascript
+// Silero mode
 const mic = new Decibri({ vad: true, vadMode: 'silero', vadThreshold: 0.5 });
 mic.on('speech', () => console.log('speaking'));
 mic.on('silence', () => console.log('silent'));
 ```
 
-The Silero model (~2.3 MB) ships inside the npm package. No downloads or API keys required.
+The same VAD modes are available in Decibri's Python and Rust bindings.
 
 ## Device Selection
 
@@ -202,32 +199,39 @@ Decibri.devices();
 
 ## Examples
 
-Runnable Node.js examples are in the [`examples/`](https://github.com/decibri/decibri/tree/main/examples) directory of the repo.
+Runnable Node.js examples are in the [examples](https://github.com/decibri/decibri/tree/main/examples) directory of the repo.
+
+Capture to WAV file (no dependencies):
 
 ```bash
-# Capture to WAV file (no dependencies)
 node examples/wav-capture.js
+```
 
-# Stream to WebSocket (requires: npm install ws)
-node examples/websocket-server.js   # terminal 1
-node examples/websocket-stream.js   # terminal 2
+Stream to WebSocket (requires `npm install ws`):
+
+```bash
+# Terminal 1
+node examples/websocket-server.js
+
+# Terminal 2
+node examples/websocket-stream.js
 ```
 
 ## Integrations
 
-decibri's capture output and playback input can pipe directly into cloud and local STT/TTS services. Integration guides at [decibri.com/docs/integrations](https://decibri.com/docs/integrations) cover:
+Decibri's capture output and playback input pipe directly into cloud and local STT/TTS services. Integration guides at [decibri.com/docs/integrations](https://decibri.com/docs/integrations) cover:
 
-| Provider | Type | Guide |
+| Provider | Environment | Guide |
 | --- | --- | --- |
-| OpenAI Realtime | cloud | [decibri.com/docs/node/integrations/openai-realtime](https://decibri.com/docs/node/integrations/openai-realtime) |
-| Deepgram | cloud | [decibri.com/docs/node/integrations/deepgram](https://decibri.com/docs/node/integrations/deepgram) |
-| AssemblyAI | cloud | [decibri.com/docs/node/integrations/assemblyai](https://decibri.com/docs/node/integrations/assemblyai) |
-| Mistral Voxtral | cloud | [decibri.com/docs/node/integrations/mistral-voxtral](https://decibri.com/docs/node/integrations/mistral-voxtral) |
-| AWS Transcribe | cloud | [decibri.com/docs/node/integrations/aws-transcribe](https://decibri.com/docs/node/integrations/aws-transcribe) |
-| Google Speech-to-Text | cloud | [decibri.com/docs/node/integrations/google-speech](https://decibri.com/docs/node/integrations/google-speech) |
-| Azure Speech-to-Text | cloud | [decibri.com/docs/node/integrations/azure-speech](https://decibri.com/docs/node/integrations/azure-speech) |
-| Sherpa-ONNX | local | [decibri.com/docs/node/integrations/sherpa-onnx-stt](https://decibri.com/docs/node/integrations/sherpa-onnx-stt) |
-| Whisper.cpp | local | [decibri.com/docs/node/integrations/whisper-cpp](https://decibri.com/docs/node/integrations/whisper-cpp) |
+| OpenAI Realtime | Cloud | [Guide](https://decibri.com/docs/node/integrations/openai-realtime) |
+| Deepgram | Cloud | [Guide](https://decibri.com/docs/node/integrations/deepgram) |
+| AssemblyAI | Cloud | [Guide](https://decibri.com/docs/node/integrations/assemblyai) |
+| Mistral Voxtral | Cloud | [Guide](https://decibri.com/docs/node/integrations/mistral-voxtral) |
+| AWS Transcribe | Cloud | [Guide](https://decibri.com/docs/node/integrations/aws-transcribe) |
+| Google Speech-to-Text | Cloud | [Guide](https://decibri.com/docs/node/integrations/google-speech) |
+| Azure Speech-to-Text | Cloud | [Guide](https://decibri.com/docs/node/integrations/azure-speech) |
+| Sherpa-ONNX | Local | [Guide](https://decibri.com/docs/node/integrations/sherpa-onnx-stt) |
+| Whisper.cpp | Local | [Guide](https://decibri.com/docs/node/integrations/whisper-cpp) |
 
 ## Platform Support
 
@@ -239,26 +243,21 @@ decibri's capture output and playback input can pipe directly into cloud and loc
 | Linux | arm64 (gnu) | ALSA |
 | Browser | n/a | Web Audio API (AudioWorklet) |
 
-Pre-built native binaries ship via per-platform optional dependencies (`@decibri/decibri-win32-x64-msvc`, `@decibri/decibri-darwin-arm64`, `@decibri/decibri-linux-x64-gnu`, `@decibri/decibri-linux-arm64-gnu`). The browser entry point is pure JavaScript and requires no native binary.
+Pre-built native binaries ship via per-platform optional dependencies. The browser entry point is pure JavaScript and requires no native binary.
 
 ## How It Works
 
-decibri is a Rust library using [cpal](https://github.com/RustAudio/cpal) for cross-platform audio I/O. The Rust core compiles to a Node.js native addon via [napi-rs](https://napi.rs/) and ships pre-built binaries for each platform. Browser support uses a JavaScript AudioWorklet implementation with the same event-driven API.
+Decibri is built on a single Rust core. Audio flows from the OS audio device through the engine, through frame-exact buffering (which guarantees consistent chunk sizes), and into Node.js as a standard `Readable` stream. Browser support uses a JavaScript AudioWorklet implementation with the same event-driven API.
 
-Audio flows from the OS audio device through cpal's callback, into a [crossbeam-channel](https://github.com/crossbeam-rs/crossbeam), through frame-exact buffering (guarantees consistent chunk sizes), and into Node.js via a threadsafe function. The JavaScript layer wraps this in a standard `Readable` stream.
-
-The same Rust core is also published to [crates.io](https://crates.io/crates/decibri) for direct Rust consumers and to [PyPI](https://pypi.org/project/decibri/) (via PyO3) for Python consumers.
+The same audio engine is also published to [crates.io](https://crates.io/crates/decibri) for direct Rust consumers and to [PyPI](https://pypi.org/project/decibri/) for Python consumers.
 
 ## Cross-references
 
-- **Polyglot project context**: [github.com/decibri/decibri](https://github.com/decibri/decibri)
-- **Python wheel**: [bindings/python/README.md](https://github.com/decibri/decibri/blob/main/bindings/python/README.md)
-- **Rust crate**: [crates/decibri/README.md](https://github.com/decibri/decibri/blob/main/crates/decibri/README.md) and [docs.rs/decibri](https://docs.rs/decibri/)
-- **CHANGELOG**: [CHANGELOG.md](https://github.com/decibri/decibri/blob/main/CHANGELOG.md)
-- **TypeScript types**: bundled in the npm package; types entry is `src/decibri.d.ts`
+- Main Project Readme: [here](https://github.com/decibri/decibri)
+- Python: [here](https://github.com/decibri/decibri/blob/main/bindings/python/README.md)
+- Rust: [here](https://github.com/decibri/decibri/blob/main/crates/decibri/README.md) (full API at [docs.rs/decibri](https://docs.rs/decibri/))
+- CHANGELOG: [here](https://github.com/decibri/decibri/blob/main/CHANGELOG.md)
 
 ## License
 
-Apache-2.0. See [LICENSE](https://github.com/decibri/decibri/blob/main/LICENSE) for details.
-
-Copyright (c) 2026 Decibri.
+Apache-2.0 © 2026 [Decibri](https://github.com/decibri).

--- a/npm/decibri/README.md
+++ b/npm/decibri/README.md
@@ -1,237 +1,139 @@
-<!-- markdownlint-disable MD024 -->
-
 # Decibri
 
-Cross-platform audio capture, playback, and voice activity detection for Node.js applications and modern browsers.
+Cross-platform audio capture, playback, and voice activity detection for Rust applications.
 
-[![npm version](https://img.shields.io/npm/v/decibri)](https://www.npmjs.com/package/decibri)
-[![npm downloads](https://img.shields.io/npm/dm/decibri)](https://www.npmjs.com/package/decibri)
+[![crates.io](https://img.shields.io/crates/v/decibri)](https://crates.io/crates/decibri)
+[![docs.rs](https://img.shields.io/docsrs/decibri)](https://docs.rs/decibri/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/decibri/decibri/blob/main/LICENSE)
 
-This is the Node.js and browser binding of decibri. The same audio engine powers decibri's Python and Rust bindings; see the [Main Project Readme](https://github.com/decibri/decibri) for the full project context.
+This is the Rust core of decibri. The same audio engine powers decibri's Python and Node.js bindings; see the [Main Project Readme](https://github.com/decibri/decibri) for the full project context.
 
-## Installation
+## Add to Cargo.toml
 
 ```bash
-npm install decibri
+cargo add decibri
 ```
 
-One package serves both Node.js and browsers via conditional exports. Node.js gets a native addon. Browsers get a JavaScript [AudioWorklet](https://developer.mozilla.org/en-US/docs/Web/API/AudioWorklet) implementation. Platform-specific binaries are installed automatically through optional dependencies.
+Or directly:
 
-Requires Node.js >= 18 for Node.js consumers. TypeScript definitions are bundled.
+```toml
+[dependencies]
+decibri = "3"
+```
+
+The default feature set (`capture`, `output`, `vad`, `denoise`, `gain`, `ort-load-dynamic`) covers most use cases. See [Feature flags](#feature-flags) below for opt-in or trimmed configurations.
 
 ## Quick Start
 
-### Capture audio (Node.js)
+### Capture and run VAD
 
-```javascript
-const Decibri = require('decibri');
+```rust
+use std::time::Duration;
+use decibri::capture::{AudioCapture, CaptureConfig};
+use decibri::vad::{SileroVad, VadConfig};
 
-const mic = new Decibri({ sampleRate: 16000, channels: 1 });
-mic.on('data', (chunk) => { /* Buffer of Int16 PCM samples */ });
-setTimeout(() => mic.stop(), 5000);
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let capture = AudioCapture::new(CaptureConfig::default())?;
+    let stream = capture.start()?;
+    let mut vad = SileroVad::new(VadConfig::default())?;
+
+    while let Ok(Some(chunk)) = stream.next_chunk(Some(Duration::from_millis(100))) {
+        let result = vad.process(&chunk.data)?;
+        if result.is_speech {
+            println!("speech @ p={:.2}", result.probability);
+        }
+    }
+    Ok(())
+}
 ```
 
-### Play audio (Node.js)
+`CaptureStream::next_chunk` returns a three-state `Result`: `Ok(Some(chunk))` on data, `Ok(None)` on timeout (stream still open), and `Err(DecibriError::CaptureStreamClosed)` once the stream ends.
 
-```javascript
-const { DecibriOutput } = require('decibri');
+### Speaker output
 
-const speaker = new DecibriOutput({ sampleRate: 16000, channels: 1 });
-speaker.write(pcmBuffer);
-speaker.end();
+```rust
+use decibri::output::{AudioOutput, OutputConfig};
+
+let output = AudioOutput::new(OutputConfig::default())?;
+let stream = output.start()?;
+stream.send(&pcm_int16_bytes)?;
+stream.drain()?;
+stream.stop()?;
 ```
 
-### Browser capture
+`OutputStream::send` accepts byte slices in the format declared by `OutputConfig` (default: int16 LE). `drain` blocks until the device has finished playing; `stop` is immediate.
 
-```javascript
-import { Decibri } from 'decibri'; // browser entry via conditional export
+### Energy-mode VAD without ONNX Runtime
 
-const mic = new Decibri({ sampleRate: 16000 });
-mic.on('data', (chunk) => { /* Int16Array of PCM samples */ });
-await mic.start(); // requires user gesture in Safari
-```
+If you do not need Silero, the lightweight RMS energy mode in `vad` does not require ORT. You can also disable the `vad` feature entirely to avoid the `ort` dependency.
 
-### Pipe capture to playback (echo)
+## Feature flags
 
-```javascript
-const mic = new Decibri({ sampleRate: 16000, channels: 1 });
-const speaker = new DecibriOutput({ sampleRate: 16000, channels: 1 });
-mic.pipe(speaker);
-```
-
-## API: Decibri (Capture)
-
-### `new Decibri(options?)`
-
-Creates a `Readable` stream that captures from the microphone.
-
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `sampleRate` | number | `16000` | Samples per second (1000 to 384000) |
-| `channels` | number | `1` | Input channels (1 to 32) |
-| `framesPerBuffer` | number | `1600` | Frames per chunk (64 to 65536). At 16kHz mono, 1600 = 100ms = 3200 bytes |
-| `device` | number \| string | system default | Device index or case-insensitive name substring |
-| `format` | `'int16'` \| `'float32'` | `'int16'` | Sample encoding |
-| `vad` | boolean | `false` | Enable voice activity detection |
-| `vadMode` | `'energy'` \| `'silero'` | `'energy'` | VAD engine: RMS threshold or Silero ML model |
-| `vadThreshold` | number | `0.01` / `0.5` | Speech threshold. Default depends on vadMode |
-| `vadHoldoff` | number | `300` | Silence holdoff in ms |
-
-Standard `ReadableOptions` (e.g. `highWaterMark`) are also accepted.
-
-### Methods
-
-| Method | Description |
-| --- | --- |
-| `mic.stop()` | Stop capture and end stream. Safe to call multiple times |
-| `Decibri.devices()` | List available input devices |
-| `Decibri.version()` | Version info: `{ decibri: '3.x.y', portaudio: 'cpal 0.17' }` |
-
-### Properties
-
-| Property | Type | Description |
+| Flag | Default | Purpose |
 | --- | --- | --- |
-| `mic.isOpen` | boolean | `true` while capturing |
+| `capture` | on | Microphone input stream support |
+| `output` | on | Speaker output stream support |
+| `vad` | on | Silero VAD ONNX inference |
+| `denoise` | on | Reserved (stub) |
+| `gain` | on | Reserved (stub) |
+| `ort-load-dynamic` | on | ORT loaded at runtime from a user-supplied path |
+| `ort-download-binaries` | off | ORT downloaded at build time and embedded in the binary |
 
-### Events
+`ort-load-dynamic` and `ort-download-binaries` are mutually exclusive; selecting both is a compile error.
 
-| Event | Payload | Description |
-| --- | --- | --- |
-| `'data'` | `Buffer` | Audio chunk (Int16 LE or Float32 LE) |
-| `'backpressure'` | (none) | Internal buffer full, consumer too slow |
-| `'speech'` | (none) | VAD: audio crosses threshold |
-| `'silence'` | (none) | VAD: audio below threshold for `vadHoldoff` ms |
-| `'end'` | (none) | Stream ended |
-| `'error'` | `Error` | An error occurred |
+Execution-provider passthrough features (off by default; opt in for GPU acceleration on specific platforms): `coreml`, `cuda`, `directml`, `rocm`. See [docs/features.md](https://github.com/decibri/decibri/blob/main/docs/features.md) for the full reference.
 
-## API: DecibriOutput (Playback)
+### Common configurations
 
-### `new DecibriOutput(options?)`
+**Zero-config builds** (ORT downloaded at `cargo build`, embedded):
 
-Creates a `Writable` stream for speaker playback.
-
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `sampleRate` | number | `16000` | Playback sample rate (1000 to 384000) |
-| `channels` | number | `1` | Output channels (1 to 32) |
-| `format` | `'int16'` \| `'float32'` | `'int16'` | Sample encoding of incoming data |
-| `device` | number \| string | system default | Output device index or name substring |
-
-Standard `WritableOptions` (e.g. `highWaterMark`) are also accepted.
-
-| Method / Property | Description |
-| --- | --- |
-| `speaker.write(chunk)` | Write PCM data for playback |
-| `speaker.end()` | Signal end. Drains remaining audio, then emits `'finish'` |
-| `speaker.stop()` | Immediate stop. Discards remaining audio |
-| `speaker.isPlaying` | `true` while audio is being output |
-| `DecibriOutput.devices()` | List available output devices |
-| `DecibriOutput.version()` | Same as `Decibri.version()` |
-
-## API: Browser
-
-The browser API uses `getUserMedia` and `AudioWorklet`. It differs from the Node.js API because browser audio is fundamentally async.
-
-### `new Decibri(options?)`
-
-Same options as Node.js, plus:
-
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `device` | string | system default | Device ID from `Decibri.devices()` (not index) |
-| `echoCancellation` | boolean | `true` | Browser echo cancellation |
-| `noiseSuppression` | boolean | `true` | Browser noise suppression |
-| `workletUrl` | string | inline blob | Custom worklet URL for strict CSP |
-
-### Key differences from Node.js
-
-| Aspect | Node.js | Browser |
-| --- | --- | --- |
-| Start | Automatic on first read | `await mic.start()` |
-| Base class | `Readable` stream | Custom `Emitter` |
-| Data type | `Buffer` | `Int16Array` / `Float32Array` |
-| `devices()` | Sync, returns array | Async, returns `Promise` |
-| Sample rate | Direct | Resampled from native rate |
-
-## Voice Activity Detection
-
-Decibri ships two VAD modes:
-
-- **Energy mode** (default): lightweight RMS energy threshold. No model required.
-- **Silero mode**: ML-based detection using the Silero VAD v5 ONNX model. More accurate, especially in noisy environments. The model (~2.3 MB) ships inside the npm package; no downloads or API keys required.
-
-```javascript
-// Energy mode
-const mic = new Decibri({ vad: true, vadThreshold: 0.01 });
-mic.on('speech', () => console.log('speaking'));
-mic.on('silence', () => console.log('silent'));
-
-// Silero mode
-const mic = new Decibri({ vad: true, vadMode: 'silero', vadThreshold: 0.5 });
-mic.on('speech', () => console.log('speaking'));
-mic.on('silence', () => console.log('silent'));
+```toml
+decibri = { version = "3", features = ["ort-download-binaries"], default-features = false }
 ```
 
-The same VAD modes are available in Decibri's Python and Rust bindings.
+Add back the other features you want (`capture`, `output`, `vad`, `denoise`, `gain`).
 
-## Device Selection
+**Production deployments with bundled ORT** (default; ORT loaded at runtime from a path you control):
 
-```javascript
-// System default
-const mic = new Decibri();
-
-// By name (case-insensitive substring match)
-const mic = new Decibri({ device: 'USB' });
-
-// By index
-const devices = Decibri.devices();
-const mic = new Decibri({ device: devices[1].index });
+```toml
+decibri = "3"
 ```
 
-```javascript
-Decibri.devices();
-// [
-//   { index: 0, name: 'Microphone', maxInputChannels: 2, defaultSampleRate: 48000, isDefault: true },
-//   { index: 1, name: 'USB Headset', maxInputChannels: 1, defaultSampleRate: 44100, isDefault: false }
-// ]
+Then either set `ORT_DYLIB_PATH=/path/to/libonnxruntime.{so,dylib,dll}` before first use, or call `ort::init_from(path).commit()` at startup. ORT initializes exactly once per process; the first successful path wins and later constructions silently reuse it.
+
+**Capture and output without VAD** (no `ort` dependency at all):
+
+```toml
+decibri = { version = "3", features = ["capture", "output"], default-features = false }
 ```
 
-## Examples
+## ONNX Runtime configuration
 
-Runnable Node.js examples are in the [examples](https://github.com/decibri/decibri/tree/main/examples) directory of the repo.
+Under `ort-load-dynamic` (default), the `ort` crate locates the ONNX Runtime shared library at runtime via either a `VadConfig::ort_library_path`, the `ORT_DYLIB_PATH` environment variable, or a process-wide `ort::init_from(...).commit()` call. Decibri performs a filesystem-level path check before handing the path to `ort::init_from`, so a missing or wrong-arch dylib surfaces as `DecibriError::OrtPathInvalid` rather than hanging on dynamic load.
 
-Capture to WAV file (no dependencies):
+See the [ort crate linking docs](https://ort.pyke.io/setup/linking) for the full runtime-loading reference.
 
-```bash
-node examples/wav-capture.js
-```
+### Fork safety (Linux)
 
-Stream to WebSocket (requires `npm install ws`):
+ORT initialized in a parent process does not survive `fork()` cleanly: internal threads, memory pools, and device handles belonging to the parent may misbehave in the child. Decibri detects this at the start of every VAD inference call and returns `DecibriError::ForkAfterOrtInit` when the calling process ID does not match the process ID that initialized ORT.
 
-```bash
-# Terminal 1
-node examples/websocket-server.js
+## Public API surface
 
-# Terminal 2
-node examples/websocket-stream.js
-```
+The 3.x stable surface includes:
 
-## Integrations
+- **Capture**: `AudioCapture`, `CaptureConfig`, `CaptureStream`
+- **Output**: `AudioOutput`, `OutputConfig`, `OutputStream`
+- **VAD**: `SileroVad`, `VadConfig`, `VadResult`
+- **Device**: enumeration and selection helpers (by index, case-insensitive name substring, or stable per-host ID)
+- **Errors**: `DecibriError` (`#[non_exhaustive]` enum covering capture, output, device, ORT, and fork-detection variants)
 
-Decibri's capture output and playback input pipe directly into cloud and local STT/TTS services. Integration guides at [decibri.com/docs/integrations](https://decibri.com/docs/integrations) cover:
+The `OnnxSession` trait abstracting ONNX Runtime is `pub(crate)` in 3.x and graduates to public at the planned 4.0 / `decibri-onnx` workspace split.
 
-| Provider | Environment | Guide |
-| --- | --- | --- |
-| OpenAI Realtime | Cloud | [Guide](https://decibri.com/docs/node/integrations/openai-realtime) |
-| Deepgram | Cloud | [Guide](https://decibri.com/docs/node/integrations/deepgram) |
-| AssemblyAI | Cloud | [Guide](https://decibri.com/docs/node/integrations/assemblyai) |
-| Mistral Voxtral | Cloud | [Guide](https://decibri.com/docs/node/integrations/mistral-voxtral) |
-| AWS Transcribe | Cloud | [Guide](https://decibri.com/docs/node/integrations/aws-transcribe) |
-| Google Speech-to-Text | Cloud | [Guide](https://decibri.com/docs/node/integrations/google-speech) |
-| Azure Speech-to-Text | Cloud | [Guide](https://decibri.com/docs/node/integrations/azure-speech) |
-| Sherpa-ONNX | Local | [Guide](https://decibri.com/docs/node/integrations/sherpa-onnx-stt) |
-| Whisper.cpp | Local | [Guide](https://decibri.com/docs/node/integrations/whisper-cpp) |
+Full API reference: [docs.rs/decibri](https://docs.rs/decibri/).
+
+## Thread safety
+
+All public types are `Send` and suitable for cross-thread handoff. `CaptureStream` and `OutputStream` are `!Sync` because they hold a `cpal::Stream` internally; wrap them in a mutex or move them into a dedicated thread for shared access.
 
 ## Platform Support
 
@@ -241,22 +143,18 @@ Decibri's capture output and playback input pipe directly into cloud and local S
 | macOS | arm64 (Apple Silicon) | CoreAudio |
 | Linux | x64 (gnu) | ALSA |
 | Linux | arm64 (gnu) | ALSA |
-| Browser | n/a | Web Audio API (AudioWorklet) |
 
-Pre-built native binaries ship via per-platform optional dependencies. The browser entry point is pure JavaScript and requires no native binary.
-
-## How It Works
-
-Decibri is built on a single Rust core. Audio flows from the OS audio device through the engine, through frame-exact buffering (which guarantees consistent chunk sizes), and into Node.js as a standard `Readable` stream. Browser support uses a JavaScript AudioWorklet implementation with the same event-driven API.
-
-The same audio engine is also published to [crates.io](https://crates.io/crates/decibri) for direct Rust consumers and to [PyPI](https://pypi.org/project/decibri/) for Python consumers.
+Source builds work on additional targets (Intel macOS, Windows arm64, musl Linux) but are not part of the binary release matrix.
 
 ## Cross-references
 
 - Main Project Readme: [here](https://github.com/decibri/decibri)
 - Python: [here](https://github.com/decibri/decibri/blob/main/bindings/python/README.md)
-- Rust: [here](https://github.com/decibri/decibri/blob/main/crates/decibri/README.md) (full API at [docs.rs/decibri](https://docs.rs/decibri/))
+- Node.js and browser: [here](https://github.com/decibri/decibri/blob/main/npm/decibri/README.md)
+- Full Rust API: [docs.rs/decibri](https://docs.rs/decibri/)
+- Feature flag reference: [docs/features.md](https://github.com/decibri/decibri/blob/main/docs/features.md)
 - CHANGELOG: [here](https://github.com/decibri/decibri/blob/main/CHANGELOG.md)
+- ORT linking docs: [ort.pyke.io/setup/linking](https://ort.pyke.io/setup/linking)
 
 ## License
 

--- a/npm/decibri/README.md
+++ b/npm/decibri/README.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable MD024 -->
 
-# decibri
+# Decibri
 
 Cross-platform audio capture, playback, and voice activity detection for Node.js applications and modern browsers.
 

--- a/npm/decibri/README.md
+++ b/npm/decibri/README.md
@@ -1,0 +1,264 @@
+<!-- markdownlint-disable MD024 -->
+
+# decibri (Node.js and browsers)
+
+Cross-platform audio capture, playback, and voice activity detection for Node.js applications and modern browsers.
+
+[![npm version](https://img.shields.io/npm/v/decibri)](https://www.npmjs.com/package/decibri)
+[![npm downloads](https://img.shields.io/npm/dm/decibri)](https://www.npmjs.com/package/decibri)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/decibri/decibri/blob/main/LICENSE)
+
+This is the Node.js and browser binding of decibri. The same Rust core powers decibri's Python wheel and Rust crate; see the [main README](https://github.com/decibri/decibri) for the polyglot project context.
+
+## Installation
+
+```bash
+npm install decibri
+```
+
+One package serves both Node.js and browsers via conditional exports. Node.js gets a native addon (Rust via [napi-rs](https://napi.rs/)). Browsers get a JavaScript [AudioWorklet](https://developer.mozilla.org/en-US/docs/Web/API/AudioWorklet) implementation. Platform-specific binaries are installed automatically through optional dependencies.
+
+Requires Node.js >= 18 for Node.js consumers. TypeScript definitions are bundled.
+
+## Quick Start
+
+### Capture audio (Node.js)
+
+```javascript
+const Decibri = require('decibri');
+
+const mic = new Decibri({ sampleRate: 16000, channels: 1 });
+mic.on('data', (chunk) => { /* Buffer of Int16 PCM samples */ });
+setTimeout(() => mic.stop(), 5000);
+```
+
+### Play audio (Node.js)
+
+```javascript
+const { DecibriOutput } = require('decibri');
+
+const speaker = new DecibriOutput({ sampleRate: 16000, channels: 1 });
+speaker.write(pcmBuffer);
+speaker.end();
+```
+
+### Browser capture
+
+```javascript
+import { Decibri } from 'decibri'; // browser entry via conditional export
+
+const mic = new Decibri({ sampleRate: 16000 });
+mic.on('data', (chunk) => { /* Int16Array of PCM samples */ });
+await mic.start(); // requires user gesture in Safari
+```
+
+### Pipe capture to playback (echo)
+
+```javascript
+const mic = new Decibri({ sampleRate: 16000, channels: 1 });
+const speaker = new DecibriOutput({ sampleRate: 16000, channels: 1 });
+mic.pipe(speaker);
+```
+
+## API: Decibri (Capture)
+
+### `new Decibri(options?)`
+
+Creates a `Readable` stream that captures from the microphone.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `sampleRate` | number | `16000` | Samples per second (1000 to 384000) |
+| `channels` | number | `1` | Input channels (1 to 32) |
+| `framesPerBuffer` | number | `1600` | Frames per chunk (64 to 65536). At 16kHz mono, 1600 = 100ms = 3200 bytes |
+| `device` | number \| string | system default | Device index or case-insensitive name substring |
+| `format` | `'int16'` \| `'float32'` | `'int16'` | Sample encoding |
+| `vad` | boolean | `false` | Enable voice activity detection |
+| `vadMode` | `'energy'` \| `'silero'` | `'energy'` | VAD engine: RMS threshold or Silero ML model |
+| `vadThreshold` | number | `0.01` / `0.5` | Speech threshold. Default depends on vadMode |
+| `vadHoldoff` | number | `300` | Silence holdoff in ms |
+
+Standard `ReadableOptions` (e.g. `highWaterMark`) are also accepted.
+
+### Methods
+
+| Method | Description |
+| --- | --- |
+| `mic.stop()` | Stop capture and end stream. Safe to call multiple times |
+| `Decibri.devices()` | List available input devices |
+| `Decibri.version()` | Version info: `{ decibri: '3.x.y', portaudio: 'cpal 0.17' }` |
+
+### Properties
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `mic.isOpen` | boolean | `true` while capturing |
+
+### Events
+
+| Event | Payload | Description |
+| --- | --- | --- |
+| `'data'` | `Buffer` | Audio chunk (Int16 LE or Float32 LE) |
+| `'backpressure'` | (none) | Internal buffer full, consumer too slow |
+| `'speech'` | (none) | VAD: audio crosses threshold |
+| `'silence'` | (none) | VAD: audio below threshold for `vadHoldoff` ms |
+| `'end'` | (none) | Stream ended |
+| `'error'` | `Error` | An error occurred |
+
+## API: DecibriOutput (Playback)
+
+### `new DecibriOutput(options?)`
+
+Creates a `Writable` stream for speaker playback.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `sampleRate` | number | `16000` | Playback sample rate (1000 to 384000) |
+| `channels` | number | `1` | Output channels (1 to 32) |
+| `format` | `'int16'` \| `'float32'` | `'int16'` | Sample encoding of incoming data |
+| `device` | number \| string | system default | Output device index or name substring |
+
+Standard `WritableOptions` (e.g. `highWaterMark`) are also accepted.
+
+| Method / Property | Description |
+| --- | --- |
+| `speaker.write(chunk)` | Write PCM data for playback |
+| `speaker.end()` | Signal end. Drains remaining audio, then emits `'finish'` |
+| `speaker.stop()` | Immediate stop. Discards remaining audio |
+| `speaker.isPlaying` | `true` while audio is being output |
+| `DecibriOutput.devices()` | List available output devices |
+| `DecibriOutput.version()` | Same as `Decibri.version()` |
+
+## Browser API
+
+The browser API uses `getUserMedia` and `AudioWorklet`. It differs from the Node.js API because browser audio is fundamentally async.
+
+### `new Decibri(options?)`
+
+Same options as Node.js, plus:
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `device` | string | system default | Device ID from `Decibri.devices()` (not index) |
+| `echoCancellation` | boolean | `true` | Browser echo cancellation |
+| `noiseSuppression` | boolean | `true` | Browser noise suppression |
+| `workletUrl` | string | inline blob | Custom worklet URL for strict CSP |
+
+### Key differences from Node.js
+
+| Aspect | Node.js | Browser |
+| --- | --- | --- |
+| Start | Automatic on first read | `await mic.start()` |
+| Base class | `Readable` stream | Custom `Emitter` |
+| Data type | `Buffer` | `Int16Array` / `Float32Array` |
+| `devices()` | Sync, returns array | Async, returns `Promise` |
+| Sample rate | Direct via cpal | Resampled from native rate |
+
+## Voice Activity Detection
+
+### Energy mode (default)
+
+Lightweight RMS energy threshold. No model required.
+
+```javascript
+const mic = new Decibri({ vad: true, vadThreshold: 0.01 });
+mic.on('speech', () => console.log('speaking'));
+mic.on('silence', () => console.log('silent'));
+```
+
+### Silero mode
+
+ML-based detection using the Silero VAD v5 ONNX model. More accurate than energy mode, especially in noisy environments.
+
+```javascript
+const mic = new Decibri({ vad: true, vadMode: 'silero', vadThreshold: 0.5 });
+mic.on('speech', () => console.log('speaking'));
+mic.on('silence', () => console.log('silent'));
+```
+
+The Silero model (~2.3 MB) ships inside the npm package. No downloads or API keys required.
+
+## Device Selection
+
+```javascript
+// System default
+const mic = new Decibri();
+
+// By name (case-insensitive substring match)
+const mic = new Decibri({ device: 'USB' });
+
+// By index
+const devices = Decibri.devices();
+const mic = new Decibri({ device: devices[1].index });
+```
+
+```javascript
+Decibri.devices();
+// [
+//   { index: 0, name: 'Microphone', maxInputChannels: 2, defaultSampleRate: 48000, isDefault: true },
+//   { index: 1, name: 'USB Headset', maxInputChannels: 1, defaultSampleRate: 44100, isDefault: false }
+// ]
+```
+
+## Examples
+
+Runnable Node.js examples are in the [`examples/`](https://github.com/decibri/decibri/tree/main/examples) directory of the repo.
+
+```bash
+# Capture to WAV file (no dependencies)
+node examples/wav-capture.js
+
+# Stream to WebSocket (requires: npm install ws)
+node examples/websocket-server.js   # terminal 1
+node examples/websocket-stream.js   # terminal 2
+```
+
+## Integrations
+
+decibri's capture output and playback input can pipe directly into cloud and local STT/TTS services. Integration guides at [decibri.com/docs/integrations](https://decibri.com/docs/integrations) cover:
+
+| Provider | Type | Guide |
+| --- | --- | --- |
+| OpenAI Realtime | cloud | [decibri.com/docs/node/integrations/openai-realtime](https://decibri.com/docs/node/integrations/openai-realtime) |
+| Deepgram | cloud | [decibri.com/docs/node/integrations/deepgram](https://decibri.com/docs/node/integrations/deepgram) |
+| AssemblyAI | cloud | [decibri.com/docs/node/integrations/assemblyai](https://decibri.com/docs/node/integrations/assemblyai) |
+| Mistral Voxtral | cloud | [decibri.com/docs/node/integrations/mistral-voxtral](https://decibri.com/docs/node/integrations/mistral-voxtral) |
+| AWS Transcribe | cloud | [decibri.com/docs/node/integrations/aws-transcribe](https://decibri.com/docs/node/integrations/aws-transcribe) |
+| Google Speech-to-Text | cloud | [decibri.com/docs/node/integrations/google-speech](https://decibri.com/docs/node/integrations/google-speech) |
+| Azure Speech-to-Text | cloud | [decibri.com/docs/node/integrations/azure-speech](https://decibri.com/docs/node/integrations/azure-speech) |
+| Sherpa-ONNX | local | [decibri.com/docs/node/integrations/sherpa-onnx-stt](https://decibri.com/docs/node/integrations/sherpa-onnx-stt) |
+| Whisper.cpp | local | [decibri.com/docs/node/integrations/whisper-cpp](https://decibri.com/docs/node/integrations/whisper-cpp) |
+
+## Platform Support
+
+| Platform | Architecture | Audio Backend |
+| --- | --- | --- |
+| Windows | x64 | WASAPI |
+| macOS | arm64 (Apple Silicon) | CoreAudio |
+| Linux | x64 (gnu) | ALSA |
+| Linux | arm64 (gnu) | ALSA |
+| Browser | n/a | Web Audio API (AudioWorklet) |
+
+Pre-built native binaries ship via per-platform optional dependencies (`@decibri/decibri-win32-x64-msvc`, `@decibri/decibri-darwin-arm64`, `@decibri/decibri-linux-x64-gnu`, `@decibri/decibri-linux-arm64-gnu`). The browser entry point is pure JavaScript and requires no native binary.
+
+## How It Works
+
+decibri is a Rust library using [cpal](https://github.com/RustAudio/cpal) for cross-platform audio I/O. The Rust core compiles to a Node.js native addon via [napi-rs](https://napi.rs/) and ships pre-built binaries for each platform. Browser support uses a JavaScript AudioWorklet implementation with the same event-driven API.
+
+Audio flows from the OS audio device through cpal's callback, into a [crossbeam-channel](https://github.com/crossbeam-rs/crossbeam), through frame-exact buffering (guarantees consistent chunk sizes), and into Node.js via a threadsafe function. The JavaScript layer wraps this in a standard `Readable` stream.
+
+The same Rust core is also published to [crates.io](https://crates.io/crates/decibri) for direct Rust consumers and to [PyPI](https://pypi.org/project/decibri/) (via PyO3) for Python consumers.
+
+## Cross-references
+
+- **Polyglot project context**: [github.com/decibri/decibri](https://github.com/decibri/decibri)
+- **Python wheel**: [bindings/python/README.md](https://github.com/decibri/decibri/blob/main/bindings/python/README.md)
+- **Rust crate**: [crates/decibri/README.md](https://github.com/decibri/decibri/blob/main/crates/decibri/README.md) and [docs.rs/decibri](https://docs.rs/decibri/)
+- **CHANGELOG**: [CHANGELOG.md](https://github.com/decibri/decibri/blob/main/CHANGELOG.md)
+- **TypeScript types**: bundled in the npm package; types entry is `src/decibri.d.ts`
+
+## License
+
+Apache-2.0. See [LICENSE](https://github.com/decibri/decibri/blob/main/LICENSE) for details.
+
+Copyright (c) 2026 Decibri.


### PR DESCRIPTION
- README.md: rewrite
- crates/decibri/README.md: new.
- crates/decibri/Cargo.toml:9: readme path fixed.
- npm/decibri/README.md: new.
- bindings/python/README.md: unchanged.