### PR TITLE
fix: release 3.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.4.0"
+version = "3.4.1"
 edition = "2021"
 # MSRV empirically verified 2026-04-22: rustc 1.88 is the minimum version
 # that compiles the workspace. Floors: ort 2.0.0-rc.12 declares

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -54,7 +54,7 @@ def test_version_decibri_matches_rust_core() -> None:
     # Literal equality per Phase 1 plan. When the Rust workspace bumps past
     # 3.4.0 this assertion breaks deliberately: force a conscious update of
     # the Python test expectation alongside the Rust version bump.
-    assert _decibri.MicrophoneBridge.version().decibri == "3.4.0"
+    assert _decibri.MicrophoneBridge.version().decibri == "3.4.1"
 
 
 def test_version_audio_backend_matches_cpal() -> None:
@@ -70,7 +70,7 @@ def test_version_info_fields() -> None:
     from decibri import _decibri
 
     info = _decibri.MicrophoneBridge.version()
-    assert info.decibri == "3.4.0"
+    assert info.decibri == "3.4.1"
     assert info.audio_backend == "cpal 0.17"
     assert info.binding == "0.1.3"
 

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -11,6 +11,12 @@ For other decibri packages, see:
 
 ## [Unreleased]
 
+## [3.4.1] - 2026-05-24
+
+### Fixed
+
+- Speaker example in `crates/decibri/README.md`: defined `pcm_int16_bytes` as `Vec<u8>` of 48000 zero bytes (1 second of int16 silence at 24kHz mono) so the example has a real value to send. Previously the example referenced `pcm_int16_bytes` without defining it, raising `error[E0425]: cannot find value 'pcm_int16_bytes' in this scope` on copy-paste.
+
 ## [3.4.0] - 2026-05-02
 
 ### Added


### PR DESCRIPTION
Fix the Speaker example in crates/decibri/README.md by defining pcm_int16_bytes. Previously the example referenced an undefined value causing E0425 on copy-paste.

First release through the new publish-crates.yml workflow using OIDC trusted publishing.