### PR TITLE
docs(python): align package summary to playback vocabulary

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,6 +1,6 @@
 # Decibri
 
-Cross-platform audio capture, output, and processing for Python.
+Cross-platform audio capture, playback, and processing for Python.
 
 [![PyPI version](https://img.shields.io/pypi/v/decibri.svg)](https://pypi.org/project/decibri/)
 [![Python versions](https://img.shields.io/pypi/pyversions/decibri.svg)](https://pypi.org/project/decibri/)

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "decibri"
 version = "0.2.0"
-description = "Cross-platform audio capture, output, and voice activity detection"
+description = "Cross-platform audio capture, playback, and voice activity detection"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Change the Python package summary from "capture, output" to "capture, playback" to match the core feature vocabulary, before the 0.2.0 production publish.

- bindings/python/pyproject.toml: description field output to playback
- bindings/python/README.md: tagline output to playback

Description text only; no code, API, or version change. The 0.2.0 version bump and renames are already on main from the prior merge; this is a wording fix on top.