### PR TITLE
docs: update root README examples to the microphone/speaker API

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ Full Python guide: [here](bindings/python/README.md).
 ### Node.js
 
 ```javascript
-const Decibri = require('decibri');
+const { Microphone } = require('decibri');
 
-const mic = new Decibri({ sampleRate: 16000 });
+const mic = new Microphone({ sampleRate: 16000 });
 mic.on('data', (chunk) => console.log(`Got ${chunk.length} bytes`));
 setTimeout(() => mic.stop(), 5000);
 ```
@@ -98,11 +98,11 @@ Full Node.js and browser guide: [here](npm/decibri/README.md).
 ### Rust
 
 ```rust
-use decibri::capture::{AudioCapture, CaptureConfig};
+use decibri::{Microphone, MicrophoneConfig};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let capture = AudioCapture::new(CaptureConfig::default())?;
-    let stream = capture.start()?;
+    let microphone = Microphone::new(MicrophoneConfig::default())?;
+    let stream = microphone.start()?;
     while let Ok(Some(chunk)) = stream.next_chunk(None) {
         println!("Got {} bytes", chunk.data.len());
     }


### PR DESCRIPTION
Updates the two Quick Start code examples in the repository README to the shipped 4.x API. The Node.js example uses named exports and the Microphone class; the Rust example uses decibri::{Microphone, MicrophoneConfig} instead of the removed capture module types. The rest of the README (tagline, Python examples, version badges) was already current. Docs only, no package or version change.