### PR TITLE
ci: add per-registry publish workflows alongside existing release workflow

### DIFF
--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -136,14 +136,14 @@ jobs:
       - name: Get decibri's pinned ORT_VERSION
         id: pinned
         run: |
-          # Anchored to the workflow-level `env:` declaration in release.yml,
-          # which is the single source of truth for ORT_VERSION. The anchor
-          # `^  ORT_VERSION:` (two-space indent) matches the env block line
-          # exactly and rejects any stray per-job bash assignments that might
-          # sneak in later.
-          VERSION=$(grep -oP '^\s+ORT_VERSION:\s*\K[0-9]+\.[0-9]+\.[0-9]+' .github/workflows/release.yml | head -1)
+          # Anchored to the workflow-level `env:` declaration in
+          # publish-npm.yml, which is the single source of truth for
+          # ORT_VERSION. The anchor `^  ORT_VERSION:` (two-space indent)
+          # matches the env block line exactly and rejects any stray
+          # per-job bash assignments that might sneak in later.
+          VERSION=$(grep -oP '^\s+ORT_VERSION:\s*\K[0-9]+\.[0-9]+\.[0-9]+' .github/workflows/publish-npm.yml | head -1)
           if [ -z "$VERSION" ]; then
-            echo "ERROR: could not extract ORT_VERSION from release.yml env block"
+            echo "ERROR: could not extract ORT_VERSION from publish-npm.yml env block"
             echo "Expected a workflow-level env: block containing 'ORT_VERSION: X.Y.Z'"
             exit 1
           fi
@@ -191,7 +191,7 @@ jobs:
           if [ "$LATEST_MINOR" -gt "$API_N" ]; then
             ABI_WARNING="
 
-          ⚠️ **ABI mismatch**: Microsoft released ORT 1.${LATEST_MINOR}.x but the \`ort\` crate is pinned to an \`api-${API_N}\` target (ONNX Runtime 1.${API_N}.x ABI). **Upgrading the bundled ORT to 1.${LATEST_MINOR}.x requires first upgrading the \`ort\` crate to a version that targets api-${LATEST_MINOR}**. Do NOT bump \`ORT_VERSION\` in \`release.yml\` until the crate upgrade is complete."
+          ⚠️ **ABI mismatch**: Microsoft released ORT 1.${LATEST_MINOR}.x but the \`ort\` crate is pinned to an \`api-${API_N}\` target (ONNX Runtime 1.${API_N}.x ABI). **Upgrading the bundled ORT to 1.${LATEST_MINOR}.x requires first upgrading the \`ort\` crate to a version that targets api-${LATEST_MINOR}**. Do NOT bump \`ORT_VERSION\` in \`publish-npm.yml\` until the crate upgrade is complete."
           fi
 
           TITLE="ONNX Runtime ${LATEST} available (pinned: ${PINNED})"
@@ -204,9 +204,9 @@ jobs:
 
           **Review upgrade path:**
           1. Check that the current \`ort\` crate version still supports \`api-${LATEST_MINOR}\` (compare against [ort.pyke.io/setup/multiversion](https://ort.pyke.io/setup/multiversion)).
-          2. Update \`ORT_VERSION\` in \`.github/workflows/release.yml\`.
+          2. Update \`ORT_VERSION\` in \`.github/workflows/publish-npm.yml\`.
           3. Update the \`api_n\` baseline in \`.github/workflows/check-upstream.yml\` if the ort crate was also upgraded.
-          4. Trigger \`release-dryrun.yml\` manually to confirm the new tarball URLs resolve and the bundled dylib loads across all four platforms.${ABI_WARNING}"
+          4. Trigger \`publish-npm.yml\` manually via workflow_dispatch with \`publish\` left unticked to confirm the new tarball URLs resolve and the bundled dylib loads across all four platforms.${ABI_WARNING}"
 
           if [ "$COUNT" = "0" ]; then
             gh issue create \

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,105 @@
+name: Publish to crates.io
+
+on:
+  push:
+    tags:
+      - 'crate-v*'
+  workflow_dispatch:
+    inputs:
+      publish:
+        type: boolean
+        default: false
+        description: 'Tick to actually publish. Unticked = dry run (preflight only, no publish).'
+
+permissions:
+  # `contents: write` permits the `gh release create` step.
+  # `id-token: write` is reserved for future OIDC trusted-publishing flows
+  # and harmless to declare today (no step consumes it yet).
+  # `attestations: write` is reserved for a future attest-build-provenance
+  # step against the .crate tarball.
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  preflight:
+    name: Preflight (version match)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run mode
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish }}" != "true" ]; then
+            echo "::notice::DRY RUN MODE (workflow_dispatch with publish=false). No publish will occur."
+          else
+            echo "Publishing run. Trigger: ${{ github.event_name }}. Tag: ${{ github.ref_name }}"
+          fi
+
+      - name: Assert tag version matches workspace Cargo.toml
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          # Tag form: refs/tags/crate-v3.4.0 -> TAG_VERSION=3.4.0
+          TAG_VERSION="${{ github.ref_name }}"
+          TAG_VERSION="${TAG_VERSION#crate-v}"
+          echo "Tag version: ${TAG_VERSION}"
+
+          # Workspace Cargo.toml: the `[workspace.package]` block's
+          # `version = "..."` line sits at column 0. Per-crate Cargo.toml
+          # files use `version.workspace = true` and have no literal version
+          # string, so the first unindented `version = "..."` match is
+          # always the workspace version.
+          CARGO_VERSION=$(grep -oP '^version\s*=\s*"\K[^"]+' Cargo.toml | head -1)
+          if [ -z "$CARGO_VERSION" ]; then
+            echo "ERROR: could not extract workspace version from Cargo.toml"
+            exit 1
+          fi
+          echo "Cargo.toml workspace version: ${CARGO_VERSION}"
+
+          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+            echo "ERROR: tag crate-v${TAG_VERSION} does not match Cargo.toml version ${CARGO_VERSION}"
+            echo "Bump Cargo.toml to ${TAG_VERSION}, then re-tag."
+            exit 1
+          fi
+
+          echo "OK: tag and Cargo.toml agree on ${TAG_VERSION}"
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: preflight
+    # Required-reviewer protection on this environment gates the publish
+    # behind a manual approval in the Actions UI.
+    environment: crates
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install ALSA headers
+        # `cargo publish` runs `cargo build` against the crate as part of
+        # its package + verify pass. The `cpal` transitive dep needs ALSA
+        # headers on Linux.
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+
+      - name: Publish to crates.io
+        # Tag-push always publishes. workflow_dispatch publishes only when
+        # the `publish` input is ticked. Pre-release tags (containing `-`
+        # after the prefix-stripped version) skip the publish.
+        if: |
+          (github.event_name == 'push' && !contains(github.ref, '-')) ||
+          (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p decibri
+
+      - name: Create GitHub Release
+        if: github.event_name == 'push'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ github.ref_name }} \
+            --title "${{ github.ref_name }}" \
+            --generate-notes

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,473 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'npm-v*'
+  workflow_dispatch:
+    inputs:
+      publish:
+        type: boolean
+        default: false
+        description: 'Tick to actually publish. Unticked = dry run (build, stage, verify-pack only; no publish).'
+
+permissions:
+  # `contents: write` permits the `gh release create` step.
+  # `id-token: write` is required for npm Trusted Publisher OIDC token
+  # issuance.
+  # `attestations: write` permits the actions/attest-build-provenance step
+  # against the native addons.
+  contents: write
+  id-token: write
+  attestations: write
+
+# Single source of truth for the bundled ONNX Runtime version, read by
+# every platform job's preflight/download step. Also parsed by the
+# check-onnxruntime job in .github/workflows/check-upstream.yml via:
+#   grep -oP '^\s+ORT_VERSION:\s*\K[0-9]+\.[0-9]+\.[0-9]+' publish-npm.yml
+# Updating this value is step 3 of the ort-crate upgrade procedure
+# documented in the workspace Cargo.toml maintainer comment.
+env:
+  ORT_VERSION: 1.24.4
+
+jobs:
+  preflight:
+    name: Preflight (version match)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run mode
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish }}" != "true" ]; then
+            echo "::notice::DRY RUN MODE (workflow_dispatch with publish=false). No publish will occur."
+          else
+            echo "Publishing run. Trigger: ${{ github.event_name }}. Tag: ${{ github.ref_name }}"
+          fi
+
+      - name: Assert tag version matches package manifests
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          # Tag form: refs/tags/npm-v3.4.0 -> TAG_VERSION=3.4.0
+          # Pre-release tags (npm-v3.5.0-rc.1) are allowed; the suffix is
+          # preserved and must match across every manifest if used.
+          TAG_VERSION="${{ github.ref_name }}"
+          TAG_VERSION="${TAG_VERSION#npm-v}"
+          echo "Tag version: ${TAG_VERSION}"
+
+          MISMATCH=0
+
+          # Every package.json must match the tag. jq is preinstalled on
+          # ubuntu-latest runners; no setup needed.
+          for pkg in \
+            npm/decibri/package.json \
+            npm/platform-darwin-arm64/package.json \
+            npm/platform-linux-arm64-gnu/package.json \
+            npm/platform-linux-x64-gnu/package.json \
+            npm/platform-win32-x64-msvc/package.json
+          do
+            PKG_VERSION=$(jq -r .version "$pkg")
+            echo "${pkg}: ${PKG_VERSION}"
+            if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+              echo "ERROR: tag npm-v${TAG_VERSION} does not match ${pkg} version ${PKG_VERSION}"
+              MISMATCH=1
+            fi
+          done
+
+          if [ "$MISMATCH" = "1" ]; then
+            echo ""
+            echo "Release aborted: version mismatch detected."
+            echo "Bump all 5 package.json files to ${TAG_VERSION}, then re-tag."
+            exit 1
+          fi
+
+          echo "OK: tag and all 5 package.json files agree on ${TAG_VERSION}"
+
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    needs: preflight
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact: win32-x64-msvc
+            ort_platform_slug: win-x64
+            ort_ext: zip
+          - os: macos-14
+            target: aarch64-apple-darwin
+            artifact: darwin-arm64
+            ort_platform_slug: osx-arm64
+            ort_ext: tgz
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: linux-x64-gnu
+            setup: sudo apt-get update && sudo apt-get install -y libasound2-dev
+            ort_platform_slug: linux-x64
+            ort_ext: tgz
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            artifact: linux-arm64-gnu
+            setup: sudo apt-get update && sudo apt-get install -y libasound2-dev
+            ort_platform_slug: linux-aarch64
+            ort_ext: tgz
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Platform setup
+        if: matrix.setup
+        run: ${{ matrix.setup }}
+
+      - name: Install npm dependencies
+        run: cd npm/decibri && npm install --ignore-optional
+
+      - name: Verify ONNX Runtime tarball availability
+        shell: bash
+        run: |
+          URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}.${{ matrix.ort_ext }}"
+          echo "Verifying: $URL"
+          if ! curl -sIfL --retry 3 --retry-delay 2 -o /dev/null "$URL"; then
+            echo "ERROR: expected ONNX Runtime tarball not available at $URL"
+            echo "This may mean Microsoft renamed release assets, delayed a release,"
+            echo "or the pinned ORT_VERSION no longer exists upstream."
+            echo "Check: https://github.com/microsoft/onnxruntime/releases/tag/v${ORT_VERSION}"
+            exit 1
+          fi
+          echo "OK: tarball is available"
+
+      - name: Download and extract ONNX Runtime (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}.tgz"
+          curl -sL --retry 3 --retry-delay 2 -o ort.tgz "$URL"
+          tar -xzf ort.tgz
+          SRC="onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}"
+          # Upstream ships libonnxruntime.<version>.dylib; rename to unversioned
+          # to match the JS wrapper's PLATFORM_DYLIB table expectation.
+          cp -L "$SRC/lib/libonnxruntime.${ORT_VERSION}.dylib" npm/decibri/libonnxruntime.dylib
+
+      - name: Verify libonnxruntime.dylib codesign (macOS, diagnostic)
+        if: runner.os == 'macOS'
+        continue-on-error: true
+        # Non-gating: `cp -L` on a real file (not symlink) preserves the
+        # signed bytes, but does not preserve the original filename the
+        # signature may be scoped to. Microsoft's upstream dylib is signed;
+        # this step logs whether the renamed file still validates. On
+        # failure the step is marked red but the workflow proceeds.
+        run: codesign -v --verbose=2 npm/decibri/libonnxruntime.dylib
+
+      - name: Download and extract ONNX Runtime (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}.tgz"
+          curl -sL --retry 3 --retry-delay 2 -o ort.tgz "$URL"
+          tar -xzf ort.tgz
+          SRC="onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}"
+          # cp -L follows the symlink chain (libonnxruntime.so -> .so.1 ->
+          # .so.1.24.4) and copies the real file as libonnxruntime.so. This
+          # avoids repeating the version in the filename. libonnxruntime_
+          # providers_shared.so keeps its exact upstream name. The main
+          # dylib dlopens it by that basename via $ORIGIN RUNPATH.
+          cp -L "$SRC/lib/libonnxruntime.so" npm/decibri/libonnxruntime.so
+          cp "$SRC/lib/libonnxruntime_providers_shared.so" npm/decibri/
+
+      - name: Download and extract ONNX Runtime (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ProgressPreference = 'SilentlyContinue'  # speeds up Invoke-WebRequest
+          $url = "https://github.com/microsoft/onnxruntime/releases/download/v$env:ORT_VERSION/onnxruntime-${{ matrix.ort_platform_slug }}-$env:ORT_VERSION.zip"
+          Invoke-WebRequest -Uri $url -OutFile ort.zip -MaximumRetryCount 3 -RetryIntervalSec 2
+          Expand-Archive -Path ort.zip -DestinationPath .
+          $src = "onnxruntime-${{ matrix.ort_platform_slug }}-$env:ORT_VERSION"
+          # Upstream DLL is already named onnxruntime.dll. No rename.
+          Copy-Item "$src/lib/onnxruntime.dll" npm/decibri/
+
+      - name: Inspect onnxruntime.dll imports (Windows, diagnostic)
+        if: runner.os == 'Windows'
+        continue-on-error: true
+        shell: pwsh
+        # Non-gating: `dumpbin` ships with MSVC under the Visual Studio
+        # install path and is NOT on the default PATH on windows-latest
+        # runners. Located via a glob over the VS install directory rather
+        # than a third-party dev-env action. Output (the DLL's import
+        # table) goes to the log so unexpected DLL dependencies (odd MSVC
+        # runtime, Windows SDK DLLs not on a user's box, etc.) are visible
+        # before users hit "cannot find library X" at runtime. On failure
+        # the step is marked red but the workflow proceeds.
+        run: |
+          $dumpbin = Get-ChildItem "C:\Program Files*\Microsoft Visual Studio\*\*\VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $dumpbin) {
+            Write-Host "dumpbin.exe not found under the Visual Studio install path"
+            exit 1
+          }
+          Write-Host "Using dumpbin: $($dumpbin.FullName)"
+          & $dumpbin.FullName /imports npm/decibri/onnxruntime.dll
+
+      - name: Build native addon
+        shell: bash
+        run: |
+          cd npm/decibri
+          npx napi build --platform --release \
+            -p decibri-node \
+            --manifest-path ../../bindings/node/Cargo.toml \
+            --js-package-name @decibri/decibri \
+            --target ${{ matrix.target }} \
+            -o .
+
+      - name: Verify binary exists
+        shell: bash
+        run: ls -la npm/decibri/decibri.*.node
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: npm/decibri/decibri.*.node
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: decibri-${{ matrix.artifact }}
+          # Only one of the libonnxruntime.* / onnxruntime.dll patterns matches
+          # per platform; non-matching patterns are silently skipped. The
+          # `.node` pattern always matches, so `if-no-files-found: error`
+          # still correctly catches the real failure (missing build output).
+          path: |
+            npm/decibri/decibri.*.node
+            npm/decibri/libonnxruntime.dylib
+            npm/decibri/libonnxruntime.so
+            npm/decibri/libonnxruntime_providers_shared.so
+            npm/decibri/onnxruntime.dll
+          if-no-files-found: error
+
+      - name: Upload napi loader (Linux x64 only)
+        if: matrix.artifact == 'linux-x64-gnu'
+        uses: actions/upload-artifact@v7
+        with:
+          name: decibri-loader
+          path: |
+            npm/decibri/index.js
+            npm/decibri/index.d.ts
+          if-no-files-found: error
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: build
+    # Required-reviewer protection on this environment gates the publish
+    # behind a manual approval in the Actions UI.
+    environment: npm
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: artifacts/
+
+      - name: Debug artifact structure
+        run: find artifacts/ -type f | sort
+
+      - name: Stage platform binaries
+        shell: bash
+        run: |
+          # macOS (darwin-arm64)
+          find artifacts/decibri-darwin-arm64 -name "decibri.darwin-arm64.node" -exec cp {} npm/platform-darwin-arm64/ \;
+          find artifacts/decibri-darwin-arm64 -name "libonnxruntime.dylib"      -exec cp {} npm/platform-darwin-arm64/ \;
+          # Linux x64
+          find artifacts/decibri-linux-x64-gnu -name "decibri.linux-x64-gnu.node"         -exec cp {} npm/platform-linux-x64-gnu/ \;
+          find artifacts/decibri-linux-x64-gnu -name "libonnxruntime.so"                  -exec cp {} npm/platform-linux-x64-gnu/ \;
+          find artifacts/decibri-linux-x64-gnu -name "libonnxruntime_providers_shared.so" -exec cp {} npm/platform-linux-x64-gnu/ \;
+          # Linux arm64
+          find artifacts/decibri-linux-arm64-gnu -name "decibri.linux-arm64-gnu.node"         -exec cp {} npm/platform-linux-arm64-gnu/ \;
+          find artifacts/decibri-linux-arm64-gnu -name "libonnxruntime.so"                    -exec cp {} npm/platform-linux-arm64-gnu/ \;
+          find artifacts/decibri-linux-arm64-gnu -name "libonnxruntime_providers_shared.so"   -exec cp {} npm/platform-linux-arm64-gnu/ \;
+          # Windows
+          find artifacts/decibri-win32-x64-msvc -name "decibri.win32-x64-msvc.node" -exec cp {} npm/platform-win32-x64-msvc/ \;
+          find artifacts/decibri-win32-x64-msvc -name "onnxruntime.dll"             -exec cp {} npm/platform-win32-x64-msvc/ \;
+
+      - name: Verify staged binaries
+        run: |
+          ls -la npm/platform-win32-x64-msvc/decibri.*.node   npm/platform-win32-x64-msvc/onnxruntime.dll
+          ls -la npm/platform-darwin-arm64/decibri.*.node     npm/platform-darwin-arm64/libonnxruntime.dylib
+          ls -la npm/platform-linux-x64-gnu/decibri.*.node    npm/platform-linux-x64-gnu/libonnxruntime.so    npm/platform-linux-x64-gnu/libonnxruntime_providers_shared.so
+          ls -la npm/platform-linux-arm64-gnu/decibri.*.node  npm/platform-linux-arm64-gnu/libonnxruntime.so  npm/platform-linux-arm64-gnu/libonnxruntime_providers_shared.so
+
+      - name: Stage napi loader
+        run: |
+          cp artifacts/decibri-loader/index.js npm/decibri/
+          cp artifacts/decibri-loader/index.d.ts npm/decibri/
+
+      - name: Verify loader exists
+        run: |
+          ls -la npm/decibri/index.js
+          ls -la npm/decibri/index.d.ts
+
+      - name: Copy README for npm package
+        # Copy the workspace README into the main npm package directory
+        # before the verify_pack gate runs so the main package's required
+        # README.md file check passes.
+        run: cp README.md npm/decibri/README.md
+
+      - name: Verify npm package contents (pre-publish gate)
+        # Defense-in-depth: verify npm package contents before any publish.
+        # Runs in both publish and dry-run modes.
+        shell: bash
+        run: |
+          set -o pipefail
+          FAIL=0
+
+          verify_pack() {
+            local pkg_dir="$1"
+            local label="$2"
+            shift 2
+            # Remaining args: required files prefixed with ':',
+            #                 forbidden regex patterns prefixed with '~'.
+            local required=()
+            local forbidden=()
+            for arg in "$@"; do
+              case "$arg" in
+                :*) required+=("${arg#:}") ;;
+                ~*) forbidden+=("${arg#~}") ;;
+              esac
+            done
+
+            echo ""
+            echo "=== $label ($pkg_dir) ==="
+            local files
+            files=$(cd "$pkg_dir" && npm pack --dry-run --json | jq -r '.[0].files[].path')
+            echo "Would pack:"
+            echo "$files" | sort | sed 's/^/  * /'
+
+            for f in "${required[@]}"; do
+              if echo "$files" | grep -Fxq "$f"; then
+                echo "  [OK]   required present: $f"
+              else
+                echo "  [FAIL] required MISSING: $f"
+                FAIL=1
+              fi
+            done
+
+            for p in "${forbidden[@]}"; do
+              local matches
+              matches=$(echo "$files" | grep -E "$p" || true)
+              if [ -n "$matches" ]; then
+                echo "  [FAIL] forbidden pattern '$p' matched:"
+                echo "$matches" | sed 's/^/         /'
+                FAIL=1
+              else
+                echo "  [OK]   forbidden absent: $p"
+              fi
+            done
+          }
+
+          # Main package: should carry JS source, models, README, napi loader;
+          # must NOT carry the native .node file or any ORT dylib (those belong
+          # in the platform packages).
+          verify_pack npm/decibri "main package (decibri)" \
+            :package.json \
+            :README.md \
+            :src/decibri.js \
+            :index.js \
+            :models/silero_vad.onnx \
+            '~\.node$' \
+            '~onnxruntime'
+
+          verify_pack npm/platform-darwin-arm64 "@decibri/decibri-darwin-arm64" \
+            :decibri.darwin-arm64.node \
+            :libonnxruntime.dylib
+
+          verify_pack npm/platform-linux-x64-gnu "@decibri/decibri-linux-x64-gnu" \
+            :decibri.linux-x64-gnu.node \
+            :libonnxruntime.so \
+            :libonnxruntime_providers_shared.so
+
+          verify_pack npm/platform-linux-arm64-gnu "@decibri/decibri-linux-arm64-gnu" \
+            :decibri.linux-arm64-gnu.node \
+            :libonnxruntime.so \
+            :libonnxruntime_providers_shared.so
+
+          verify_pack npm/platform-win32-x64-msvc "@decibri/decibri-win32-x64-msvc" \
+            :decibri.win32-x64-msvc.node \
+            :onnxruntime.dll
+
+          echo ""
+          if [ "$FAIL" -ne 0 ]; then
+            echo "================================================"
+            echo "  VERIFICATION FAILED - not publish-ready"
+            echo "================================================"
+            exit 1
+          fi
+          echo "All 5 packages pass verification."
+
+      # Platform packages publish first because the main package's
+      # optionalDependencies reference them. npm Trusted Publishing (OIDC)
+      # supplies auth automatically given `id-token: write` and the
+      # registered trusted publisher record. No NODE_AUTH_TOKEN is used.
+      # Each publish step is gated on either a tag-push trigger or a
+      # workflow_dispatch run with `publish: true`.
+
+      - name: Publish @decibri/decibri-win32-x64-msvc
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+        run: cd npm/platform-win32-x64-msvc && npm publish --access public
+
+      - name: Publish @decibri/decibri-darwin-arm64
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+        run: cd npm/platform-darwin-arm64 && npm publish --access public
+
+      - name: Publish @decibri/decibri-linux-x64-gnu
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+        run: cd npm/platform-linux-x64-gnu && npm publish --access public
+
+      - name: Publish @decibri/decibri-linux-arm64-gnu
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+        run: cd npm/platform-linux-arm64-gnu && npm publish --access public
+
+      - name: Publish decibri
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+        run: cd npm/decibri && npm publish --access public
+
+      - name: Create GitHub Release
+        if: github.event_name == 'push'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ github.ref_name }} \
+            --title "${{ github.ref_name }}" \
+            --generate-notes
+
+      - name: Verify npm publish
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+        # Strip the `npm-v` prefix from the tag so the `npm view` lookup
+        # uses the registry-side semver, not the literal tag name. Under
+        # workflow_dispatch the tag is HEAD's most recent tag or empty;
+        # the strip is a no-op for non-prefixed inputs.
+        shell: bash
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#npm-v}"
+          echo "Verifying npm registry view for decibri@${VERSION}"
+          sleep 30
+          npm view "decibri@${VERSION}"

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -28,11 +28,17 @@ on:
   push:
     tags:
       - 'python-v*'
-  # workflow_dispatch lets the maintainer run build-and-validate against the current
-  # branch without pushing a tag. The publish jobs skip cleanly because
-  # their if: conditions key on github.event_name == 'push'. Used for
-  # workflow YAML validation pre-tag (LD-10-8).
+  # workflow_dispatch lets the maintainer run build-and-validate against the
+  # current branch without pushing a tag. By default the publish jobs skip
+  # cleanly so workflow_dispatch acts as a dry run. Ticking the `publish`
+  # input promotes the run to a real publish (build-and-validate, then
+  # TestPyPI or PyPI per the same prerelease/stable routing as tag pushes).
   workflow_dispatch:
+    inputs:
+      publish:
+        type: boolean
+        default: false
+        description: 'Tick to actually publish. Unticked = dry run (build and validate only).'
 
 permissions:
   contents: read
@@ -424,15 +430,20 @@ jobs:
   publish-testpypi:
     name: Publish to TestPyPI
     # Prerelease tags (PEP 440 a / b / rc segments) route to TestPyPI.
-    # The github.event_name == 'push' guard ensures workflow_dispatch
-    # validation runs (LD-10-8) never publish; build-and-validate runs
-    # the matrix and the publish jobs skip cleanly.
+    # Tag pushes publish automatically. workflow_dispatch publishes only
+    # when the `publish` input is ticked; otherwise build-and-validate
+    # runs and this job skips, giving a dry-run path.
     if: |
-      github.event_name == 'push' && (
+      (github.event_name == 'push' && (
         contains(github.ref_name, 'a') ||
         contains(github.ref_name, 'b') ||
         contains(github.ref_name, 'rc')
-      )
+      )) ||
+      (github.event_name == 'workflow_dispatch' && inputs.publish == true && (
+        contains(github.ref_name, 'a') ||
+        contains(github.ref_name, 'b') ||
+        contains(github.ref_name, 'rc')
+      ))
     needs: [build-and-validate, build-sdist]
     runs-on: ubuntu-latest
     environment:
@@ -469,13 +480,18 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     # Stable tags (no PEP 440 a / b / rc segments) route to production
-    # PyPI. github.event_name == 'push' guard mirrors publish-testpypi.
+    # PyPI. The push guard and workflow_dispatch gate mirror publish-testpypi.
     if: |
-      github.event_name == 'push' && !(
+      (github.event_name == 'push' && !(
         contains(github.ref_name, 'a') ||
         contains(github.ref_name, 'b') ||
         contains(github.ref_name, 'rc')
-      )
+      )) ||
+      (github.event_name == 'workflow_dispatch' && inputs.publish == true && !(
+        contains(github.ref_name, 'a') ||
+        contains(github.ref_name, 'b') ||
+        contains(github.ref_name, 'rc')
+      ))
     needs: [build-and-validate, build-sdist]
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
- .github/workflows/publish-crates.yml: new. Publishes the Rust core on crate-v* tag pushes. Supports workflow_dispatch with a publish input defaulting to false for dry-run runs.
- .github/workflows/publish-npm.yml: new. Publishes the npm packages on npm-v* tag pushes. Same workflow_dispatch dry-run pattern.
- .github/workflows/publish-pypi.yml: add publish input to existing workflow_dispatch for dry-run runs. Tag-push behaviour unchanged.
- .github/workflows/check-upstream.yml: update ORT_VERSION grep target to publish-npm.yml.

Existing release.yml and release-dryrun.yml unchanged. The v* tag pattern continues to publish through release.yml as before.