### PR TITLE
release(python): decibri 0.2.1 (picks up core 4.0.1 device-index message fix)

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -8,6 +8,12 @@ For Rust core (`crates/decibri`) and npm binding (`bindings/node`) changes, see 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-05-30
+
+### Fixed
+
+- Device-index error message. Passing an out-of-range device index no longer produces a message that names a class removed in the rename. The fix is picked up from the decibri Rust core 4.0.1; the message now points at the neutral `devices()` enumeration.
+
 ## [0.2.0] - 2026-05-30
 
 ### Python binding

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -28,7 +28,7 @@ crate-type = ["cdylib"]
 # features across both bindings silently; diverging overrides produce a build
 # that neither binding tests in isolation. Both bindings inherit decibri's
 # default features (capture, playback, vad, denoise, gain, ort-load-dynamic).
-decibri = { version = "4.0.0", path = "../../crates/decibri" }
+decibri = { version = "4.0.1", path = "../../crates/decibri" }
 
 # PyO3 0.28 is the first MSRV-1.83 release line with the attach / detach /
 # initialize API renames; aligns with workspace MSRV 1.88 (headroom preserved).

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "decibri"
-version = "0.2.0"
+version = "0.2.1"
 description = "Cross-platform audio capture, playback, and voice activity detection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/python/python/decibri/__init__.py
+++ b/bindings/python/python/decibri/__init__.py
@@ -51,7 +51,7 @@ from decibri.exceptions import (
     VadThresholdOutOfRange,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 
 def input_devices() -> list[MicrophoneInfo]:

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -422,7 +422,7 @@ fn build_version_info() -> VersionInfo {
     VersionInfo {
         decibri: env!("CARGO_PKG_VERSION").to_string(),
         audio_backend: format!("cpal {}", CPAL_VERSION),
-        binding: "0.2.0".to_string(),
+        binding: "0.2.1".to_string(),
     }
 }
 

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -16,7 +16,7 @@ import decibri
 
 
 def test_package_imports() -> None:
-    assert decibri.__version__ == "0.2.0"
+    assert decibri.__version__ == "0.2.1"
     # The bridges are hidden behind the private _decibri module. They are
     # NOT accessible at decibri.<X> top level (sync or async). The async
     # pair was never accessible at the top level; the sync pair
@@ -72,7 +72,7 @@ def test_version_info_fields() -> None:
     info = _decibri.MicrophoneBridge.version()
     assert info.decibri == "4.0.1"
     assert info.audio_backend == "cpal 0.17"
-    assert info.binding == "0.2.0"
+    assert info.binding == "0.2.1"
 
 
 def test_version_info_is_frozen() -> None:

--- a/bindings/python/tests/test_wheel_smoke.py
+++ b/bindings/python/tests/test_wheel_smoke.py
@@ -29,7 +29,7 @@ def test_import_decibri() -> None:
     """The package imports successfully from the installed wheel."""
     assert decibri is not None
     assert hasattr(decibri, "__version__")
-    assert decibri.__version__ == "0.2.0"
+    assert decibri.__version__ == "0.2.1"
 
 
 def test_construct_decibri_default() -> None:

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -27,7 +27,7 @@ wheels = [
 
 [[package]]
 name = "decibri"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions" },


### PR DESCRIPTION
Patch release. Rebuilds the Python package against the Rust core 4.0.1 so it carries the corrected DeviceIndexOutOfRange message (the prior text named a class removed in the rename). No API or wrapper-logic change.

- bindings/python/Cargo.toml: core dependency pin 4.0.0 to 4.0.1
- version bump to 0.2.1 across pyproject.toml, __version__, the bridge binding string, and the test assertions; uv.lock regenerated
- bindings/python/CHANGELOG.md: [0.2.1] entry
