### PR TITLE
fix(ci): build-sdist via PyO3/maturin-action command:sdist (Fix C)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -352,17 +352,20 @@ jobs:
           retention-days: 7
 
   build-sdist:
-    # 0.1.3 addition. Source distribution job. The Bucket 3 research showed
-    # 5 of 5 cohort projects (pydantic-core, ruff, uv, tokenizers, polars)
-    # publish a .tar.gz sdist alongside binary wheels; decibri was the lone
-    # holdout. Cohort majority pattern, polars-style. Single platform
-    # (Linux) because sdist is platform-neutral text by definition; the
-    # tarball is identical regardless of build host.
+    # 0.1.3 addition. Source distribution job. Three of three sdist-shipping
+    # cohort projects (pydantic-core, polars, tokenizers) use
+    # PyO3/maturin-action with command: sdist; ruff ships wheels-only.
+    # decibri matches the cohort pattern and unifies the workflow on a
+    # single tool: maturin-action for both wheel (build-and-validate) and
+    # sdist (this job) builds. Single platform (Linux) because sdist is
+    # platform-neutral text by definition; the tarball is identical
+    # regardless of build host.
     #
-    # Source-build prerequisites for an sdist consumer: Rust toolchain
-    # (any recent stable), a C++ toolchain (cpal transitive dep on
-    # macOS / Linux), and an ORT dylib at runtime (the wheel bundles it;
-    # sdist users supply via ORT_DYLIB_PATH or install onnxruntime
+    # Source-build prerequisites for an sdist consumer (downstream from
+    # this job, not in this job's environment): Rust toolchain (any
+    # recent stable), a C++ toolchain (cpal transitive dep on macOS /
+    # Linux), and an ORT dylib at runtime (the wheel bundles it; sdist
+    # users supply via ORT_DYLIB_PATH or install onnxruntime
     # system-wide). The Silero VAD ONNX model is included in the sdist
     # via the existing pyproject.toml [tool.maturin] include directive
     # (format = ["sdist", "wheel"], pre-positioned in 0.1.0).
@@ -376,48 +379,39 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: "bindings/python/uv.lock"
-
-      - name: Install Python (3.10 floor)
-        run: uv python install 3.10
-
-      - name: Sync dev environment (locked, no editable build)
-        working-directory: bindings/python
-        # --no-editable suppresses uv's default editable install of the local
-        # decibri package. The sdist job only needs maturin + twine (dev
-        # dependencies); it does NOT need a built decibri wheel. Without this
-        # flag, uv sync invokes maturin.build_editable which compiles the Rust
-        # extension and requires libasound2-dev on Linux runners.
-        run: uv sync --dev --locked --no-editable
-
       - name: Build sdist
-        working-directory: bindings/python
-        shell: bash
-        # `maturin sdist` produces a Cargo-default tarball plus the files
-        # listed in [tool.maturin] include with format containing "sdist".
-        # Cleared output dir first so a stale rust-cache-restored .tar.gz
-        # cannot leak into the upload.
-        run: |
-          set -euo pipefail
-          rm -rf "${GITHUB_WORKSPACE}/target/wheels/"
-          uv run maturin sdist --out "${GITHUB_WORKSPACE}/target/wheels"
-          ls -la "${GITHUB_WORKSPACE}/target/wheels/"
+        # PyO3/maturin-action command: sdist produces a Cargo-default
+        # tarball plus the files listed in [tool.maturin] include with
+        # format containing "sdist". The action is sdist-aware: it does
+        # NOT trigger a Rust compile and does NOT require libasound2-dev
+        # on Linux runners (unlike a manual `uv sync + maturin sdist`
+        # combination, which always installs the local project and
+        # therefore always invokes maturin.build_wheel for the local
+        # decibri package). SHA pinned to match build-and-validate's
+        # maturin-action usage so a single cross-job bump is the only
+        # place the version lives.
+        uses: PyO3/maturin-action@3e2bdf6ba6453a61e649744019b8a2d906c7eb38 # v1.51.0
+        with:
+          command: sdist
+          args: --out ${{ github.workspace }}/target/wheels
+          working-directory: bindings/python
 
       - name: Validate sdist via twine check
-        working-directory: bindings/python
+        # twine check is a separate concern from maturin-action; it
+        # validates the produced tarball's PKG-INFO and structure
+        # before the publish gate. Installed via pip directly (no uv
+        # involved) since this job no longer maintains a uv-managed
+        # virtualenv.
         shell: bash
         run: |
           set -euo pipefail
-          uv pip install twine
+          pip install twine
           SDIST=$(ls "${GITHUB_WORKSPACE}/target/wheels/decibri-"*.tar.gz | head -1)
           if [ -z "$SDIST" ]; then
             echo "ERROR: no sdist found for twine check"
             exit 1
           fi
-          uv run twine check "$SDIST"
+          twine check "$SDIST"
 
       - name: Upload sdist artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -384,9 +384,14 @@ jobs:
       - name: Install Python (3.10 floor)
         run: uv python install 3.10
 
-      - name: Sync dev environment (locked)
+      - name: Sync dev environment (locked, no editable build)
         working-directory: bindings/python
-        run: uv sync --dev --locked
+        # --no-editable suppresses uv's default editable install of the local
+        # decibri package. The sdist job only needs maturin + twine (dev
+        # dependencies); it does NOT need a built decibri wheel. Without this
+        # flag, uv sync invokes maturin.build_editable which compiles the Rust
+        # extension and requires libasound2-dev on Linux runners.
+        run: uv sync --dev --locked --no-editable
 
       - name: Build sdist
         working-directory: bindings/python


### PR DESCRIPTION
- .github/workflows/publish-pypi.yml: replace raw uv sync + maturin sdist + twine tool chain with PyO3/maturin-action command:sdist matching the wheel-build job's existing maturin-action SHA pin (3e2bdf6...; v1.51.0). Fix B1 (--no-editable) and Fix B3 (--no-install-project) both addressed surface symptoms; the maturin-action pattern is the cohort standard (3 of 3 sdist-shipping cohort projects: pydantic-core, polars, tokenizers).
- Header comment block updated. The previous comment claimed "polars-style" but the implementation did not actually match polars. After this fix the workflow matches the cohort pattern and matches decibri's own build-and-validate job (which already uses maturin-action).
- Removed: setup-uv, install Python, sync dev environment, manual maturin sdist invocation. The action handles Python toolchain, maturin install, and sdist production internally.
- twine check kept as a separate step (twine is not part of maturin-action). Installed via plain pip; no uv layer.