### PR TITLE
fix(core): device-index error message + 4.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "decibri"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "cpal",
  "crossbeam-channel",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "decibri-node"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "decibri",
  "napi",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "decibri-python"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "decibri",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.0.0"
+version = "4.0.1"
 edition = "2021"
 # MSRV empirically verified 2026-04-22: rustc 1.88 is the minimum version
 # that compiles the workspace. Floors: ort 2.0.0-rc.12 declares

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -54,7 +54,7 @@ def test_version_decibri_matches_rust_core() -> None:
     # Literal equality is intentional. When the Rust workspace bumps past
     # 4.0.0 this assertion breaks deliberately, to force a conscious update of
     # the Python expectation alongside the Rust version bump.
-    assert _decibri.MicrophoneBridge.version().decibri == "4.0.0"
+    assert _decibri.MicrophoneBridge.version().decibri == "4.0.1"
 
 
 def test_version_audio_backend_matches_cpal() -> None:
@@ -70,7 +70,7 @@ def test_version_info_fields() -> None:
     from decibri import _decibri
 
     info = _decibri.MicrophoneBridge.version()
-    assert info.decibri == "4.0.0"
+    assert info.decibri == "4.0.1"
     assert info.audio_backend == "cpal 0.17"
     assert info.binding == "0.2.0"
 

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -11,6 +11,12 @@ For other decibri packages, see:
 
 ## [Unreleased]
 
+## [4.0.1] - 2026-05-30
+
+### Fixed
+
+- **Device-index error message.** `DeviceIndexOutOfRange` no longer references a class name that was removed in the 4.0.0 rename. The message keeps its `device index out of range` prefix and now points at the neutral `devices()` enumeration, so the guidance is direction-agnostic and names no removed type.
+
 ## [4.0.0] - 2026-05-30
 
 Renames the public API to a microphone/speaker vocabulary. This is a breaking

--- a/crates/decibri/src/error.rs
+++ b/crates/decibri/src/error.rs
@@ -59,7 +59,7 @@ pub enum DecibriError {
     #[error("Multiple devices match \"{name}\":\n{matches}")]
     MultipleDevicesMatch { name: String, matches: String },
 
-    #[error("device index out of range. Call Decibri.devices() to list available devices")]
+    #[error("device index out of range. Call devices() to list available devices")]
     DeviceIndexOutOfRange,
 
     #[error("No microphone found. Check system audio input settings.")]


### PR DESCRIPTION
Patch release. Corrects the DeviceIndexOutOfRange error message, which still named the removed Decibri class after the 4.0.0 rename. The message now points at the neutral devices() and keeps the "device index out of range" prefix that callers match on. Bumps the workspace to 4.0.1 and updates the Python binding's pinned core-version assertions to match.

- crates/decibri/src/error.rs: reword DeviceIndexOutOfRange (direction-agnostic, prefix preserved)
- Cargo.toml: workspace version 4.0.0 to 4.0.1
- bindings/python/tests/test_smoke.py: pinned core-version assertions 4.0.0 to 4.0.1
- crates/decibri/CHANGELOG.md: [4.0.1] entry