### PR TITLE
fix: release 3.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.4.1"
+version = "3.4.2"
 edition = "2021"
 # MSRV empirically verified 2026-04-22: rustc 1.88 is the minimum version
 # that compiles the workspace. Floors: ort 2.0.0-rc.12 declares

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -54,7 +54,7 @@ def test_version_decibri_matches_rust_core() -> None:
     # Literal equality per Phase 1 plan. When the Rust workspace bumps past
     # 3.4.0 this assertion breaks deliberately: force a conscious update of
     # the Python test expectation alongside the Rust version bump.
-    assert _decibri.MicrophoneBridge.version().decibri == "3.4.1"
+    assert _decibri.MicrophoneBridge.version().decibri == "3.4.2"
 
 
 def test_version_audio_backend_matches_cpal() -> None:
@@ -70,7 +70,7 @@ def test_version_info_fields() -> None:
     from decibri import _decibri
 
     info = _decibri.MicrophoneBridge.version()
-    assert info.decibri == "3.4.1"
+    assert info.decibri == "3.4.2"
     assert info.audio_backend == "cpal 0.17"
     assert info.binding == "0.1.3"
 

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Decibri Rust Core Changelog
 
-Changes to the decibri Rust core crate, published to crates.io. Tags use the `crate-v*` pattern (e.g., `crate-v3.4.1`).
+Changes to the decibri Rust core crate, published to crates.io. Tags use the `crate-v*` pattern (e.g., `crate-v3.4.2`).
 
 For other decibri packages, see:
 
@@ -11,7 +11,7 @@ For other decibri packages, see:
 
 ## [Unreleased]
 
-## [3.4.1] - 2026-05-24
+## [3.4.2] - 2026-05-25
 
 ### Fixed
 


### PR DESCRIPTION
Fix the Speaker example in crates/decibri/README.md by defining pcm_int16_bytes. Previously the example referenced an undefined value causing E0425 on copy-paste.