### PR TITLE
docs: revise package documentation and normalize changelog formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,15 +20,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- **`OnnxSession` trait abstraction in Rust core** (Phase 8). New internal `pub(crate) trait OnnxSession` inside `crates/decibri/src/onnx.rs` abstracting ONNX Runtime usage behind a backend-agnostic interface. `SileroVad` migrates to consume the trait through `Box<dyn OnnxSession>`. ORT-backed implementation is the only impl in 3.x; future backends (CoreML at iOS time, TFLite at Android time, GPU EPs at the P4 GPU project) plug in additively at the `decibri-onnx` workspace split planned for 4.0.
-- `DecibriError::OnnxBackendFailed { backend: &'static str, source: Box<dyn std::error::Error + Send + Sync> }` variant for future non-ORT backend errors. Additive (the enum is `#[non_exhaustive]`); existing 8 ORT variants unchanged. `is_ort_path_error` continues to return false on the new variant.
-- **`DecibriError::ForkAfterOrtInit { init_pid: u32, current_pid: u32 }` variant + runtime fork detection** (Phase 9 Item C7). Linux-only failure-mode hardening: a process that forks after a successful `SileroVad::new` previously inherited `static ORT_INIT` flagged as set while the underlying ORT runtime state (allocators, thread pools) was unsafe to reuse, producing silent wrong probabilities, segfaults, or hangs in the child. 3.4.0 stamps the initializing pid into a paired `static ORT_INIT_PID: OnceLock<u32>` inside the same `init_ort_once` success path; a `pub(crate) fn check_pid_for_ort()` runs at the entry of `SileroVad::process()` and returns `Err(ForkAfterOrtInit { init_pid, current_pid })` on pid mismatch. The `Display` message embeds both pids and the two remediation options ("Use `multiprocessing.set_start_method('spawn')` or construct `Microphone(vad='silero')` inside each child process"). Single-check coverage at the outer entry point applies to every inference call without per-window overhead. macOS and Windows are unaffected by fork semantics. Additive on the `#[non_exhaustive]` `DecibriError` enum; mapped through to npm via the napi `_ =>` catch-all (`Status::GenericFailure` carrying `e.to_string()`) and to Python via an explicit `ForkAfterOrtInit(DecibriError)` subclass in the wheel.
+- **`OnnxSession` trait abstraction in Rust core.** New internal `pub(crate) trait OnnxSession` inside `crates/decibri/src/onnx.rs` abstracts ONNX Runtime usage behind a backend-agnostic interface. `SileroVad` consumes the trait through `Box<dyn OnnxSession>`. The ORT-backed implementation is the only impl in 3.x.
+- `DecibriError::OnnxBackendFailed { backend: &'static str, source: Box<dyn std::error::Error + Send + Sync> }` variant. Reserved on the `#[non_exhaustive]` enum. Additive; existing 8 ORT variants unchanged. `is_ort_path_error` continues to return false on the new variant.
+- **`DecibriError::ForkAfterOrtInit { init_pid: u32, current_pid: u32 }` variant + runtime fork detection.** Linux-only failure-mode hardening: a process that forks after a successful `SileroVad::new` previously inherited `static ORT_INIT` flagged as set while the underlying ORT runtime state (allocators, thread pools) was unsafe to reuse, producing silent wrong probabilities, segfaults, or hangs in the child. 3.4.0 stamps the initializing pid into a paired `static ORT_INIT_PID: OnceLock<u32>` inside the same `init_ort_once` success path; a `pub(crate) fn check_pid_for_ort()` runs at the entry of `SileroVad::process()` and returns `Err(ForkAfterOrtInit { init_pid, current_pid })` on pid mismatch. The `Display` message embeds both pids and the two remediation options ("Use `multiprocessing.set_start_method('spawn')` or construct `Microphone(vad='silero')` inside each child process"). Single-check coverage at the outer entry point applies to every inference call without per-window overhead. macOS and Windows are unaffected by fork semantics. Additive on the `#[non_exhaustive]` `DecibriError` enum; mapped through to npm via the napi `_ =>` catch-all (`Status::GenericFailure` carrying `e.to_string()`) and to Python via an explicit `ForkAfterOrtInit(DecibriError)` subclass in the wheel.
 
 ### Internal
 
-- Phase 8 of the Python Integration Project. `crates/decibri` 3.x public API stays byte-identical (`SileroVad`, `VadConfig`, `VadResult`, `DecibriError` keep Phase 7.x signatures). npm, Python binding, browser shim are unchanged. See `~/.claude/plans/phase-8-onnxsession-trait.md` for the plan and `~/.claude/plans/phase-8-prep-research.md` for the empirical investigation that produced the trait shape.
+- `crates/decibri` 3.x public API stays byte-identical (`SileroVad`, `VadConfig`, `VadResult`, `DecibriError` keep their 3.3.x signatures). npm binding, Python binding, browser shim are unchanged.
 - `vad::init_ort_once` visibility raised from private to `pub(crate)` so the `onnx` module's inline ORT-backed test can reuse the same process-global init path that `vad` tests use.
-- Phase 9 Item C7 (continued): `static ORT_INIT_PID: OnceLock<u32>` paired with the existing `ORT_INIT`, set inside the `OnceLock::get_or_init` callback so the pid stamp is paired with the successful ORT init rather than a speculative pre-init value. `pub(crate) fn check_pid_for_ort()` exposes the comparison to inference call sites within the crate. Linux-only `test_fork_safety.py` tests in the Python wheel pin the behavior end-to-end (gated `skipif sys.platform != "linux"`); they run on CI's `ubuntu-latest` job and skip on other hosts.
+- `static ORT_INIT_PID: OnceLock<u32>` paired with the existing `ORT_INIT`, set inside the `OnceLock::get_or_init` callback so the pid stamp is paired with the successful ORT init rather than a speculative pre-init value. `pub(crate) fn check_pid_for_ort()` exposes the comparison to inference call sites within the crate. Linux-only `test_fork_safety.py` tests in the Python wheel pin the behavior end-to-end (gated `skipif sys.platform != "linux"`); they run on CI's `ubuntu-latest` job and skip on other hosts.
 
 ## [3.3.2] - 2026-04-26
 
@@ -60,136 +60,52 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Migration notes
 
-Error message wording on shipped `DecibriError` variants has historically been stable across the 3.x line. 3.3.1 explicitly refines five messages to remove audience-leak issues identified during P3 Phase 2 planning: Node-API-targeted camelCase parameter names, class-name hardcoding in `AlreadyRunning`, a Rust-internal type reference (`VadConfig`) in `OrtInitFailed`, npm-internal phrasing ("platform package") in `OrtLoadFailed` / `OrtPathInvalid`, and macOS-only platform guidance in `PermissionDenied`. Future releases re-establish wording stability; 3.3.1 is the consolidation point.
+Error message wording on shipped `DecibriError` variants has historically been stable across the 3.x line. 3.3.1 explicitly refines five messages to remove audience-leak issues: Node-API-targeted camelCase parameter names, class-name hardcoding in `AlreadyRunning`, a Rust-internal type reference (`VadConfig`) in `OrtInitFailed`, npm-internal phrasing ("platform package") in `OrtLoadFailed` / `OrtPathInvalid`, and macOS-only platform guidance in `PermissionDenied`. 3.3.1 is the consolidation point.
 
 - **Direct Rust crate consumers** asserting on `DecibriError::Display` strings should update assertions for the five refined messages. Type-level matching on `DecibriError` variants is unaffected; only string-text assertions need updating.
 - **Node consumers** using `e.message.includes(prefix)` or `e.message.startsWith(prefix)` patterns should update for `sampleRate` -> `sample rate`, `framesPerBuffer` -> `frames per buffer`, and the `AlreadyRunning` message text. Type-level matching on `RangeError` / `TypeError` is unaffected.
-- **Python consumers**: P3 Phase 2's first wheel (still pre-release) consumes `decibri@3.3.1`, so the messages it sees are the corrected forms from day one. No migration needed (Phase 1 wheel was scaffold-only with no error message surface).
+- **Python consumers**: the in-development Python wheel consumes `decibri@3.3.1`, so the messages it sees are the corrected forms.
 
 ## [3.3.0] - 2026-04-23
 
-Groundwork release for upcoming P3 Python bindings. Adds a stable-ID form
-for audio device selection (`DeviceSelector::Id`), fixes a long-standing
-direction bug in `DecibriError::DeviceNotFound` when resolving output
-devices, exposes both in the Node binding, and extends the reference
-documentation with a Cargo feature flag guide plus additional crate-level
-rustdoc. No Node.js or browser API break. Direct Rust crate consumers
-pattern-matching on `DeviceSelector` or struct-literal-constructing
-`DeviceInfo` / `OutputDeviceInfo` need to update for the new
-`#[non_exhaustive]` attributes (see Migration notes below).
+Groundwork release for upcoming P3 Python bindings. Adds a stable-ID form for audio device selection (`DeviceSelector::Id`), fixes a long-standing direction bug in `DecibriError::DeviceNotFound` when resolving output devices, exposes both in the Node binding, and extends the reference documentation with a Cargo feature flag guide plus additional crate-level rustdoc. No Node.js or browser API break. Direct Rust crate consumers pattern-matching on `DeviceSelector` or struct-literal-constructing `DeviceInfo` / `OutputDeviceInfo` need to update for the new `#[non_exhaustive]` attributes (see Migration notes below).
 
 ### Changed
 
-- `DeviceSelector`, `DeviceInfo`, and `OutputDeviceInfo` are now
-  `#[non_exhaustive]`. External Rust consumers pattern-matching on
-  `DeviceSelector` must add a `_ =>` catch-all arm; consumers
-  constructing `DeviceInfo` or `OutputDeviceInfo` via struct literal
-  from outside the crate must switch to reading fields off instances
-  returned by `enumerate_input_devices` / `enumerate_output_devices`.
-  Field names and display strings are unchanged. This future-proofs
-  the API: subsequent variant or field additions are source-compatible
-  for consumers who include the catch-all.
+- `DeviceSelector`, `DeviceInfo`, and `OutputDeviceInfo` are now `#[non_exhaustive]`. External Rust consumers pattern-matching on `DeviceSelector` must add a `_ =>` catch-all arm; consumers constructing `DeviceInfo` or `OutputDeviceInfo` via struct literal from outside the crate must switch to reading fields off instances returned by `enumerate_input_devices` / `enumerate_output_devices`. Field names and display strings are unchanged. This future-proofs the API: subsequent variant or field additions are source-compatible for consumers who include the catch-all.
 
 ### Added
 
-- `DeviceSelector::Id(String)` for selecting audio devices by stable
-  per-host identifier (WASAPI endpoint ID on Windows, CoreAudio UID on
-  macOS, ALSA pcm_id on Linux). Unlike `DeviceSelector::Name`
-  (case-insensitive substring) and `DeviceSelector::Index` (positional),
-  `Id` survives across enumerations: display names can shift when other
-  devices are plugged in but per-host IDs do not.
-- `id: String` field on `DeviceInfo` and `OutputDeviceInfo`, populated
-  from `cpal::DeviceId`'s `Display` output. Empty string if cpal cannot
-  produce a stable ID for a given device (rare; some host backends
-  cannot assign IDs to every enumerated device). Obtain the ID from
-  these fields and pass to `DeviceSelector::Id`.
-- `DecibriError::OutputDeviceNotFound(String)` variant, the output-device
-  equivalent of `DeviceNotFound`. See Fixed below for the motivating
-  bug.
-- Node binding accepts `device: { id: string }` as a third form
-  alongside `device: <number>` (index) and `device: <string>` (name
-  substring). The JS wrapper passes it through to Rust unchanged; Rust
-  resolves via cpal's `DeviceId`.
-- `DeviceInfoJs.id` and `OutputDeviceInfoJs.id` fields on the Node
-  binding types, mirroring the Rust `DeviceInfo.id` / `OutputDeviceInfo.id`
-  additions. Visible in the auto-regenerated `npm/decibri/index.d.ts`
-  and in the hand-authored `npm/decibri/src/decibri.d.ts`.
-- `npm/decibri/src/errors.js` helper that re-wraps plain `Error`
-  instances thrown from the native boundary as `TypeError` or
-  `RangeError`, matching the JS wrapper's existing validation error
-  classes. Brought in by `decibri.js` and `decibri-output.js`
-  constructors to align Rust-originated errors with the JS wrapper's
-  error class contract. Triggered only by code paths that reach Rust's
-  `to_napi_error` (currently only `device: { id: ... }` selection); all
-  other validation paths continue to throw from the JS wrapper directly
-  with no behavior change.
-- `docs/features.md`: comprehensive Cargo feature reference covering
-  ORT distribution mode tradeoffs, execution-provider features,
-  binding-author guidance, and feature compatibility constraints.
-  Targeted at Rust crate consumers and FFI binding authors; lib.rs
-  rustdoc now links to it for deep-dive reference.
+- `DeviceSelector::Id(String)` for selecting audio devices by stable per-host identifier (WASAPI endpoint ID on Windows, CoreAudio UID on macOS, ALSA pcm_id on Linux). Unlike `DeviceSelector::Name` (case-insensitive substring) and `DeviceSelector::Index` (positional), `Id` survives across enumerations: display names can shift when other devices are plugged in but per-host IDs do not.
+- `id: String` field on `DeviceInfo` and `OutputDeviceInfo`, populated from `cpal::DeviceId`'s `Display` output. Empty string if cpal cannot produce a stable ID for a given device (rare; some host backends cannot assign IDs to every enumerated device). Obtain the ID from these fields and pass to `DeviceSelector::Id`.
+- `DecibriError::OutputDeviceNotFound(String)` variant, the output-device equivalent of `DeviceNotFound`. See Fixed below for the motivating bug.
+- Node binding accepts `device: { id: string }` as a third form alongside `device: <number>` (index) and `device: <string>` (name substring). The JS wrapper passes it through to Rust unchanged; Rust resolves via cpal's `DeviceId`.
+- `DeviceInfoJs.id` and `OutputDeviceInfoJs.id` fields on the Node binding types, mirroring the Rust `DeviceInfo.id` / `OutputDeviceInfo.id` additions. Visible in the auto-regenerated `npm/decibri/index.d.ts` and in the hand-authored `npm/decibri/src/decibri.d.ts`.
+- `npm/decibri/src/errors.js` helper that re-wraps plain `Error` instances thrown from the native boundary as `TypeError` or `RangeError`, matching the JS wrapper's existing validation error classes. Brought in by `decibri.js` and `decibri-output.js` constructors to align Rust-originated errors with the JS wrapper's error class contract. Triggered only by code paths that reach Rust's `to_napi_error` (currently only `device: { id: ... }` selection); all other validation paths continue to throw from the JS wrapper directly with no behavior change.
+- `docs/features.md`: comprehensive Cargo feature reference covering ORT distribution mode tradeoffs, execution-provider features, binding-author guidance, and feature compatibility constraints. Targeted at Rust crate consumers and FFI binding authors; lib.rs rustdoc now links to it for deep-dive reference.
 
 ### Fixed
 
-- `DecibriError::DeviceNotFound`'s display string hardcoded
-  "No audio input device found matching..." regardless of whether
-  the lookup was against input or output devices. Direct Rust
-  consumers and the new `device: { id: ... }` Node path now receive
-  the correct direction via `DecibriError::OutputDeviceNotFound`
-  for output-device misses. No change visible through the Node
-  binding for existing name- and index-based lookups: those are
-  intercepted by the JS wrapper and always threw direction-correct
-  messages from JS before reaching Rust.
+- `DecibriError::DeviceNotFound`'s display string hardcoded "No audio input device found matching..." regardless of whether the lookup was against input or output devices. Direct Rust consumers and the new `device: { id: ... }` Node path now receive the correct direction via `DecibriError::OutputDeviceNotFound` for output-device misses. No change visible through the Node binding for existing name- and index-based lookups: those are intercepted by the JS wrapper and always threw direction-correct messages from JS before reaching Rust.
 
 ### Internal
 
-- `DeviceDirection` trait gains a `not_found_error(String) -> DecibriError`
-  method so `resolve_device_generic`'s `Name` and `Id` arms produce
-  direction-correct errors via the `Input` / `Output` impls.
-- Unit tests for `Arc<Mutex<CaptureStream>>` confirming the wrapping is
-  `Send + Sync` (compile-time assertion) and serializes concurrent
-  access across two threads (runtime test with `Barrier`). Documents
-  the wrapping strategy the P3 Python binding will apply to share
-  `!Sync` capture streams across Python threads.
-- Crate-level rustdoc additions in `lib.rs`: a section on ORT error
-  construction FFI side effects (the `ortsys![CreateStatus]` dylib-load
-  trigger that motivates the `OrtPathInvalid` split from
-  `OrtLoadFailed`) and a section on fork safety (guidance for Python
-  `multiprocessing` consumers to use `spawn` start method).
-- `lib.rs` rustdoc "Feature flags" section cross-references
-  `docs/features.md` for consumers wanting the deep-dive reference.
-- Em-dash cleanup across 19 code locations in `lib.rs`, `capture.rs`,
-  `output.rs`, `vad.rs`, `error.rs`, `vad_integration.rs`, and
-  `vad_ort_load_failure.rs`. Per CLAUDE.md, the codebase forbids em
-  dashes; these were pre-existing violations.
-- CLAUDE.md corrections: validation-gate commands updated to the
-  canonical set (`cargo clippy --workspace -- -D warnings`,
-  `cargo fmt --all -- --check`, `cargo test-decibri`); stale
-  `## [3.0.0] - Unreleased` reference replaced with a template
-  placeholder.
+- `DeviceDirection` trait gains a `not_found_error(String) -> DecibriError` method so `resolve_device_generic`'s `Name` and `Id` arms produce direction-correct errors via the `Input` / `Output` impls.
+- Unit tests for `Arc<Mutex<CaptureStream>>` confirming the wrapping is `Send + Sync` (compile-time assertion) and serializes concurrent access across two threads (runtime test with `Barrier`). Documents the wrapping strategy the P3 Python binding will apply to share `!Sync` capture streams across Python threads.
+- Crate-level rustdoc additions in `lib.rs`: a section on ORT error construction FFI side effects (the `ortsys![CreateStatus]` dylib-load trigger that motivates the `OrtPathInvalid` split from `OrtLoadFailed`) and a section on fork safety (guidance for Python `multiprocessing` consumers to use `spawn` start method).
+- `lib.rs` rustdoc "Feature flags" section cross-references `docs/features.md` for consumers wanting the deep-dive reference.
+- Em-dash cleanup across 19 code locations in `lib.rs`, `capture.rs`, `output.rs`, `vad.rs`, `error.rs`, `vad_integration.rs`, and `vad_ort_load_failure.rs`. Per CLAUDE.md, the codebase forbids em dashes; these were pre-existing violations.
+- CLAUDE.md corrections: validation-gate commands updated to the canonical set (`cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`, `cargo test-decibri`); stale `## [3.0.0] - Unreleased` reference replaced with a template placeholder.
 - `ort` crate version unchanged at `2.0.0-rc.12`.
 - Bundled ONNX Runtime version unchanged at `1.24.4`.
 - No Node.js API signatures, event names, or error messages changed.
-- TypeScript declaration files in both `npm/decibri/index.d.ts`
-  (auto-regenerated) and `npm/decibri/src/decibri.d.ts` (hand-authored)
-  updated for the new `id` field and extended `device` option type.
+- TypeScript declaration files in both `npm/decibri/index.d.ts` (auto-regenerated) and `npm/decibri/src/decibri.d.ts` (hand-authored) updated for the new `id` field and extended `device` option type.
 
 ### Migration notes for direct Rust crate consumers
 
-- Exhaustive matches on `DeviceSelector` will stop compiling. Add a
-  `_ =>` catch-all arm. Display strings and existing variant names
-  are unchanged; code using `to_string()` or only constructing variants
-  (not matching them) continues to work unaffected.
-- Struct literal construction of `DeviceInfo` and `OutputDeviceInfo`
-  from outside the `decibri` crate will stop compiling (added
-  `#[non_exhaustive]`, added `id: String` field). External consumers
-  should read these structs from `enumerate_input_devices()` /
-  `enumerate_output_devices()` rather than constructing them directly.
-- Consumers matching specifically on `DecibriError::DeviceNotFound`
-  for output-device misses should now also match
-  `DecibriError::OutputDeviceNotFound`. The convenience predicate
-  `DecibriError::is_ort_path_error` remains unchanged and already
-  groups only ORT-path variants.
+- Exhaustive matches on `DeviceSelector` will stop compiling. Add a `_ =>` catch-all arm. Display strings and existing variant names are unchanged; code using `to_string()` or only constructing variants (not matching them) continues to work unaffected.
+- Struct literal construction of `DeviceInfo` and `OutputDeviceInfo` from outside the `decibri` crate will stop compiling (added `#[non_exhaustive]`, added `id: String` field). External consumers should read these structs from `enumerate_input_devices()` / `enumerate_output_devices()` rather than constructing them directly.
+- Consumers matching specifically on `DecibriError::DeviceNotFound` for output-device misses should now also match `DecibriError::OutputDeviceNotFound`. The convenience predicate `DecibriError::is_ort_path_error` remains unchanged and already groups only ORT-path variants.
 - MSRV unchanged at rustc 1.88.
 
 ## [3.2.0] - 2026-04-22
@@ -316,8 +232,8 @@ the 38-assertion CI suite).
   semantics are identical.
 - docs.rs metadata added to target all 4 production platforms (Linux x64/ARM64,
   macOS ARM64, Windows x64) for full platform-specific rustdoc rendering.
-  Future-proofs against the docs.rs change effective 2026-05-01 (building
-  fewer targets by default).
+  Aligns with the docs.rs change effective 2026-05-01 (which builds fewer
+  targets by default).
 
 ## [3.1.0] - 2026-04-22
 
@@ -405,7 +321,7 @@ Complete rewrite from C++ (PortAudio) to Rust (cpal). One unified package for No
 
 - Complete rewrite from C++ (PortAudio) to Rust (cpal)
 - Native addon built with napi-rs (replaces node-gyp / prebuildify)
-- JS API unchanged: drop-in replacement for v1.x consumers (mcp-listen, voxagent, Wake Word verified)
+- JS API unchanged: drop-in replacement for v1.x consumers (verified against the in-house consumer surface)
 
 ### Added
 
@@ -442,4 +358,3 @@ Initial release. C++ native addon wrapping PortAudio with pre-built binaries.
 [3.2.0]: https://github.com/decibri/decibri/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/decibri/decibri/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/decibri/decibri/compare/v1.0.0...v3.0.0
-[1.0.0]: https://github.com/analyticsinmotion/decibri/releases/tag/v1.0.0

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -25,19 +25,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Python binding
 
-Patch release adding source distribution publication, property-based and soak/leak tests, and a shift-left of the abi3 compliance gate to PR-time CI. Mechanical version bump only on the version-handling surface; full single-source-of-truth consolidation deferred to the 4.0 platform decoupling release.
+Patch release adding source distribution publication, property-based and soak/leak tests, and a shift-left of the abi3 compliance gate to PR-time CI. Mechanical version bump only on the version-handling surface; full single-source-of-truth consolidation is out of scope for 0.1.x.
 
 #### Added
 
 - Source distribution (sdist) publication to PyPI alongside binary wheels. Users on platforms outside the 4-platform wheel matrix, security-conscious environments that require source builds, and consumers running `pip install --no-binary :all: decibri` now have an install path. The Silero VAD ONNX model is included in the sdist via the existing `[tool.maturin] include` directive (`format = ["sdist", "wheel"]`, pre-positioned in 0.1.0). Source-build prerequisites: Rust toolchain, a C++ toolchain (cpal transitive dep on macOS/Linux), and an ORT dylib at runtime (the wheel bundles ORT; sdist users supply via `ORT_DYLIB_PATH` or system-installed `onnxruntime`). Cohort majority pattern: pydantic-core, ruff, uv, tokenizers, polars all publish sdist; decibri was the lone holdout. New `build-sdist` job in `publish-pypi.yml` runs on Linux (sdist is platform-neutral), validates via `twine check`, and uploads alongside per-platform wheel artifacts. Both `publish-testpypi` and `publish-pypi` jobs depend on it and pull the sdist in their artifact glob.
-- Hypothesis property tests for `Microphone` constructor validation at `bindings/python/tests/test_microphone_properties.py`. Five tests covering `sample_rate`, `channels`, `frames_per_buffer`, `dtype`, and the positive valid-input path. Each test runs `max_examples=20` Hypothesis-generated cases against the existing typed-exception contract (`SampleRateOutOfRange`, `ChannelsOutOfRange`, `FramesPerBufferOutOfRange`, `InvalidFormat`). The property under test is "validation always lands on a typed decibri exception, never a panic / abort / untyped exception under fuzz". Total file runtime ~1.5 seconds. Tier 1 testing per `prerelease-decibri-additional-testing-reqs.md` Test 3.
-- Soak and leak detection tests at `bindings/python/tests/test_lifecycle_leak.py`. Three bounded loops (5-iteration warmup + 15-iteration measurement window) with `tracemalloc` (Python-side allocations) and `psutil` RSS sampling (native allocations under cpal / pyo3 / ort). Tests cover `Microphone`, `AsyncMicrophone`, and `Microphone(vad="silero")` construct/destroy cycles. Thresholds: 1 MB tracemalloc growth, 5 MB RSS growth (10 MB for the silero variant to absorb ORT allocator behavior). The silero test uses the `requires_bundled_ort` marker so it auto-skips on dev installs where `_ort/` is empty and runs in CI where the dylib is staged. Total combined runtime ~3 seconds locally. Tier 1 testing per `prerelease-decibri-additional-testing-reqs.md` Test 4.
+- Hypothesis property tests for `Microphone` constructor validation at `bindings/python/tests/test_microphone_properties.py`. Five tests covering `sample_rate`, `channels`, `frames_per_buffer`, `dtype`, and the positive valid-input path. Each test runs `max_examples=20` Hypothesis-generated cases against the existing typed-exception contract (`SampleRateOutOfRange`, `ChannelsOutOfRange`, `FramesPerBufferOutOfRange`, `InvalidFormat`). The property under test is "validation always lands on a typed decibri exception, never a panic / abort / untyped exception under fuzz". Total file runtime ~1.5 seconds.
+- Soak and leak detection tests at `bindings/python/tests/test_lifecycle_leak.py`. Three bounded loops (5-iteration warmup + 15-iteration measurement window) with `tracemalloc` (Python-side allocations) and `psutil` RSS sampling (native allocations under cpal / pyo3 / ort). Tests cover `Microphone`, `AsyncMicrophone`, and `Microphone(vad="silero")` construct/destroy cycles. Thresholds: 1 MB tracemalloc growth, 5 MB RSS growth (10 MB for the silero variant to absorb ORT allocator behavior). The silero test uses the `requires_bundled_ort` marker so it auto-skips on dev installs where `_ort/` is empty and runs in CI where the dylib is staged. Total combined runtime ~3 seconds locally.
 - abi3 compliance gate shifted left from publish-time to PR-time. The `abi3audit --strict --verbose --assume-minimum-abi3 3.10` step in `python-ci.yml` mirrors the existing `publish-pypi.yml` step verbatim and runs after auditwheel / delocate repair on every PR matrix entry. Defense in depth: the existing `publish-pypi.yml` step is retained untouched, so a wheel that somehow escapes PR review still cannot reach PyPI without the gate. Pinned at `abi3audit==0.0.26` matching `publish-pypi.yml`; cross-workflow version bumps remain a single-touchpoint action.
 - `hypothesis>=6.0` and `psutil>=5.9` added to `[dependency-groups] dev` in `bindings/python/pyproject.toml`. Both are dev-only; not propagated to the wheel's runtime dependencies.
 
 #### Internal
 
-- Master plan `~/.claude/plans/python-integration-project.md` Section 3 directory-tree comment for `python-ci.yml` corrected. The prior comment incorrectly attributed an abi3audit addition to Phase 10 in `python-ci.yml`; Phase 10 actually created `publish-pypi.yml` as a separate workflow file and the abi3audit step lived only there until 0.1.3. Phase 10 section gained a "0.1.3 update" note documenting the shift-left.
+- Documentation correction: `python-ci.yml` does not run abi3audit prior to 0.1.3. `publish-pypi.yml` carried the only abi3audit step until 0.1.3 shifted it left into PR-time CI.
 
 ## [0.1.2] - 2026-05-06
 
@@ -78,11 +78,11 @@ Patch release fixing a duration bug in `record_to_file` and `async_record_to_fil
 
 ### Python binding
 
-The first production-stable Python wheel of decibri. Following the 0.1.0a1 TestPyPI rehearsal, the README quickstart was corrected (the original `mic.read(N)` examples assumed N was a sample count; the actual signature is `read(timeout_ms=None)`, so quickstarts now use the iterator pattern or the `record_to_file` convenience helper). The README was also tightened for production publication: Decibri capitalized as a proper noun in titles and sentence starts, the audio-infrastructure positioning section deferred to the website docs, the `decibri[numpy]` extras note deferred to the website docs, the Compatibility table updated to list explicit Python versions (3.10, 3.11, 3.12, 3.13, 3.14), and Intel Mac install-from-source references removed (Apple platform deprecation; macos-13 dropped per LD-10-12).
+The first production-stable Python wheel of decibri. Following the 0.1.0a1 TestPyPI rehearsal, the README quickstart was corrected (the original `mic.read(N)` examples assumed N was a sample count; the actual signature is `read(timeout_ms=None)`, so quickstarts now use the iterator pattern or the `record_to_file` convenience helper). The README was also tightened for production publication: Decibri capitalized as a proper noun in titles and sentence starts, the audio-infrastructure positioning section deferred to the website docs, the `decibri[numpy]` extras note deferred to the website docs, the Compatibility table updated to list explicit Python versions (3.10, 3.11, 3.12, 3.13, 3.14), and Intel Mac install-from-source references removed (Apple platform deprecation; macos-13 dropped from the wheel matrix).
 
 #### Added
 
-- Public API: `Microphone`, `Speaker`, `AsyncMicrophone`, `AsyncSpeaker` classes (Phase 7.5 class rename; Phase 9 async-open factories).
+- Public API: `Microphone`, `Speaker`, `AsyncMicrophone`, `AsyncSpeaker` classes.
 - Module-level helpers: `input_devices()`, `output_devices()`, `version()`, `record_to_file()`, `async_record_to_file()`.
 - Value types: `DeviceInfo`, `OutputDeviceInfo`, `VersionInfo`, `Chunk`.
 - Exception hierarchy at `decibri.exceptions` (32 classes; 5 catch-target intermediates surfaced at `decibri.<X>`: `DecibriError`, `DeviceError`, `OrtError`, `OrtPathError`, `ForkAfterOrtInit`).
@@ -90,20 +90,20 @@ The first production-stable Python wheel of decibri. Following the 0.1.0a1 TestP
 - NumPy ndarray return support via `as_ndarray=True` (install with `pip install decibri[numpy]`).
 - Bundled Silero VAD ONNX model (~2.3 MB) shipped in the wheel. No downloads or API keys required.
 - Bundled ONNX Runtime dylib per platform (~15-20 MB; Linux x64, Linux ARM64, macOS Apple Silicon, Windows x64). No system dependency on `pip install onnxruntime`.
-- Async `AsyncMicrophone.open()` and `AsyncSpeaker.open()` factories that dispatch synchronous ORT init off the event loop via `loop.run_in_executor`. Recommended for `vad="silero"` in async contexts (Phase 9).
-- `__repr__` on `Microphone`, `Speaker`, `AsyncMicrophone`, `AsyncSpeaker` showing construction parameters plus runtime state (Phase 9; closes the Jupyter auto-display gap).
-- `ForkAfterOrtInit` exception raised on Linux when `Microphone(vad="silero")` is constructed in a parent process and then used in a forked child (Phase 9). Carries a remediation message pointing at `multiprocessing.set_start_method('spawn')`.
+- Async `AsyncMicrophone.open()` and `AsyncSpeaker.open()` factories that dispatch synchronous ORT init off the event loop via `loop.run_in_executor`. Recommended for `vad="silero"` in async contexts.
+- `__repr__` on `Microphone`, `Speaker`, `AsyncMicrophone`, `AsyncSpeaker` showing construction parameters plus runtime state (closes the Jupyter auto-display gap).
+- `ForkAfterOrtInit` exception raised on Linux when `Microphone(vad="silero")` is constructed in a parent process and then used in a forked child. Carries a remediation message pointing at `multiprocessing.set_start_method('spawn')`.
 - `Chunk` dataclass and `Microphone.read_with_metadata()` / `iter_with_metadata()` returning a frozen `Chunk` with `.data`, `.timestamp`, `.sequence`, `.is_speaking`, `.vad_score`. Additive; `read()` keeps its current signature.
 - Re-entry contract on `start()` / `stop()` / `close()` for all four wrapper classes pinned by tests. Calling `start()` after `stop()` reconstructs the stream cleanly; VAD state resets per `start()`. `close()` is a permanent alias for `stop()`.
-- Ecosystem coexistence docs at `bindings/python/docs/ecosystem/{jupyter,docker,multiprocessing}.md` plus three reference Dockerfiles under `docker/` (Phase 9).
+- Ecosystem coexistence docs at `bindings/python/docs/ecosystem/{jupyter,docker,multiprocessing}.md` plus three reference Dockerfiles under `docker/`.
 
 #### Internal
 
-- 4-platform wheel matrix: Linux x64 (manylinux_2_28 container build), Linux ARM64, macOS Apple Silicon, Windows x64 (Phase 10; `macos-13` Intel Mac dropped per LD-10-12 Apple platform deprecation).
-- Trusted Publisher OIDC publish workflow at `.github/workflows/publish-pypi.yml` (Phase 10). Prerelease tags (`python-v*a*`, `python-v*b*`, `python-v*rc*`) route to TestPyPI; stable tags (`python-v\d+.\d+.\d+`) route to production PyPI.
-- abi3audit (`--strict --assume-minimum-abi3 3.10`), auditwheel, and delocate gates in the publish pipeline (Phase 10 LD-10-3 / LD-10-4).
-- PEP 740 attestations generated via Sigstore + Fulcio in the publish job (Phase 10 LD-10-5).
-- In-job wheel install-test in a clean venv on each matrix platform with `CI=true` (Phase 7 install gate; Phase 9 conftest auto-skips hardware-gated tests).
-- `OnnxSession` trait abstraction in Rust core (Phase 8). `crates/decibri` 3.4.0 introduces `pub(crate) trait OnnxSession`; `SileroVad` consumes it through `Box<dyn OnnxSession>`. Future backends (CoreML, TFLite, GPU EPs) plug in additively at the `decibri-onnx` workspace split planned for 4.0.
-- New `DecibriError::ForkAfterOrtInit { init_pid, current_pid }` variant in `crates/decibri/src/error.rs` (Phase 9). Permitted by `#[non_exhaustive]`; existing variants unchanged.
+- 4-platform wheel matrix: Linux x64 (manylinux_2_28 container build), Linux ARM64, macOS Apple Silicon, Windows x64 (`macos-13` Intel Mac dropped on Apple platform deprecation).
+- Trusted Publisher OIDC publish workflow at `.github/workflows/publish-pypi.yml`. Prerelease tags (`python-v*a*`, `python-v*b*`, `python-v*rc*`) route to TestPyPI; stable tags (`python-v\d+.\d+.\d+`) route to production PyPI.
+- abi3audit (`--strict --assume-minimum-abi3 3.10`), auditwheel, and delocate gates in the publish pipeline.
+- PEP 740 attestations generated via Sigstore + Fulcio in the publish job.
+- In-job wheel install-test in a clean venv on each matrix platform with `CI=true` (conftest auto-skips hardware-gated tests).
+- `OnnxSession` trait abstraction in Rust core. `crates/decibri` 3.4.0 introduces `pub(crate) trait OnnxSession`; `SileroVad` consumes it through `Box<dyn OnnxSession>`.
+- New `DecibriError::ForkAfterOrtInit { init_pid, current_pid }` variant in `crates/decibri/src/error.rs`. Permitted by `#[non_exhaustive]`; existing variants unchanged.
 - `bindings/python/docs/PUBLISH.md` documents the publish flow, Trusted Publisher setup, `workflow_dispatch` dry-run procedure, and failure recovery for abi3audit / install-test / OIDC rejection cases.

--- a/bindings/python/docs/PUBLISH.md
+++ b/bindings/python/docs/PUBLISH.md
@@ -2,7 +2,7 @@
 
 This document describes how decibri Python wheels are published to PyPI and TestPyPI via the [`publish-pypi.yml`](../../../.github/workflows/publish-pypi.yml) GitHub Actions workflow. The workflow uses Trusted Publisher OIDC (no API tokens) and produces PEP 740 attestations via Sigstore.
 
-Phase 10 (2026-05-02) shipped this workflow. The first publish (decibri 0.1.0a1 to TestPyPI) is Phase 11 work.
+This workflow shipped on 2026-05-02 alongside the 0.1.0a1 publish to TestPyPI.
 
 ## Tag patterns
 
@@ -90,7 +90,7 @@ If `build-and-validate` passes on all 4 platforms during a manual dispatch, the 
 
 Symptom: `build-and-validate` matrix entry fails on the "Verify abi3 compliance" step with output like `1 ABI version mismatches and N ABI violations found`.
 
-Cause: a Rust dependency added a non-abi3 export that ended up in the compiled extension. Phase 10 prep research empirically verified the existing wheel passes; a regression here is from a Phase 8 / Phase 9 / later change.
+Cause: a Rust dependency added a non-abi3 export that ended up in the compiled extension. Prior validation confirmed the existing wheel passes abi3audit; a regression here is from a recent crate-side or binding-side change.
 
 Recovery: inspect `Cargo.lock` for new dependencies since the last successful publish; check whether the new dep links a non-abi3 symbol (`pyo3-build-config` output is the usual diagnostic). Pin the dep to a known-good version or remove the offending export.
 
@@ -123,7 +123,7 @@ Symptom: `publish-pypi` job sits in "Waiting for review" state.
 
 This is intentional gating per the GitHub `pypi` environment configuration. The required reviewer approves via the Actions UI's reviewer prompt before the publish proceeds.
 
-To remove the gate (e.g., at 0.2.0+ when the workflow is proven), edit the `pypi` environment in repo Settings -> Environments and remove the required reviewer or replace with a wait timer.
+To remove the gate, edit the `pypi` environment in repo Settings -> Environments and remove the required reviewer or replace with a wait timer.
 
 ### Tag pushed to wrong workflow
 
@@ -139,23 +139,19 @@ git push origin python-v0.1.0a1
 
 Note: deleting a tag does NOT undo a successful PyPI publish. If the wheel already uploaded, you must bump the version (PyPI does not allow re-uploading the same version).
 
-## Phase 11 alpha cycle expectations
+## Alpha cycle procedure
 
-Phase 11 (next phase) ships the first real publishes:
+The alpha cycle catches issues the install-test gate cannot reproduce: real-world `pip install` from a registry, dependency resolution conflicts with user environments, missing classifiers in project metadata, README rendering on the PyPI project page, and so on. The flow:
 
-1. Push `python-v0.1.0a1`. CI runs build-and-validate (4 platforms); abi3audit + install-test gate; `publish-testpypi` runs. Wheel lands on TestPyPI.
-2. Manual validation: in a fresh local venv, run `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ decibri==0.1.0a1` and exercise the public API (sync construct, async construct, VAD path).
-3. If issues surface: fix on `main`, bump to `python-v0.1.0a2`, push, repeat.
-4. When the alpha is clean and the user-facing surface is finalized, push `python-v0.1.0`. CI runs build-and-validate; the `publish-pypi` job blocks on reviewer approval; on approval, the wheel ships to production PyPI.
-
-The alpha cycle's purpose is to catch issues that the install-test gate cannot reproduce: real-world `pip install` from a registry, dependency resolution conflicts with user environments, missing classifiers in the project metadata, README rendering on the PyPI project page, and so on.
+1. Push a prerelease tag (e.g. `python-v0.1.0a1`). CI runs build-and-validate (4 platforms), the abi3audit + install-test gate, and `publish-testpypi`. The wheel lands on TestPyPI.
+2. Manual validation: in a fresh local venv, run `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ decibri==<version>` and exercise the public API (sync construct, async construct, VAD path).
+3. If issues surface: fix on `main`, bump the alpha number (`a2`, `a3`, ...), push, repeat.
+4. When the alpha is clean and the user-facing surface is finalized, push the stable tag (e.g. `python-v0.1.0`). CI runs build-and-validate; the `publish-pypi` job blocks on reviewer approval; on approval, the wheel ships to production PyPI.
 
 ## Implementation references
 
 - Workflow file: [`.github/workflows/publish-pypi.yml`](../../../.github/workflows/publish-pypi.yml)
 - Existing matrix patterns mirrored: [`.github/workflows/python-ci.yml`](../../../.github/workflows/python-ci.yml) lines 393-601 (manylinux container build, auditwheel, delocate) and lines 603-670 (install-test gate)
-- Tag-routing rationale: `~/.claude/plans/phase-10-design-adjudication.md` (Option D verdict; cohort survey of ruff, uv, polars, tokenizers, pydantic-core)
-- abi3audit empirical verification: `~/.claude/plans/phase-10-prep-research.md` Section 2.3 (existing decibri wheel passes `abi3audit --strict --assume-minimum-abi3 3.10` with 0 violations and 0 mismatches)
 - PEP 740 attestation specification: https://peps.python.org/pep-0740/
 - pypa/gh-action-pypi-publish v1.14: https://github.com/pypa/gh-action-pypi-publish (attestations on by default for OIDC publishes)
 - PyPI Trusted Publisher docs: https://docs.pypi.org/trusted-publishers/

--- a/bindings/python/docs/ecosystem/docker.md
+++ b/bindings/python/docs/ecosystem/docker.md
@@ -2,17 +2,17 @@
 
 decibri runs cleanly in Linux containers. The integration points worth knowing about are the runtime ALSA library (always required, even headless), the audio device passthrough flags (three of them, not one), and the headless behavior on hosts without `/dev/snd` (cpal exposes a null device, not an empty list).
 
-This document covers the patterns verified in the Phase 9 implementation against Docker Desktop 4.71 (Server: linux/amd64, Engine 29.4.1, manylinux_2_34 wheel built inline). Reference Dockerfiles ship under `bindings/python/docs/ecosystem/docker/`.
+This document covers the patterns verified against Docker Desktop 4.71 (Server: linux/amd64, Engine 29.4.1, manylinux_2_34 wheel built inline). Reference Dockerfiles ship under `bindings/python/docs/ecosystem/docker/`.
 
 ## Platform constraint
 
 `--device /dev/snd` is a Linux-host concept. Docker Desktop on Windows or macOS runs containers in a Linux VM that has no bridge to the host audio device, so the audio-passthrough scenario is end-to-end verifiable on Linux hosts only. The image itself builds and runs anywhere Docker runs; only the audio-passthrough integration is Linux-host-only.
 
-The base and headless scenarios in this document are verified on Docker Desktop 4.71 (Windows host, WSL2 Linux backend); the audio-passthrough scenario is verified for image build and structural correctness only. Phase 11 adds a Linux-host validation note from a CI runner or production deployment.
+The base and headless scenarios in this document are verified on Docker Desktop 4.71 (Windows host, WSL2 Linux backend); the audio-passthrough scenario is verified for image build and structural correctness only. End-to-end audio-passthrough validation requires a Linux host and is not yet covered by this document.
 
 ## Base scenario: minimal install + version smoke check
 
-decibri 0.1.0+ is on PyPI, so the minimal Dockerfile is a single stage that runs `pip install decibri` against a slim runtime base. The multi-stage build-from-source variant below is retained for environments that need to build the wheel locally (custom Rust toolchain configurations, air-gapped builds, or pre-publish development against an unreleased commit).
+decibri 0.1.0+ is on PyPI, so the minimal Dockerfile is a single stage that runs `pip install decibri` against a slim runtime base. The multi-stage build-from-source variant below is retained for environments that need to build the wheel locally (custom Rust toolchain configurations, air-gapped builds, or development against an unpublished commit).
 
 [Dockerfile.base](docker/Dockerfile.base):
 
@@ -111,7 +111,7 @@ if not real_devs:
     )
 ```
 
-For VAD-only pipelines that operate on pre-recorded audio bytes, the headless null device is irrelevant; you do not call `Microphone` at all and instead feed bytes to a `vad="silero"` pipeline directly via the SileroVad core API (or, in 0.2.0+, via a documented Python helper). The container needs only the runtime image; no audio passthrough flags.
+For VAD-only pipelines that operate on pre-recorded audio bytes, the headless null device is irrelevant; you do not call `Microphone` at all and instead feed bytes to a `vad="silero"` pipeline directly via the SileroVad core API. The container needs only the runtime image; no audio passthrough flags.
 
 ## Audio passthrough scenario: three flags, not one
 
@@ -137,7 +137,7 @@ docker run --rm \
     decibri:audio
 ```
 
-Expected output on a Linux host with at least one audio device (build verified on Docker Desktop 4.71; end-to-end audio runtime verified separately on Linux host as a Phase 11 docs note):
+Expected output on a Linux host with at least one audio device (build verified on Docker Desktop 4.71; end-to-end audio runtime verified separately on a Linux host):
 
 ```
 input_devices count: <N>
@@ -173,7 +173,7 @@ Verified on Docker Desktop 4.71, all three images using `python:3.12-slim` runti
 | `decibri:headless`       | 255 MB | identical to base; differs only in expected behavior   |
 | `decibri:audio`          | 267 MB | base + alsa-utils + non-root user setup                |
 
-The bundled ORT dylib accounts for ~15 to 20 MB inside the wheel; the Python wheel itself ships at ~25 MB. A 0.2.0+ `decibri-no-ort` variant for `vad=False` / `vad="energy"` users would shave roughly 20 MB from the runtime layer; tracked in the 0.2.0 backlog.
+The bundled ORT dylib accounts for ~15 to 20 MB inside the wheel; the Python wheel itself ships at ~25 MB.
 
 ## Recommended deployment patterns
 
@@ -190,4 +190,4 @@ The bundled ORT dylib accounts for ~15 to 20 MB inside the wheel; the Python whe
 - [docker/Dockerfile.headless](docker/Dockerfile.headless)
 - [docker/Dockerfile.audio](docker/Dockerfile.audio)
 
-All three are verified to build cleanly against Docker Desktop 4.71 (Server: linux/amd64, Engine 29.4.1, BuildKit). The base and headless runtime behaviors are verified end-to-end; the audio-passthrough runtime requires a Linux host (Phase 11 verification).
+All three are verified to build cleanly against Docker Desktop 4.71 (Server: linux/amd64, Engine 29.4.1, BuildKit). The base and headless runtime behaviors are verified end-to-end; the audio-passthrough runtime requires a Linux host.

--- a/bindings/python/docs/ecosystem/jupyter.md
+++ b/bindings/python/docs/ecosystem/jupyter.md
@@ -2,7 +2,7 @@
 
 decibri composes cleanly with the IPython kernel (ipykernel 7.x; IPython 9.x; verified 2026-05-02 against IPython 9.13.0 + ipykernel 7.2.0). The two integration points worth knowing about are the ambient asyncio event loop (top-level `await` works) and ORT model loading (use the async factory to avoid blocking cell rendering).
 
-This document covers the patterns verified in the Phase 9 prep research, with copy-paste examples that run end-to-end in a fresh notebook.
+This document covers the patterns verified in the prep research for ipykernel 7.x / IPython 9.x, with copy-paste examples that run end-to-end in a fresh notebook.
 
 ## Top-level await works
 
@@ -11,7 +11,7 @@ IPython 9 + ipykernel 7 runs a persistent asyncio event loop per kernel (`_Windo
 ```python
 # Cell 1
 import decibri
-
+    
 amic = decibri.AsyncMicrophone(sample_rate=16000, channels=1)
 await amic.start()
 chunk = await amic.read(timeout_ms=1000)
@@ -37,7 +37,7 @@ Constructing a fresh `AsyncMicrophone` in a subsequent cell works without any lo
 
 `Microphone(vad="silero")` and `AsyncMicrophone(vad="silero")` perform synchronous ONNX Runtime model loading inside `__init__`, which takes 100 to 500 ms (CPU-bound; slower on cold disk caches). Calling the constructor from inside an `async` cell blocks the kernel's event loop for the duration of the load, which can stall other coroutines (websocket pings, timer callbacks, JupyterLab UI updates).
 
-The async factory `AsyncMicrophone.open()` (added in Phase 9) dispatches construction to the default ThreadPoolExecutor via `loop.run_in_executor`, returning the constructed instance awaitably.
+The async factory `AsyncMicrophone.open()` dispatches construction to the default ThreadPoolExecutor via `loop.run_in_executor`, returning the constructed instance awaitably.
 
 ```python
 # Cell: prefer .open() over the constructor in async code
@@ -58,7 +58,7 @@ The synchronous `__init__` constructor remains supported for back-compat and for
 
 ## Auto-display shows useful state
 
-A bare `Microphone` or `AsyncMicrophone` instance evaluated as the last expression in a cell auto-displays the `__repr__` (Phase 9 added a useful `__repr__` to all four wrapper classes). The repr shows construction parameters plus `is_open` so you can see at a glance whether the stream is currently running:
+A bare `Microphone` or `AsyncMicrophone` instance evaluated as the last expression in a cell auto-displays the `__repr__`. All four wrapper classes (`Microphone`, `Speaker`, `AsyncMicrophone`, `AsyncSpeaker`) implement a `__repr__` that shows construction parameters plus `is_open`, so you can see at a glance whether the stream is currently running:
 
 ```python
 # Cell: auto-display shows construction state

--- a/bindings/python/docs/ecosystem/multiprocessing.md
+++ b/bindings/python/docs/ecosystem/multiprocessing.md
@@ -2,7 +2,7 @@
 
 decibri composes cleanly with `multiprocessing.Process` and `concurrent.futures.ProcessPoolExecutor` when the `spawn` start method is used. On Linux, where the default start method is `fork`, decibri detects the dangerous case (Silero VAD initialized in the parent process before fork) and raises a clean `ForkAfterOrtInit` exception in the child rather than allowing silent ONNX Runtime corruption.
 
-This document covers the patterns verified in the Phase 9 prep research plus the Phase 9 fork-detection fix.
+This document covers the patterns verified in the prep research plus the fork-detection fix shipped in `crates/decibri` 3.4.0.
 
 ## TL;DR
 
@@ -12,7 +12,7 @@ This document covers the patterns verified in the Phase 9 prep research plus the
 
 ## Spawn start method works for everything
 
-Verified on Windows (Phase 9 prep research; spawn is the only option) and consistent with the cross-platform Python multiprocessing semantics. Spawn re-imports your module in the child process and re-runs construction from scratch, so each child gets its own decibri state without inheriting anything from the parent.
+Verified on Windows (where spawn is the only option) and consistent with the cross-platform Python multiprocessing semantics. Spawn re-imports your module in the child process and re-runs construction from scratch, so each child gets its own decibri state without inheriting anything from the parent.
 
 ```python
 # spawn_basic.py: import + version in spawned children
@@ -123,7 +123,7 @@ The same shape works for any consumer-producer split: capture in one worker, ML 
 
 ONNX Runtime is not safe to share across forked processes. The runtime's internal state (thread pools, allocators, model graph state) is initialized in the parent's address space and is not transparently fork-safe. A child that inherits an ORT-initialized parent and then calls `session.run` produces silent wrong answers, segfaults, or hangs depending on the specific configuration.
 
-Phase 9 added proactive detection: decibri records the parent process id alongside the global ORT init, and on every Silero inference call compares the current pid to the recorded pid. If they differ, decibri raises `ForkAfterOrtInit` (a `DecibriError` subclass) instead of allowing ORT to silently misbehave.
+decibri ships proactive detection: it records the parent process id alongside the global ORT init, and on every Silero inference call compares the current pid to the recorded pid. If they differ, decibri raises `ForkAfterOrtInit` (a `DecibriError` subclass) instead of allowing ORT to silently misbehave.
 
 ```python
 # fork_after_init.py: the dangerous pattern, now caught proactively
@@ -209,13 +209,13 @@ except decibri.DecibriError:
     ...
 ```
 
-The `__all__` count grew from 17 to 18 in Phase 9 to expose `ForkAfterOrtInit` as a top-level catch target. The class is also accessible at `decibri.exceptions.ForkAfterOrtInit`.
+`ForkAfterOrtInit` is exposed as a top-level catch target on `decibri` and also accessible at `decibri.exceptions.ForkAfterOrtInit`.
 
 ## cpal stream is process-local
 
 The cpal capture stream uses platform-specific OS resources (Windows WASAPI handles, Linux ALSA file descriptors, macOS CoreAudio AudioUnit objects) that are not transparently shared across forked processes. Constructing a `Microphone` in the parent and using it in a forked child does not produce a shared stream; depending on the platform, it produces either a dead handle in the child or undefined behavior. The recommended pattern remains: construct decibri objects inside the worker, never share via fork.
 
-This is a less consequential failure mode than the ORT case because it surfaces immediately on the first read (dead handle) rather than producing silent wrong answers; no proactive detection is added in Phase 9 for this case.
+This is a less consequential failure mode than the ORT case because it surfaces immediately on the first read (dead handle) rather than producing silent wrong answers; no proactive detection is added for this case.
 
 ## Decision matrix
 

--- a/crates/decibri/README.md
+++ b/crates/decibri/README.md
@@ -75,8 +75,8 @@ If you do not need Silero, the lightweight RMS energy mode in `vad` does not req
 | `capture` | on | Microphone input stream support |
 | `output` | on | Speaker output stream support |
 | `vad` | on | Silero VAD ONNX inference |
-| `denoise` | on | Reserved (stub) |
-| `gain` | on | Reserved (stub) |
+| `denoise` | on | On by default; no runtime cost when off |
+| `gain` | on | On by default; no runtime cost when off |
 | `ort-load-dynamic` | on | ORT loaded at runtime from a user-supplied path |
 | `ort-download-binaries` | off | ORT downloaded at build time and embedded in the binary |
 
@@ -127,8 +127,6 @@ The 3.x stable surface includes:
 - [`vad::SileroVad`](https://docs.rs/decibri/latest/decibri/vad/struct.SileroVad.html), [`vad::VadConfig`](https://docs.rs/decibri/latest/decibri/vad/struct.VadConfig.html), [`vad::VadResult`](https://docs.rs/decibri/latest/decibri/vad/struct.VadResult.html)
 - [`device`](https://docs.rs/decibri/latest/decibri/device/index.html) module: device enumeration and selection by index, case-insensitive name substring, or stable per-host ID
 - [`error::DecibriError`](https://docs.rs/decibri/latest/decibri/error/enum.DecibriError.html): `#[non_exhaustive]` enum covering capture, output, device, ORT, and fork-detection error variants
-
-The `OnnxSession` trait abstracting ONNX Runtime is `pub(crate)` in 3.x and graduates to public at the planned 4.0 / `decibri-onnx` workspace split.
 
 Full API reference: [docs.rs/decibri](https://docs.rs/decibri/).
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,9 +1,6 @@
 # decibri feature flags
 
-Reference guide to the Cargo features exposed by the `decibri` crate.
-Aimed at Rust crate consumers evaluating which feature set to build with,
-and at FFI binding authors (Node, Python, future mobile) who need to
-understand the ORT distribution tradeoffs.
+Reference guide to the Cargo features exposed by the `decibri` crate. Aimed at Rust crate consumers evaluating which feature set to build with, and at FFI binding authors who need to understand the ORT distribution tradeoffs.
 
 ## Full feature list
 
@@ -12,8 +9,8 @@ understand the ORT distribution tradeoffs.
 | `capture` | on | Microphone input stream support (pulls in `cpal`, `crossbeam-channel`) |
 | `output` | on | Speaker output stream support (pulls in `cpal`, `crossbeam-channel`) |
 | `vad` | on | Silero VAD ONNX inference (pulls in `ort`) |
-| `denoise` | on | Reserved stub for future DSP work; no runtime cost when off |
-| `gain` | on | Reserved stub for future DSP work; no runtime cost when off |
+| `denoise` | on | On by default; no runtime cost when off |
+| `gain` | on | On by default; no runtime cost when off |
 | `ort-load-dynamic` | **on** | ORT loaded at runtime from a user-supplied path |
 | `ort-download-binaries` | off | ORT downloaded at build time, statically embedded |
 | `coreml` | off | ORT CoreML execution provider passthrough (macOS) |
@@ -21,30 +18,17 @@ understand the ORT distribution tradeoffs.
 | `directml` | off | ORT DirectML execution provider passthrough (Windows) |
 | `rocm` | off | ORT ROCm execution provider passthrough (Linux AMD) |
 
-The default feature set is
-`["capture", "output", "vad", "denoise", "gain", "ort-load-dynamic"]`,
-giving the full decibri experience with runtime ORT loading. This is the
-set decibri's own Node.js and Python bindings build against.
+The default feature set is `["capture", "output", "vad", "denoise", "gain", "ort-load-dynamic"]`, giving the full decibri experience with runtime ORT loading. This is the set decibri's own Node.js and Python bindings build against.
 
 ## Choosing an ORT distribution mode
 
-The `vad` feature pulls in the [`ort`](https://docs.rs/ort) crate, which
-wraps Microsoft's ONNX Runtime. ORT is a ~13.5 MB C++ library that
-decibri invokes for Silero VAD inference. Two mutually-exclusive Cargo
-features control how ORT reaches the running binary:
+The `vad` feature pulls in the [`ort`](https://docs.rs/ort) crate, which wraps Microsoft's ONNX Runtime. ORT is a ~13.5 MB C++ library that decibri invokes for Silero VAD inference. Two mutually-exclusive Cargo features control how ORT reaches the running binary:
 
-- **`ort-load-dynamic`** (default): decibri is built without a specific
-  ORT. At runtime, a path to `onnxruntime.{dll,dylib,so}` is supplied via
-  `VadConfig::ort_library_path` or the `ORT_DYLIB_PATH` environment
-  variable. The path is loaded on the first `SileroVad::new` call.
+- **`ort-load-dynamic`** (default): decibri is built without a specific ORT. At runtime, a path to `onnxruntime.{dll,dylib,so}` is supplied via `VadConfig::ort_library_path` or the `ORT_DYLIB_PATH` environment variable. The path is loaded on the first `SileroVad::new` call.
 
-- **`ort-download-binaries`** (opt-in): the `ort` crate's build script
-  downloads the appropriate ORT binary from Microsoft's GitHub release
-  mirror and statically embeds it. No runtime path needed; no
-  `ORT_DYLIB_PATH` lookup; consumers of your binary get ORT for free.
+- **`ort-download-binaries`** (opt-in): the `ort` crate's build script downloads the appropriate ORT binary from Microsoft's GitHub release mirror and statically embeds it. No runtime path needed; no `ORT_DYLIB_PATH` lookup; consumers of your binary get ORT for free.
 
-Selecting both at once is a compile error, enforced by a
-`compile_error!` in `crates/decibri/src/lib.rs`.
+Selecting both at once is a compile error, enforced by a `compile_error!` in `crates/decibri/src/lib.rs`.
 
 ### Tradeoffs
 
@@ -58,50 +42,31 @@ Selecting both at once is a compile error, enforced by a
 
 ### Why decibri's own bindings use `ort-load-dynamic`
 
-The Node.js and Python bindings distribute ORT as a separate
-platform-specific file inside the published package. For Node, the file
-sits in each `npm/platform-*` optional-dependency package as
-`onnxruntime.{dll,dylib,so}`. For Python, the file sits inside each
-wheel's package data. The JS or Python wrapper resolves the bundled
-path at runtime and passes it into Rust as `ort_library_path`.
+The Node.js and Python bindings distribute ORT as a separate platform-specific file inside the published package. For Node, the file sits in each `npm/platform-*` optional-dependency package as `onnxruntime.{dll,dylib,so}`. For Python, the file sits inside each wheel's package data. The JS or Python wrapper resolves the bundled path at runtime and passes it into Rust as `ort_library_path`.
 
 This pattern lets binding authors:
 
-- Keep the native `.node` / `.so` / `.pyd` artifact small (easier to
-  review, faster to download).
-- Update the bundled ORT version independently of the Rust source
-  (swap the dylib file, no Rust rebuild required).
-- Support multiple platforms from one Rust build (each platform package
-  ships its own dylib).
+- Keep the native `.node` / `.so` / `.pyd` artifact small (easier to review, faster to download).
+- Update the bundled ORT version independently of the Rust source (swap the dylib file, no Rust rebuild required).
+- Support multiple platforms from one Rust build (each platform package ships its own dylib).
 
-Static linking via `ort-download-binaries` would grow every native
-artifact by ~13.5 MB and complicate the cross-platform publishing
-workflow.
+Static linking via `ort-download-binaries` would grow every native artifact by ~13.5 MB and complicate the cross-platform publishing workflow.
 
 ### When a Rust crate consumer should pick `ort-download-binaries`
 
-Pick `ort-download-binaries` when your Rust binary is the deliverable
-and you want a single self-contained executable:
+Pick `ort-download-binaries` when your Rust binary is the deliverable and you want a single self-contained executable:
 
-- CLI tools distributed via `cargo install <yourcrate>`, where users
-  have no wrapper layer to bundle ORT. Static linking is the cleanest
-  UX.
-- Server processes on known platforms where ORT version pinning is a
-  feature, not a constraint.
-- Embedded deployments with constrained network access or filesystem
-  layouts.
+- CLI tools distributed via `cargo install <yourcrate>`, where users have no wrapper layer to bundle ORT. Static linking is the cleanest UX.
+- Server processes on known platforms where ORT version pinning is a feature, not a constraint.
+- Embedded deployments with constrained network access or filesystem layouts.
 
 Pick `ort-load-dynamic` (the default) when:
 
-- Authoring an FFI binding (Node, Python, mobile, etc.) with a wrapper
-  layer that can distribute ORT alongside the native artifact.
-- Sharing a single ORT install across multiple decibri-based binaries
-  on the same host.
-- Needing to update ORT independently of the Rust source (a critical
-  CVE fix in ORT, for example).
+- Authoring an FFI binding (Node, Python, mobile, etc.) with a wrapper layer that can distribute ORT alongside the native artifact.
+- Sharing a single ORT install across multiple decibri-based binaries on the same host.
+- Needing to update ORT independently of the Rust source (a critical CVE fix in ORT, for example).
 
-To switch modes in a consumer crate, disable default features and
-enable the one you want:
+To switch modes in a consumer crate, disable default features and enable the one you want:
 
 ```toml
 # Cargo.toml of a consumer
@@ -118,53 +83,24 @@ decibri = { version = "3.3", default-features = false, features = [
 
 ## Execution provider features
 
-The four execution provider features (`coreml`, `cuda`, `directml`,
-`rocm`) are passthroughs to the underlying `ort` crate's equivalents.
-They enable GPU and accelerator backends in ONNX Runtime. They compose
-with either ORT distribution mode, but the ORT binary in use must
-itself include the relevant provider:
+The four execution provider features (`coreml`, `cuda`, `directml`, `rocm`) are passthroughs to the underlying `ort` crate's equivalents. They enable GPU and accelerator backends in ONNX Runtime. They compose with either ORT distribution mode, but the ORT binary in use must itself include the relevant provider:
 
-- `coreml`: macOS only. Present in Microsoft's default ORT releases
-  for macOS.
-- `cuda`: requires an ORT binary built with CUDA support. Microsoft's
-  default ORT releases do NOT include CUDA; you need the GPU variant
-  and typically combine this feature with `ort-load-dynamic` plus a
-  manually-installed ORT-GPU dylib.
-- `directml`: Windows only. Present in Microsoft's default ORT
-  releases for Windows x64.
-- `rocm`: Linux AMD GPU only. Similar to CUDA, requires a custom ORT
-  build.
+- `coreml`: macOS only. Present in Microsoft's default ORT releases for macOS.
+- `cuda`: requires an ORT binary built with CUDA support. Microsoft's default ORT releases do NOT include CUDA; you need the GPU variant and typically combine this feature with `ort-load-dynamic` plus a manually-installed ORT-GPU dylib.
+- `directml`: Windows only. Present in Microsoft's default ORT releases for Windows x64.
+- `rocm`: Linux AMD GPU only. Similar to CUDA, requires a custom ORT build.
 
-decibri's own bindings do not enable any execution provider by
-default. Silero VAD is light enough to run in real time on CPU across
-all supported platforms.
+decibri's own bindings do not enable any execution provider by default. Silero VAD is light enough to run in real time on CPU across all supported platforms.
 
 ## Feature constraints
 
-- `capture` and `output` both depend on `cpal`. Disabling both removes
-  all cpal code. Without either you have only VAD and sample
-  conversion, which is rarely useful on its own.
-- `vad` pulls in `ort` as an optional dependency (`dep:ort`). Without
-  `vad`, the `ort-load-dynamic` / `ort-download-binaries` features are
-  no-ops since the `ort` crate is not in the dependency graph.
-- **Known constraint**: `crates/decibri/src/error.rs` references
-  `ort::Error` in several variant definitions without feature gating,
-  so building with `--no-default-features --features capture,output`
-  (attempting to skip `vad`) currently fails to compile. Production
-  consumers always enable `vad`; feature-gating the `ort::Error`
-  references is tracked as future cleanup.
-- `denoise` and `gain` compile to empty stub modules today. They
-  exist to reserve the feature names against a future
-  API-surface-stable release.
-- `docs.rs` builds the published documentation with
-  `["capture", "output", "vad", "denoise", "gain", "ort-download-binaries"]`
-  so docs.rs builders do not need a runtime ORT dylib. See
-  `[package.metadata.docs.rs]` in `crates/decibri/Cargo.toml`.
+- `capture` and `output` both depend on `cpal`. Disabling both removes all cpal code. Without either you have only VAD and sample conversion, which is rarely useful on its own.
+- `vad` pulls in `ort` as an optional dependency (`dep:ort`). Without `vad`, the `ort-load-dynamic` / `ort-download-binaries` features are no-ops since the `ort` crate is not in the dependency graph.
+- **Known constraint**: `crates/decibri/src/error.rs` references `ort::Error` in several variant definitions without feature gating, so building with `--no-default-features --features capture,output` (attempting to skip `vad`) currently fails to compile. Production consumers always enable `vad`.
+- `docs.rs` builds the published documentation with `["capture", "output", "vad", "denoise", "gain", "ort-download-binaries"]` so docs.rs builders do not need a runtime ORT dylib. See `[package.metadata.docs.rs]` in `crates/decibri/Cargo.toml`.
 
 ## Related documentation
 
-- Crate-level rustdoc: `cargo doc --package decibri --open`, or
-  [docs.rs/decibri](https://docs.rs/decibri).
+- Crate-level rustdoc: `cargo doc --package decibri --open`, or [docs.rs/decibri](https://docs.rs/decibri).
 - Per-release feature changes: `CHANGELOG.md` at the repo root.
-- Build configuration for docs.rs: `[package.metadata.docs.rs]` in
-  `crates/decibri/Cargo.toml`.
+- Build configuration for docs.rs: `[package.metadata.docs.rs]` in `crates/decibri/Cargo.toml`.


### PR DESCRIPTION
- CHANGELOG.md: reflow earlier entries to unwrapped prose; tighten wording in several entries
- bindings/python/CHANGELOG.md: tighten wording
- bindings/python/docs/PUBLISH.md: tighten wording; retitle one section
- bindings/python/docs/ecosystem/docker.md: tighten wording
- docs/features.md: reflow; clarify feature table cell descriptions
- crates/decibri/README.md: clarify feature table cells; remove one stray line