### PR TITLE
fix: ship the Node.js-specific README to npmjs.com (3.4.2)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -325,12 +325,6 @@ jobs:
           ls -la npm/decibri/index.js
           ls -la npm/decibri/index.d.ts
 
-      - name: Copy README for npm package
-        # Copy the workspace README into the main npm package directory
-        # before the verify_pack gate runs so the main package's required
-        # README.md file check passes.
-        run: cp README.md npm/decibri/README.md
-
       - name: Verify npm package contents (pre-publish gate)
         # Defense-in-depth: verify npm package contents before any publish.
         # Runs in both publish and dry-run modes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [3.4.2] - 2026-05-24
+
+### Fixed
+
+- npm package now ships its Node.js-specific README to npmjs.com. The publish workflow previously copied the root README into the npm package directory at publish time, which meant the npmjs.com page for `decibri` showed a generic multi-language overview instead of the Node-focused documentation at `npm/decibri/README.md`. Removing the copy step lets the proper README ship.
+
 ## [3.4.1] - 2026-05-23
 
 ### Fixed

--- a/npm/decibri/package.json
+++ b/npm/decibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decibri",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Cross-platform audio capture, output, and processing for Node.js and browsers",
   "main": "src/decibri.js",
   "types": "src/decibri.d.ts",
@@ -70,10 +70,10 @@
     "README.md"
   ],
   "optionalDependencies": {
-    "@decibri/decibri-win32-x64-msvc": "3.4.1",
-    "@decibri/decibri-darwin-arm64": "3.4.1",
-    "@decibri/decibri-linux-x64-gnu": "3.4.1",
-    "@decibri/decibri-linux-arm64-gnu": "3.4.1"
+    "@decibri/decibri-win32-x64-msvc": "3.4.2",
+    "@decibri/decibri-darwin-arm64": "3.4.2",
+    "@decibri/decibri-linux-x64-gnu": "3.4.2",
+    "@decibri/decibri-linux-arm64-gnu": "3.4.2"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.0.0"

--- a/npm/platform-darwin-arm64/package.json
+++ b/npm/platform-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-darwin-arm64",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "os": ["darwin"],
   "cpu": ["arm64"],
   "main": "decibri.darwin-arm64.node",

--- a/npm/platform-linux-arm64-gnu/package.json
+++ b/npm/platform-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-arm64-gnu",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "os": ["linux"],
   "cpu": ["arm64"],
   "main": "decibri.linux-arm64-gnu.node",

--- a/npm/platform-linux-x64-gnu/package.json
+++ b/npm/platform-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-x64-gnu",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "os": ["linux"],
   "cpu": ["x64"],
   "main": "decibri.linux-x64-gnu.node",

--- a/npm/platform-win32-x64-msvc/package.json
+++ b/npm/platform-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-win32-x64-msvc",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "os": ["win32"],
   "cpu": ["x64"],
   "main": "decibri.win32-x64-msvc.node",


### PR DESCRIPTION
Remove the README copy step from publish-npm.yml that overwrote the npm package's Node.js-focused README with the root multi-language one at publish time. The on-disk npm/decibri/README.md now ships as intended.