### PR TITLE
ci: switch publish-crates.yml to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -13,8 +13,8 @@ on:
 
 permissions:
   # `contents: write` permits the `gh release create` step.
-  # `id-token: write` is reserved for future OIDC trusted-publishing flows
-  # and harmless to declare today (no step consumes it yet).
+  # `id-token: write` lets the `rust-lang/crates-io-auth-action` step
+  # exchange a GitHub OIDC token for a short-lived crates.io publish token.
   # `attestations: write` is reserved for a future attest-build-provenance
   # step against the .crate tarball.
   contents: write
@@ -84,6 +84,16 @@ jobs:
         # headers on Linux.
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev
 
+      - name: Authenticate to crates.io
+        # Exchanges a GitHub OIDC token for a short-lived crates.io publish
+        # token. The token is exposed via `steps.auth.outputs.token` and
+        # consumed by the next step's `CARGO_REGISTRY_TOKEN` env var.
+        if: |
+          (github.event_name == 'push' && !contains(github.ref, '-')) ||
+          (github.event_name == 'workflow_dispatch' && inputs.publish == true)
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
       - name: Publish to crates.io
         # Tag-push always publishes. workflow_dispatch publishes only when
         # the `publish` input is ticked. Pre-release tags (containing `-`
@@ -92,7 +102,7 @@ jobs:
           (github.event_name == 'push' && !contains(github.ref, '-')) ||
           (github.event_name == 'workflow_dispatch' && inputs.publish == true)
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo publish -p decibri
 
       - name: Create GitHub Release

--- a/crates/decibri/README.md
+++ b/crates/decibri/README.md
@@ -1,4 +1,4 @@
-# decibri (Rust)
+# Decibri (Rust)
 
 Cross-platform audio capture, playback, and voice activity detection for Rust applications.
 
@@ -6,7 +6,7 @@ Cross-platform audio capture, playback, and voice activity detection for Rust ap
 [![docs.rs](https://img.shields.io/docsrs/decibri)](https://docs.rs/decibri/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/decibri/decibri/blob/main/LICENSE)
 
-This is the Rust core of decibri. The same crate powers decibri's Python wheel (via PyO3) and Node.js native addon (via napi-rs); see the [main README](https://github.com/decibri/decibri) for the polyglot project context.
+This is the Rust core of decibri. The same crate powers decibri's Python wheel (via PyO3) and Node.js native addon (via napi-rs); see the [main README](https://github.com/decibri/decibri) for cross-language project context.
 
 ## Add to Cargo.toml
 


### PR DESCRIPTION
Use rust-lang/crates-io-auth-action to obtain a short-lived publish token at workflow runtime. Replaces the long-lived secret as the auth mechanism for cargo publish.