### PR TITLE
release(node): decibri 4.1.0 (non-blocking async I/O surface)

### DIFF
--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -4,6 +4,7 @@ use std::thread;
 
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::ThreadsafeFunctionCallMode;
+use napi::{Env, Task};
 use napi_derive::napi;
 
 use decibri::device::{self, DeviceSelector};
@@ -71,76 +72,148 @@ pub struct DecibriBridge {
     vad_probability: Arc<AtomicU32>,
 }
 
+/// The `Send` pieces of a microphone bridge produced by the open work: the
+/// resolved device wrapped in a `Microphone` and the (optionally) loaded Silero
+/// model. Holding these lets the blocking open work run off the JS thread in an
+/// `AsyncTask` and the bridge be assembled back on the JS thread in `resolve`.
+/// Every field here is `Send`, so the whole struct can cross the libuv boundary:
+/// `Microphone` owns only config plus a `cpal::Device` (Send + Sync), and
+/// `SileroVad` already crosses threads in the capture pump. The `!Send`
+/// `cpal::Stream` is not created here; it is opened later in `start`.
+pub struct MicrophoneParts {
+    capture: Microphone,
+    format: SampleFormat,
+    frames_per_buffer: u32,
+    channels: u16,
+    vad: Option<SileroVad>,
+}
+
+/// Resolve the device and load the Silero model. This is the blocking open work
+/// shared by the synchronous constructor and the async `openAsync` task. It is
+/// safe to run off the JS thread: it touches no napi/JS state and produces only
+/// `Send` values. The Silero model load is the slow part (roughly 100 to 500 ms
+/// on a cold cache); device resolution is fast.
+fn build_microphone_parts(options: Option<DecibriOptions>) -> Result<MicrophoneParts> {
+    let opts = options.unwrap_or_default();
+
+    let sample_rate = opts.sample_rate.unwrap_or(16000);
+    let channels = opts.channels.unwrap_or(1) as u16;
+    let frames_per_buffer = opts.frames_per_buffer.unwrap_or(1600);
+
+    let format_str = opts.format.as_deref().unwrap_or("int16");
+    let format = match format_str {
+        "int16" => SampleFormat::Int16,
+        "float32" => SampleFormat::Float32,
+        _ => {
+            return Err(Error::new(
+                Status::InvalidArg,
+                "format must be 'int16' or 'float32'",
+            ))
+        }
+    };
+
+    let device = resolve_device_option(&opts.device)?;
+
+    let config = MicrophoneConfig {
+        sample_rate,
+        channels,
+        frames_per_buffer,
+        device,
+    };
+
+    let capture = Microphone::new(config).map_err(to_napi_error)?;
+
+    // Silero VAD: load model if vadMode is 'silero'
+    let vad_mode = opts.vad_mode.as_deref().unwrap_or("energy");
+    let vad = if vad_mode == "silero" {
+        let model_path = opts.model_path.ok_or_else(|| {
+            Error::new(
+                Status::InvalidArg,
+                "modelPath is required when vadMode is 'silero'",
+            )
+        })?;
+        let vad_config = VadConfig {
+            model_path: std::path::PathBuf::from(model_path),
+            sample_rate,
+            threshold: 0.5, // JS wrapper controls the actual threshold
+            // Populated by the JS wrapper from require.resolve on the
+            // resolved platform package. When `None`, Rust falls through
+            // to `ort::init()` which honours the `ORT_DYLIB_PATH` env var.
+            ort_library_path: opts
+                .ort_library_path
+                .as_deref()
+                .map(std::path::PathBuf::from),
+        };
+        Some(SileroVad::new(vad_config).map_err(to_napi_error)?)
+    } else {
+        None
+    };
+
+    Ok(MicrophoneParts {
+        capture,
+        format,
+        frames_per_buffer,
+        channels,
+        vad,
+    })
+}
+
+impl MicrophoneParts {
+    /// Assemble the bridge from the loaded parts. No blocking work: just struct
+    /// assembly with fresh runtime state. Runs on the JS thread (either inside
+    /// the synchronous constructor or in the async task's `resolve`).
+    fn into_bridge(self) -> DecibriBridge {
+        DecibriBridge {
+            capture: Some(self.capture),
+            stream: None,
+            format: self.format,
+            frames_per_buffer: self.frames_per_buffer,
+            channels: self.channels,
+            running: Arc::new(AtomicBool::new(false)),
+            pump_handle: None,
+            vad: self.vad,
+            vad_probability: Arc::new(AtomicU32::new(0)),
+        }
+    }
+}
+
+/// Background task that performs the blocking microphone open work (device
+/// resolution and the Silero model load) on the libuv thread pool, off the JS
+/// event loop, then resolves to a constructed bridge on the JS thread. A failed
+/// open propagates through the default `reject`, rejecting the Promise with the
+/// matching error.
+pub struct OpenMicrophoneTask {
+    options: Option<DecibriOptions>,
+}
+
+impl Task for OpenMicrophoneTask {
+    type Output = MicrophoneParts;
+    type JsValue = DecibriBridge;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        build_microphone_parts(self.options.take())
+    }
+
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        Ok(output.into_bridge())
+    }
+}
+
 #[napi]
 impl DecibriBridge {
     #[napi(constructor)]
     pub fn new(options: Option<DecibriOptions>) -> Result<Self> {
-        let opts = options.unwrap_or_default();
+        Ok(build_microphone_parts(options)?.into_bridge())
+    }
 
-        let sample_rate = opts.sample_rate.unwrap_or(16000);
-        let channels = opts.channels.unwrap_or(1) as u16;
-        let frames_per_buffer = opts.frames_per_buffer.unwrap_or(1600);
-
-        let format_str = opts.format.as_deref().unwrap_or("int16");
-        let format = match format_str {
-            "int16" => SampleFormat::Int16,
-            "float32" => SampleFormat::Float32,
-            _ => {
-                return Err(Error::new(
-                    Status::InvalidArg,
-                    "format must be 'int16' or 'float32'",
-                ))
-            }
-        };
-
-        let device = resolve_device_option(&opts.device)?;
-
-        let config = MicrophoneConfig {
-            sample_rate,
-            channels,
-            frames_per_buffer,
-            device,
-        };
-
-        let capture = Microphone::new(config).map_err(to_napi_error)?;
-
-        // Silero VAD: load model if vadMode is 'silero'
-        let vad_mode = opts.vad_mode.as_deref().unwrap_or("energy");
-        let vad = if vad_mode == "silero" {
-            let model_path = opts.model_path.ok_or_else(|| {
-                Error::new(
-                    Status::InvalidArg,
-                    "modelPath is required when vadMode is 'silero'",
-                )
-            })?;
-            let vad_config = VadConfig {
-                model_path: std::path::PathBuf::from(model_path),
-                sample_rate,
-                threshold: 0.5, // JS wrapper controls the actual threshold
-                // Populated by the JS wrapper from require.resolve on the
-                // resolved platform package. When `None`, Rust falls through
-                // to `ort::init()` which honours the `ORT_DYLIB_PATH` env var.
-                ort_library_path: opts
-                    .ort_library_path
-                    .as_deref()
-                    .map(std::path::PathBuf::from),
-            };
-            Some(SileroVad::new(vad_config).map_err(to_napi_error)?)
-        } else {
-            None
-        };
-
-        Ok(Self {
-            capture: Some(capture),
-            stream: None,
-            format,
-            frames_per_buffer,
-            channels,
-            running: Arc::new(AtomicBool::new(false)),
-            pump_handle: None,
-            vad,
-            vad_probability: Arc::new(AtomicU32::new(0)),
-        })
+    /// Construct a microphone bridge without blocking the JS event loop. The
+    /// device resolution and Silero model load run on the libuv thread pool;
+    /// the returned Promise resolves to a fully constructed bridge, or rejects
+    /// with the matching error. The synchronous `new` remains available and
+    /// unchanged.
+    #[napi]
+    pub fn open_async(options: Option<DecibriOptions>) -> AsyncTask<OpenMicrophoneTask> {
+        AsyncTask::new(OpenMicrophoneTask { options })
     }
 
     /// Start capturing audio. The callback receives `(err, chunk)` for each buffer.
@@ -418,42 +491,96 @@ pub struct DecibriOutputBridge {
     format: SampleFormat,
 }
 
+/// The `Send` pieces of a speaker bridge produced by the open work. Unlike the
+/// microphone, there is no model to load: the only open work is device
+/// resolution, so `Speaker.open()` exists chiefly for API parity with
+/// `Microphone.open()` (and the Python `AsyncSpeaker.open()`). `Speaker` owns
+/// only config plus a `cpal::Device` (Send + Sync), so this struct is `Send`;
+/// the `!Send` `cpal::Stream` is opened lazily on the first write, not here.
+pub struct SpeakerParts {
+    output: Speaker,
+    format: SampleFormat,
+}
+
+/// Resolve the output device. Shared by the synchronous constructor and the
+/// async `openAsync` task; safe to run off the JS thread and produces only
+/// `Send` values.
+fn build_speaker_parts(options: Option<DecibriOutputOptions>) -> Result<SpeakerParts> {
+    let opts = options.unwrap_or_default();
+
+    let sample_rate = opts.sample_rate.unwrap_or(16000);
+    let channels = opts.channels.unwrap_or(1) as u16;
+
+    let format_str = opts.format.as_deref().unwrap_or("int16");
+    let format = match format_str {
+        "int16" => SampleFormat::Int16,
+        "float32" => SampleFormat::Float32,
+        _ => {
+            return Err(Error::new(
+                Status::InvalidArg,
+                "format must be 'int16' or 'float32'",
+            ))
+        }
+    };
+
+    let device = resolve_device_option(&opts.device)?;
+
+    let config = SpeakerConfig {
+        sample_rate,
+        channels,
+        device,
+    };
+
+    let output = Speaker::new(config).map_err(to_napi_error)?;
+
+    Ok(SpeakerParts { output, format })
+}
+
+impl SpeakerParts {
+    /// Assemble the bridge from the resolved parts. Runs on the JS thread.
+    fn into_bridge(self) -> DecibriOutputBridge {
+        DecibriOutputBridge {
+            output: Some(self.output),
+            stream: None,
+            format: self.format,
+        }
+    }
+}
+
+/// Background task that performs the speaker open work (device resolution) on
+/// the libuv thread pool, then resolves to a constructed bridge on the JS
+/// thread. A failed open rejects the Promise with the matching error.
+pub struct OpenSpeakerTask {
+    options: Option<DecibriOutputOptions>,
+}
+
+impl Task for OpenSpeakerTask {
+    type Output = SpeakerParts;
+    type JsValue = DecibriOutputBridge;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        build_speaker_parts(self.options.take())
+    }
+
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        Ok(output.into_bridge())
+    }
+}
+
 #[napi]
 impl DecibriOutputBridge {
     #[napi(constructor)]
     pub fn new(options: Option<DecibriOutputOptions>) -> Result<Self> {
-        let opts = options.unwrap_or_default();
+        Ok(build_speaker_parts(options)?.into_bridge())
+    }
 
-        let sample_rate = opts.sample_rate.unwrap_or(16000);
-        let channels = opts.channels.unwrap_or(1) as u16;
-
-        let format_str = opts.format.as_deref().unwrap_or("int16");
-        let format = match format_str {
-            "int16" => SampleFormat::Int16,
-            "float32" => SampleFormat::Float32,
-            _ => {
-                return Err(Error::new(
-                    Status::InvalidArg,
-                    "format must be 'int16' or 'float32'",
-                ))
-            }
-        };
-
-        let device = resolve_device_option(&opts.device)?;
-
-        let config = SpeakerConfig {
-            sample_rate,
-            channels,
-            device,
-        };
-
-        let output = Speaker::new(config).map_err(to_napi_error)?;
-
-        Ok(Self {
-            output: Some(output),
-            stream: None,
-            format,
-        })
+    /// Construct a speaker bridge without blocking the JS event loop. The device
+    /// resolution runs on the libuv thread pool; the returned Promise resolves
+    /// to a constructed bridge, or rejects with the matching error. The
+    /// synchronous `new` remains available and unchanged.
+    #[napi]
+    pub fn open_async(options: Option<DecibriOutputOptions>) -> AsyncTask<OpenSpeakerTask> {
+        AsyncTask::new(OpenSpeakerTask { options })
     }
 
     /// Write PCM data for playback. Starts the output stream on first call.

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -10,7 +10,7 @@ use napi_derive::napi;
 use decibri::device::{self, DeviceSelector};
 use decibri::microphone::{Microphone, MicrophoneConfig, MicrophoneStream};
 use decibri::sample;
-use decibri::speaker::{Speaker, SpeakerConfig, SpeakerStream};
+use decibri::speaker::{Speaker, SpeakerConfig, SpeakerSink, SpeakerStream};
 use decibri::vad::{SileroVad, VadConfig};
 use decibri::CPAL_VERSION;
 
@@ -78,8 +78,8 @@ pub struct DecibriBridge {
 /// `AsyncTask` and the bridge be assembled back on the JS thread in `resolve`.
 /// Every field here is `Send`, so the whole struct can cross the libuv boundary:
 /// `Microphone` owns only config plus a `cpal::Device` (Send + Sync), and
-/// `SileroVad` already crosses threads in the capture pump. The `!Send`
-/// `cpal::Stream` is not created here; it is opened later in `start`.
+/// `SileroVad` already crosses threads in the capture pump. The `cpal::Stream`
+/// is not created here; it is opened later in `start`.
 pub struct MicrophoneParts {
     capture: Microphone,
     format: SampleFormat,
@@ -488,6 +488,11 @@ pub struct OutputDeviceInfoJs {
 pub struct DecibriOutputBridge {
     output: Option<Speaker>,
     stream: Option<SpeakerStream>,
+    /// A `Send` handle to the live stream's channel and drain state, captured
+    /// when the `stream` is created. The async write/drain tasks clone this to do
+    /// the blocking work off the JS thread without holding the `stream`, which the
+    /// bridge keeps on the JS thread. `None` until the stream is first created.
+    sink: Option<SpeakerSink>,
     format: SampleFormat,
 }
 
@@ -496,7 +501,7 @@ pub struct DecibriOutputBridge {
 /// resolution, so `Speaker.open()` exists chiefly for API parity with
 /// `Microphone.open()` (and the Python `AsyncSpeaker.open()`). `Speaker` owns
 /// only config plus a `cpal::Device` (Send + Sync), so this struct is `Send`;
-/// the `!Send` `cpal::Stream` is opened lazily on the first write, not here.
+/// the `cpal::Stream` is opened lazily on the first write, not here.
 pub struct SpeakerParts {
     output: Speaker,
     format: SampleFormat,
@@ -542,8 +547,63 @@ impl SpeakerParts {
         DecibriOutputBridge {
             output: Some(self.output),
             stream: None,
+            sink: None,
             format: self.format,
         }
+    }
+}
+
+/// Background task that performs the blocking channel `send` (write under
+/// backpressure) off the JS event loop. It holds only `Send` primitives: a clone
+/// of the stream's crossbeam `Sender` (wrapped in a `SpeakerSink`) and the
+/// already-converted samples. The `cpal::Stream` is not touched here; because the
+/// sink is lock-free, the offloaded `send` cannot block the JS thread's `stop` or
+/// `is_playing`. A closed stream rejects the Promise with `SpeakerStreamClosed`.
+/// An empty task (no sink) is a no-op for empty writes.
+pub struct WriteTask {
+    sink: Option<SpeakerSink>,
+    samples: Option<Vec<f32>>,
+}
+
+impl Task for WriteTask {
+    type Output = ();
+    type JsValue = ();
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        if let (Some(sink), Some(samples)) = (self.sink.as_ref(), self.samples.take()) {
+            sink.send(samples).map_err(to_napi_error)?;
+        }
+        Ok(())
+    }
+
+    fn resolve(&mut self, _env: Env, _output: Self::Output) -> Result<Self::JsValue> {
+        Ok(())
+    }
+}
+
+/// Background task that performs the drain wait (the poll loop that blocks until
+/// the cpal callback has played everything queued) off the JS event loop. It
+/// holds only a `Send` `SpeakerSink` clone and never touches the `cpal::Stream`;
+/// because the sink is lock-free, a long drain never blocks the JS thread's
+/// `stop` or `is_playing`. With no stream yet created the sink is `None` and the
+/// drain is a no-op that resolves immediately, matching the synchronous `drain`.
+pub struct DrainTask {
+    sink: Option<SpeakerSink>,
+}
+
+impl Task for DrainTask {
+    type Output = ();
+    type JsValue = ();
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        if let Some(sink) = self.sink.as_ref() {
+            sink.drain();
+        }
+        Ok(())
+    }
+
+    fn resolve(&mut self, _env: Env, _output: Self::Output) -> Result<Self::JsValue> {
+        Ok(())
     }
 }
 
@@ -583,6 +643,22 @@ impl DecibriOutputBridge {
         AsyncTask::new(OpenSpeakerTask { options })
     }
 
+    /// Open the output stream on first use, capturing the stream (kept on the JS
+    /// thread by the bridge) and a `Send` sink handle (used by the async tasks).
+    /// Idempotent: a no-op once the stream exists. Always runs on the JS thread.
+    fn ensure_stream(&mut self) -> Result<()> {
+        if self.stream.is_none() {
+            let output = self
+                .output
+                .as_ref()
+                .ok_or_else(|| Error::new(Status::GenericFailure, "Output not initialized"))?;
+            let stream = output.start().map_err(to_napi_error)?;
+            self.sink = Some(stream.sink());
+            self.stream = Some(stream);
+        }
+        Ok(())
+    }
+
     /// Write PCM data for playback. Starts the output stream on first call.
     /// Empty buffers are a no-op.
     #[napi]
@@ -592,14 +668,7 @@ impl DecibriOutputBridge {
         }
 
         // Start stream on first write
-        if self.stream.is_none() {
-            let output = self
-                .output
-                .as_ref()
-                .ok_or_else(|| Error::new(Status::GenericFailure, "Output not initialized"))?;
-            let stream = output.start().map_err(to_napi_error)?;
-            self.stream = Some(stream);
-        }
+        self.ensure_stream()?;
 
         let samples = match self.format {
             SampleFormat::Int16 => sample::i16_le_bytes_to_f32(&buffer),
@@ -613,12 +682,52 @@ impl DecibriOutputBridge {
             .map_err(to_napi_error)
     }
 
+    /// Non-blocking write: convert the samples and start the stream on the JS
+    /// thread (a fast device open, same as the synchronous first write), then
+    /// perform the blocking channel `send` (which stalls under backpressure when
+    /// the queue is full) on the libuv thread pool. The returned Promise
+    /// resolves when the samples are queued, or rejects with the matching error.
+    /// Empty buffers resolve immediately. The synchronous `write` is unchanged.
+    #[napi]
+    pub fn write_async(&mut self, buffer: Buffer) -> Result<AsyncTask<WriteTask>> {
+        if buffer.is_empty() {
+            return Ok(AsyncTask::new(WriteTask {
+                sink: None,
+                samples: None,
+            }));
+        }
+
+        // Stream creation stays on the JS thread; only the lock-free send is offloaded.
+        self.ensure_stream()?;
+
+        let samples = match self.format {
+            SampleFormat::Int16 => sample::i16_le_bytes_to_f32(&buffer),
+            SampleFormat::Float32 => sample::f32_le_bytes_to_f32(&buffer),
+        };
+
+        Ok(AsyncTask::new(WriteTask {
+            sink: self.sink.clone(),
+            samples: Some(samples),
+        }))
+    }
+
     /// Graceful drain: blocks until all queued samples have been played.
     #[napi]
     pub fn drain(&self) {
         if let Some(stream) = self.stream.as_ref() {
             stream.drain();
         }
+    }
+
+    /// Non-blocking drain: the poll loop that waits for the cpal callback to play
+    /// everything queued runs on the libuv thread pool instead of the event loop.
+    /// The returned Promise resolves when the buffer has drained. With no stream
+    /// yet created it resolves immediately. The synchronous `drain` is unchanged.
+    #[napi]
+    pub fn drain_async(&self) -> AsyncTask<DrainTask> {
+        AsyncTask::new(DrainTask {
+            sink: self.sink.clone(),
+        })
     }
 
     /// Immediate stop. Discards remaining samples.
@@ -628,6 +737,7 @@ impl DecibriOutputBridge {
             stream.stop();
         }
         self.stream = None;
+        self.sink = None;
     }
 
     /// Whether audio is currently being output.

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -11,6 +11,10 @@ For other decibri packages, see:
 
 ## [Unreleased]
 
+### Added
+
+- `SpeakerSink`: a cloneable, `Send + Sync` handle to a running `SpeakerStream`'s sample channel and drain state, obtained from `SpeakerStream::sink()`. It exposes `send()` and `drain()` with the same semantics as the stream's. `SpeakerStream` is `Send`; a `SpeakerSink` is a cheaper, lock-free companion that clones only the thread-safe primitives (the channel sender and the atomic flags), so callers can push samples or wait for drain from another thread (for example a worker pool) without holding the stream, and the off-thread work never blocks a holder of the stream that needs `stop()` or `is_playing()`. The stream must stay alive while a sink is in use; a `send` on a surviving sink after the stream is dropped returns `SpeakerStreamClosed`. Additive: `SpeakerStream` and its methods are unchanged.
+
 ## [4.0.1] - 2026-05-30
 
 ### Fixed

--- a/crates/decibri/src/lib.rs
+++ b/crates/decibri/src/lib.rs
@@ -220,7 +220,7 @@ pub mod gain;
 pub use microphone::{AudioChunk, Microphone, MicrophoneConfig, MicrophoneStream};
 
 #[cfg(feature = "playback")]
-pub use speaker::{Speaker, SpeakerConfig, SpeakerStream};
+pub use speaker::{Speaker, SpeakerConfig, SpeakerSink, SpeakerStream};
 
 #[cfg(any(feature = "capture", feature = "playback"))]
 pub use device::{input_devices, output_devices, DeviceSelector, MicrophoneInfo, SpeakerInfo};

--- a/crates/decibri/src/speaker.rs
+++ b/crates/decibri/src/speaker.rs
@@ -131,6 +131,72 @@ impl SpeakerStream {
         // Drop all pending samples by draining the channel
         while self.sender.try_send(Vec::new()).is_ok() {}
     }
+
+    /// A cloneable, `Send` handle to this stream's sample channel and drain
+    /// state. Use it to push samples or wait for drain from another thread (for
+    /// example a worker pool) without holding the `SpeakerStream` itself. Because
+    /// the handle clones only the lock-free channel sender and atomic flags, its
+    /// off-thread `send` and `drain` never block a holder of the stream that
+    /// needs `stop` or `is_playing`.
+    ///
+    /// The handle shares the same crossbeam channel and atomic drain flags as
+    /// the stream, so [`SpeakerSink::send`] and [`SpeakerSink::drain`] behave
+    /// exactly like their [`SpeakerStream`] counterparts. The stream must stay
+    /// alive while a sink is in use: dropping the `SpeakerStream` releases the
+    /// device, after which a `send` on a surviving sink returns
+    /// [`DecibriError::SpeakerStreamClosed`] rather than playing.
+    pub fn sink(&self) -> SpeakerSink {
+        SpeakerSink {
+            sender: self.sender.clone(),
+            running: self.running.clone(),
+            drain_complete: self.drain_complete.clone(),
+        }
+    }
+}
+
+/// A cloneable, `Send` handle to a running [`SpeakerStream`]'s sample channel
+/// and drain state.
+///
+/// Obtained from [`SpeakerStream::sink`]. The `SpeakerStream` itself is `Send`,
+/// so it can be held wherever its owner likes; a `SpeakerSink` is a cheaper,
+/// lock-free companion that clones only the thread-safe pieces (the crossbeam
+/// channel sender and the atomic flags) and is `Send + Sync + Clone`. Several
+/// threads can push samples or wait for drain through sinks at once, and because
+/// a sink never touches the audio stream handle, its `send` and `drain` cannot
+/// block whoever holds the `SpeakerStream` and needs `stop` or `is_playing`.
+#[cfg(feature = "playback")]
+#[derive(Clone)]
+pub struct SpeakerSink {
+    sender: Sender<Vec<f32>>,
+    running: Arc<AtomicBool>,
+    drain_complete: Arc<AtomicBool>,
+}
+
+#[cfg(feature = "playback")]
+impl SpeakerSink {
+    /// Send `f32` samples for playback. Identical semantics to
+    /// [`SpeakerStream::send`]: blocks when the internal buffer is full
+    /// (backpressure), treats an empty vector as a no-op, and returns
+    /// [`DecibriError::SpeakerStreamClosed`] once the stream has stopped.
+    pub fn send(&self, samples: Vec<f32>) -> Result<(), DecibriError> {
+        if samples.is_empty() {
+            return Ok(());
+        }
+        self.sender
+            .send(samples)
+            .map_err(|_| DecibriError::SpeakerStreamClosed)
+    }
+
+    /// Block until all queued samples have played. Identical semantics to
+    /// [`SpeakerStream::drain`]: sends a sentinel, polls the shared drain flag,
+    /// then marks the stream no longer playing.
+    pub fn drain(&self) {
+        let _ = self.sender.send(Vec::new());
+        while !self.drain_complete.load(Ordering::Relaxed) {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        self.running.store(false, Ordering::Relaxed);
+    }
 }
 
 /// An output device you play audio to.

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -11,6 +11,8 @@ For other decibri packages, see:
 
 ## [Unreleased]
 
+## [4.1.0] - 2026-05-31
+
 ### Added
 
 - Async factories `Microphone.open(options)` and `Speaker.open(options)`, each returning a `Promise` that resolves to a constructed instance. They perform the blocking open work (the Silero VAD model load for the microphone; device resolution for both) on the native thread pool instead of the event loop, so latency-sensitive callers do not stall during construction. A failed open rejects with the matching error (`RangeError` / `TypeError` for invalid options, `DeviceError` / `OrtError` / `OrtPathError` for native failures). The synchronous `new Microphone(...)` and `new Speaker(...)` constructors are unchanged; the factories are an additive, non-blocking alternative that mirrors the Python `AsyncMicrophone.open()` / `AsyncSpeaker.open()` surface.

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -11,6 +11,10 @@ For other decibri packages, see:
 
 ## [Unreleased]
 
+### Added
+
+- Async factories `Microphone.open(options)` and `Speaker.open(options)`, each returning a `Promise` that resolves to a constructed instance. They perform the blocking open work (the Silero VAD model load for the microphone; device resolution for both) on the native thread pool instead of the event loop, so latency-sensitive callers do not stall during construction. A failed open rejects with the matching error (`RangeError` / `TypeError` for invalid options, `DeviceError` / `OrtError` / `OrtPathError` for native failures). The synchronous `new Microphone(...)` and `new Speaker(...)` constructors are unchanged; the factories are an additive, non-blocking alternative that mirrors the Python `AsyncMicrophone.open()` / `AsyncSpeaker.open()` surface.
+
 ## [4.0.0] - 2026-05-30
 
 ### Changed

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -14,6 +14,7 @@ For other decibri packages, see:
 ### Added
 
 - Async factories `Microphone.open(options)` and `Speaker.open(options)`, each returning a `Promise` that resolves to a constructed instance. They perform the blocking open work (the Silero VAD model load for the microphone; device resolution for both) on the native thread pool instead of the event loop, so latency-sensitive callers do not stall during construction. A failed open rejects with the matching error (`RangeError` / `TypeError` for invalid options, `DeviceError` / `OrtError` / `OrtPathError` for native failures). The synchronous `new Microphone(...)` and `new Speaker(...)` constructors are unchanged; the factories are an additive, non-blocking alternative that mirrors the Python `AsyncMicrophone.open()` / `AsyncSpeaker.open()` surface.
+- Non-blocking `Speaker.writeAsync(chunk)` and `Speaker.drainAsync()` methods, each returning a `Promise`. They run the blocking parts of playback off the event loop: `writeAsync` performs the backpressure wait when the native playback queue is full, and `drainAsync` performs the wait for queued audio to finish playing. The audio stream stays on its own thread; only the thread-safe sample channel and drain state are used off the event loop. A failed write or drain rejects with the matching error class. The synchronous `write()` / `pipe()` / `end()` Writable interface is unchanged; the async methods are an additive, direct alternative (do not interleave the two paths on one instance).
 
 ## [4.0.0] - 2026-05-30
 

--- a/npm/decibri/MIGRATION.md
+++ b/npm/decibri/MIGRATION.md
@@ -5,6 +5,23 @@ vocabulary that matches the Rust and Python packages, and tidies several option
 and return shapes. This guide lists every breaking change with before and after
 code.
 
+## New in 4.1.0 (additive, nothing to migrate)
+
+decibri 4.1.0 is a non-breaking, additive release. Code written for 4.0.0 keeps
+working unchanged; there is nothing to migrate. The release adds an opt-in
+non-blocking API for event-loop-sensitive code:
+
+- `Microphone.open(options)` and `Speaker.open(options)`: async factories that
+  construct an instance without blocking the event loop and resolve to a ready
+  instance. The synchronous `new Microphone(...)` and `new Speaker(...)`
+  constructors are unchanged.
+- `speaker.writeAsync(chunk)` and `speaker.drainAsync()`: write and drain
+  without blocking the event loop. The synchronous `write()` / `pipe()` /
+  `end()` interface is unchanged.
+
+See the Non-blocking API section of the README for examples. The rest of this
+guide covers the 4.0.0 changes from 3.x.
+
 ## Named exports
 
 The package no longer has a single default export. Destructure what you need.

--- a/npm/decibri/README.md
+++ b/npm/decibri/README.md
@@ -87,6 +87,7 @@ Standard `ReadableOptions` (e.g. `highWaterMark`) are also accepted.
 | Method | Description |
 | --- | --- |
 | `mic.stop()` | Stop capture and end stream. Safe to call multiple times |
+| `Microphone.open(options?)` | Construct without blocking the event loop. Returns a `Promise<Microphone>`. See [Non-blocking API](#non-blocking-api) |
 | `Microphone.devices()` | List available input devices |
 | `Microphone.version()` | Version info: `{ decibri, audioBackend, binding }` |
 
@@ -128,13 +129,46 @@ Standard `WritableOptions` (e.g. `highWaterMark`) are also accepted.
 | Method / Property | Description |
 | --- | --- |
 | `speaker.write(chunk)` | Write PCM data for playback |
+| `speaker.writeAsync(chunk)` | Write without blocking the event loop. Returns a `Promise`. See [Non-blocking API](#non-blocking-api) |
 | `speaker.end()` | Signal end. Drains remaining audio, then emits `'finish'` |
+| `speaker.drainAsync()` | Wait for queued audio to finish without blocking the event loop. Returns a `Promise` |
 | `speaker.stop()` | Immediate stop. Discards remaining audio |
 | `speaker.isPlaying` | `true` while audio is being output |
+| `Speaker.open(options?)` | Construct without blocking the event loop. Returns a `Promise<Speaker>` |
 | `Speaker.devices()` | List available output devices |
 | `Speaker.version()` | Same as `Microphone.version()` |
 
 The module-level `outputDevices()` free function is equivalent to `Speaker.devices()`.
+
+## Non-blocking API
+
+The synchronous constructors and `write` / `drain` do their work on the event loop, which is fine for most apps. For event-loop-sensitive code (servers, real-time voice pipelines), 4.1.0 adds async variants that perform the blocking work without stalling the event loop. They are additive: the synchronous API is unchanged, and you opt in only where you need it.
+
+### Non-blocking construction
+
+`Microphone.open(options?)` and `Speaker.open(options?)` are async factories that return a Promise of a ready instance. They take the same options as the constructors. For a microphone with Silero VAD, the model load that the constructor does inline runs without blocking the event loop.
+
+```javascript
+const { Microphone, Speaker } = require('decibri');
+
+const mic = await Microphone.open({ sampleRate: 16000, vad: 'silero' });
+const speaker = await Speaker.open({ sampleRate: 16000, channels: 1 });
+```
+
+The synchronous `new Microphone(...)` and `new Speaker(...)` still work unchanged. A failed open rejects the Promise with the same typed error a failed constructor throws.
+
+### Non-blocking playback
+
+`speaker.writeAsync(chunk)` resolves once the audio is queued, performing the backpressure wait (when the playback buffer is full) without blocking the event loop. `speaker.drainAsync()` resolves when all queued audio has finished playing, again without blocking.
+
+```javascript
+const speaker = await Speaker.open({ sampleRate: 16000, channels: 1 });
+
+await speaker.writeAsync(pcmBuffer);
+await speaker.drainAsync(); // resolves when playback finishes
+```
+
+These are a direct alternative to the synchronous `write()` / `pipe()` / `end()` stream interface, which is unchanged. Use one path per instance (the stream methods or the async methods, not both at once), and await calls in sequence to keep samples in order.
 
 ## Errors
 

--- a/npm/decibri/package.json
+++ b/npm/decibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decibri",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Cross-platform audio capture, playback, and processing for Node.js and browsers",
   "main": "src/decibri.js",
   "types": "src/decibri.d.ts",
@@ -72,10 +72,10 @@
     "MIGRATION.md"
   ],
   "optionalDependencies": {
-    "@decibri/decibri-win32-x64-msvc": "4.0.0",
-    "@decibri/decibri-darwin-arm64": "4.0.0",
-    "@decibri/decibri-linux-x64-gnu": "4.0.0",
-    "@decibri/decibri-linux-arm64-gnu": "4.0.0"
+    "@decibri/decibri-win32-x64-msvc": "4.1.0",
+    "@decibri/decibri-darwin-arm64": "4.1.0",
+    "@decibri/decibri-linux-x64-gnu": "4.1.0",
+    "@decibri/decibri-linux-arm64-gnu": "4.1.0"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.7.0"

--- a/npm/decibri/src/decibri-output.js
+++ b/npm/decibri/src/decibri-output.js
@@ -158,6 +158,56 @@ class Speaker extends Writable {
   }
 
   /**
+   * Write PCM audio without blocking the event loop.
+   *
+   * The blocking part of a write is the backpressure wait when the native
+   * playback queue is full; the synchronous stream path (`write()` / `pipe()`)
+   * performs that wait on the event loop. This method performs it on the native
+   * thread pool and resolves when the samples are queued. The audio stream is
+   * created on the first call (a fast device open) and stays on its own thread;
+   * only the queue handoff runs off the event loop.
+   *
+   * Additive and non-blocking: the synchronous `write()` / `pipe()` stream
+   * interface is unchanged. This is a direct, opt-in alternative that bypasses
+   * the Writable buffer, so do not interleave it with `write()` / `pipe()` on
+   * the same instance; pick one path per instance. Await calls sequentially to
+   * preserve sample order. An empty buffer resolves immediately. A failed write
+   * (a closed or stopped stream) rejects with the matching error class.
+   *
+   * @param {Buffer} chunk PCM samples in the configured `dtype`.
+   * @returns {Promise<void>}
+   */
+  async writeAsync(chunk) {
+    try {
+      await this._native.writeAsync(chunk);
+    } catch (err) {
+      throw wrapNativeError(err);
+    }
+  }
+
+  /**
+   * Wait for all queued audio to finish playing without blocking the event
+   * loop.
+   *
+   * The synchronous drain (run by `end()` / `_final`) polls for completion on
+   * the event loop for the full playback tail; this method runs that wait on the
+   * native thread pool and resolves when the buffer has drained. If nothing has
+   * been written yet it resolves immediately.
+   *
+   * Additive and non-blocking: the synchronous drain via `end()` is unchanged.
+   * Pair this with `writeAsync()` for a fully non-blocking playback path.
+   *
+   * @returns {Promise<void>}
+   */
+  async drainAsync() {
+    try {
+      await this._native.drainAsync();
+    } catch (err) {
+      throw wrapNativeError(err);
+    }
+  }
+
+  /**
    * Immediate stop. Discards remaining buffered audio.
    */
   stop() {

--- a/npm/decibri/src/decibri-output.js
+++ b/npm/decibri/src/decibri-output.js
@@ -13,10 +13,45 @@ const PACKAGE_VERSION = require('../package.json').version;
 class Speaker extends Writable {
   /**
    * @param {import('./decibri').SpeakerOptions} [options]
+   * @param {{ prepared: object, native: object }} [_internal] Internal: a
+   *   pre-resolved options bundle and an already-constructed native bridge,
+   *   passed by the async `Speaker.open()` factory. Not part of the public API.
    */
-  constructor(options = {}) {
+  constructor(options = {}, _internal = undefined) {
     super({ highWaterMark: options.highWaterMark || 16384 });
 
+    // Validate and resolve options once. The async factory passes its already
+    // resolved bundle through `_internal` to avoid recomputing it.
+    const prepared = _internal ? _internal.prepared : Speaker._prepareOptions(options);
+
+    // ── Store config ───────────────────────────────────────────────────────
+
+    this._dtype = prepared.dtype;
+    this._started = false;
+
+    // ── Create or adopt native bridge ───────────────────────────────────────
+
+    if (_internal) {
+      // Built off the event loop by Speaker.open(); already wrapped.
+      this._native = _internal.native;
+    } else {
+      try {
+        this._native = new DecibriOutputBridge(prepared.nativeOptions);
+      } catch (err) {
+        throw wrapNativeError(err);
+      }
+    }
+  }
+
+  /**
+   * Validate the constructor options and resolve them into the native options
+   * object plus the wrapper-side state. Throws the same `RangeError` /
+   * `TypeError` as the constructor on invalid input. Shared by the synchronous
+   * constructor and the async `open()` factory.
+   * @internal
+   * @param {import('./decibri').SpeakerOptions} options
+   */
+  static _prepareOptions(options) {
     // ── Validate options ───────────────────────────────────────────────────
 
     const sampleRate = options.sampleRate ?? 16000;
@@ -61,23 +96,41 @@ class Speaker extends Writable {
       resolvedDevice = options.device;
     }
 
-    // ── Store config ───────────────────────────────────────────────────────
-
-    this._dtype = dtype;
-    this._started = false;
-
-    // ── Create native bridge ───────────────────────────────────────────────
-
-    try {
-      this._native = new DecibriOutputBridge({
+    return {
+      dtype,
+      nativeOptions: {
         sampleRate,
         channels,
         format: dtype,
         device: resolvedDevice,
-      });
+      },
+    };
+  }
+
+  /**
+   * Construct a Speaker without blocking the event loop.
+   *
+   * Symmetric with `Microphone.open()` and the Python `AsyncSpeaker.open()`.
+   * The speaker loads no model, so the only open work is device resolution and
+   * the practical blocking risk is small; this factory exists chiefly so async
+   * callers can use one consistent construction pattern across both classes.
+   * The synchronous constructor remains available and unchanged.
+   *
+   * A failed open (unknown device) rejects the returned Promise with the
+   * matching error class rather than throwing synchronously.
+   *
+   * @param {import('./decibri').SpeakerOptions} [options]
+   * @returns {Promise<Speaker>}
+   */
+  static async open(options = {}) {
+    const prepared = Speaker._prepareOptions(options);
+    let native;
+    try {
+      native = await DecibriOutputBridge.openAsync(prepared.nativeOptions);
     } catch (err) {
       throw wrapNativeError(err);
     }
+    return new Speaker(options, { prepared, native });
   }
 
   /** @internal */

--- a/npm/decibri/src/decibri.d.ts
+++ b/npm/decibri/src/decibri.d.ts
@@ -273,6 +273,29 @@ export declare class Speaker extends Writable {
    */
   static open(options?: SpeakerOptions): Promise<Speaker>;
 
+  /**
+   * Write PCM audio without blocking the event loop. Performs the backpressure
+   * wait (when the native playback queue is full) on the native thread pool and
+   * resolves when the samples are queued.
+   *
+   * Additive: the synchronous `write()` / `pipe()` stream interface is
+   * unchanged. This is a direct, opt-in alternative that bypasses the Writable
+   * buffer; do not interleave it with `write()` / `pipe()` on the same instance.
+   * Await calls sequentially to preserve sample order. An empty buffer resolves
+   * immediately; a closed or stopped stream rejects with the matching error.
+   */
+  writeAsync(chunk: Buffer): Promise<void>;
+
+  /**
+   * Wait for all queued audio to finish playing without blocking the event
+   * loop. Runs the drain wait on the native thread pool and resolves when the
+   * buffer has drained; resolves immediately if nothing was written.
+   *
+   * Additive: the synchronous drain via `end()` is unchanged. Pair with
+   * `writeAsync()` for a fully non-blocking playback path.
+   */
+  drainAsync(): Promise<void>;
+
   /** Immediate stop. Discards remaining buffered audio. */
   stop(): void;
 

--- a/npm/decibri/src/decibri.d.ts
+++ b/npm/decibri/src/decibri.d.ts
@@ -124,6 +124,27 @@ export interface MicrophoneOptions extends ReadableOptions {
 export declare class Microphone extends Readable {
   constructor(options?: MicrophoneOptions);
 
+  /**
+   * Construct a Microphone without blocking the event loop on the open work.
+   *
+   * The synchronous constructor loads the Silero VAD model inline when
+   * `vad: 'silero'` is set, blocking the event loop for roughly 100 to 500 ms
+   * on a cold cache. This factory runs that load (and device resolution) on the
+   * native thread pool and resolves to a ready instance. The synchronous
+   * constructor remains available and unchanged.
+   *
+   * Options are identical to the constructor. A failed open rejects the Promise
+   * with the matching error: `RangeError` / `TypeError` for invalid options, or
+   * a `DeviceError` / `OrtError` / `OrtPathError` for native failures.
+   *
+   * @example
+   * ```js
+   * const mic = await Microphone.open({ vad: 'silero' });
+   * mic.on('data', (chunk) => { ... });
+   * ```
+   */
+  static open(options?: MicrophoneOptions): Promise<Microphone>;
+
   /** Stop microphone capture and end the stream. Safe to call multiple times. */
   stop(): void;
 
@@ -234,6 +255,23 @@ export interface SpeakerOptions extends WritableOptions {
  */
 export declare class Speaker extends Writable {
   constructor(options?: SpeakerOptions);
+
+  /**
+   * Construct a Speaker without blocking the event loop. Symmetric with
+   * `Microphone.open()`. The speaker loads no model, so the only open work is
+   * device resolution; this factory is provided so async callers can use one
+   * consistent construction pattern across both classes. The synchronous
+   * constructor remains available and unchanged.
+   *
+   * A failed open (unknown device) rejects the Promise with the matching error.
+   *
+   * @example
+   * ```js
+   * const speaker = await Speaker.open({ sampleRate: 24000 });
+   * speaker.write(pcmBuffer);
+   * ```
+   */
+  static open(options?: SpeakerOptions): Promise<Speaker>;
 
   /** Immediate stop. Discards remaining buffered audio. */
   stop(): void;

--- a/npm/decibri/src/decibri.js
+++ b/npm/decibri/src/decibri.js
@@ -96,10 +96,56 @@ function computeRMS(chunk, dtype) {
 class Microphone extends Readable {
   /**
    * @param {import('./decibri').MicrophoneOptions} [options]
+   * @param {{ prepared: object, native: object }} [_internal] Internal: a
+   *   pre-resolved options bundle and an already-constructed native bridge,
+   *   passed by the async `Microphone.open()` factory so the heavy open work
+   *   (the Silero model load) is not repeated on the event loop. Not part of
+   *   the public API.
    */
-  constructor(options = {}) {
+  constructor(options = {}, _internal = undefined) {
     super({ highWaterMark: options.highWaterMark, objectMode: false });
 
+    // Validate and resolve options once. The async factory passes its already
+    // resolved bundle through `_internal` to avoid recomputing it.
+    const prepared = _internal ? _internal.prepared : Microphone._prepareOptions(options);
+
+    // ── Store config ───────────────────────────────────────────────────────
+
+    this._dtype = prepared.dtype;
+    this._vad = prepared.vadEnabled;
+    this._vadMode = prepared.vadMode;
+    this._vadThreshold = prepared.vadThreshold;
+    this._vadHoldoff = prepared.vadHoldoff;
+    this._vadScore = 0;
+    this._isSpeaking = false;
+    this._silenceTimer = null;
+    this._started = false;
+
+    // ── Create or adopt native bridge ───────────────────────────────────────
+
+    if (_internal) {
+      // Built off the event loop by Microphone.open(); already wrapped.
+      this._native = _internal.native;
+    } else {
+      try {
+        this._native = new DecibriBridge(prepared.nativeOptions);
+      } catch (err) {
+        throw wrapNativeError(err);
+      }
+    }
+  }
+
+  /**
+   * Validate the constructor options and resolve them into the native options
+   * object plus the wrapper-side state. Throws the same `RangeError` /
+   * `TypeError` / `Error` as the constructor on invalid input. Shared by the
+   * synchronous constructor and the async `open()` factory so both validate
+   * identically. Does no native open work beyond the numeric-device bounds
+   * check (a fast device enumeration).
+   * @internal
+   * @param {import('./decibri').MicrophoneOptions} options
+   */
+  static _prepareOptions(options) {
     // ── Validate options ───────────────────────────────────────────────────
 
     const sampleRate = options.sampleRate ?? 16000;
@@ -189,22 +235,13 @@ class Microphone extends Readable {
       ortLibraryPath = resolveBundledOrtPath();
     }
 
-    // ── Store config ───────────────────────────────────────────────────────
-
-    this._dtype = dtype;
-    this._vad = vadEnabled;
-    this._vadMode = vadMode;
-    this._vadThreshold = options.vadThreshold ?? (vadMode === 'silero' ? 0.5 : 0.01);
-    this._vadHoldoff = options.vadHoldoff ?? 300;
-    this._vadScore = 0;
-    this._isSpeaking = false;
-    this._silenceTimer = null;
-    this._started = false;
-
-    // ── Create native bridge ───────────────────────────────────────────────
-
-    try {
-      this._native = new DecibriBridge({
+    return {
+      dtype,
+      vadEnabled,
+      vadMode,
+      vadThreshold: options.vadThreshold ?? (vadMode === 'silero' ? 0.5 : 0.01),
+      vadHoldoff: options.vadHoldoff ?? 300,
+      nativeOptions: {
         sampleRate,
         channels,
         framesPerBuffer,
@@ -213,10 +250,39 @@ class Microphone extends Readable {
         vadMode,
         modelPath,
         ortLibraryPath,
-      });
+      },
+    };
+  }
+
+  /**
+   * Construct a Microphone without blocking the event loop on the open work.
+   *
+   * The synchronous `new Microphone(...)` constructor loads the Silero VAD
+   * model inline when `vad: 'silero'` is set, which blocks the event loop for
+   * roughly 100 to 500 ms on a cold cache. This static factory runs that load
+   * (and device resolution) on the native thread pool and resolves to a ready
+   * instance, so latency-sensitive callers (voice pipelines, websocket
+   * handlers) do not stall. The synchronous constructor remains available and
+   * unchanged.
+   *
+   * Mirrors the Python `AsyncMicrophone.open()` factory. Options are identical
+   * to the constructor. A failed open (bad model path, unknown device, ORT
+   * load failure) rejects the returned Promise with the matching error class
+   * (`RangeError` / `TypeError` for invalid options, `DeviceError` / `OrtError`
+   * / `OrtPathError` for native failures), rather than throwing synchronously.
+   *
+   * @param {import('./decibri').MicrophoneOptions} [options]
+   * @returns {Promise<Microphone>}
+   */
+  static async open(options = {}) {
+    const prepared = Microphone._prepareOptions(options);
+    let native;
+    try {
+      native = await DecibriBridge.openAsync(prepared.nativeOptions);
     } catch (err) {
       throw wrapNativeError(err);
     }
+    return new Microphone(options, { prepared, native });
   }
 
   /** @internal */

--- a/npm/platform-darwin-arm64/package.json
+++ b/npm/platform-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-darwin-arm64",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "os": ["darwin"],
   "cpu": ["arm64"],
   "main": "decibri.darwin-arm64.node",

--- a/npm/platform-linux-arm64-gnu/package.json
+++ b/npm/platform-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-arm64-gnu",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "os": ["linux"],
   "cpu": ["arm64"],
   "main": "decibri.linux-arm64-gnu.node",

--- a/npm/platform-linux-x64-gnu/package.json
+++ b/npm/platform-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-x64-gnu",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "os": ["linux"],
   "cpu": ["x64"],
   "main": "decibri.linux-x64-gnu.node",

--- a/npm/platform-win32-x64-msvc/package.json
+++ b/npm/platform-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-win32-x64-msvc",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "os": ["win32"],
   "cpu": ["x64"],
   "main": "decibri.win32-x64-msvc.node",

--- a/tests/test-async-open.js
+++ b/tests/test-async-open.js
@@ -1,0 +1,295 @@
+'use strict';
+
+/**
+ * Async open() factory tests: Microphone.open() and Speaker.open().
+ *
+ * These factories perform the blocking open work (the Silero model load for the
+ * microphone; device resolution for both) on the native thread pool and resolve
+ * to a ready instance, mirroring the Python AsyncMicrophone.open() /
+ * AsyncSpeaker.open() factories. The synchronous constructors are unchanged.
+ *
+ * Group 1 (deterministic, no hardware) asserts resolve-to-instance and the
+ * reject paths. Groups 3 and 4 exercise a real instance end to end and need a
+ * microphone/speaker; like the other hardware suites they are local-only.
+ * Environmental failures (no audio device, missing ORT dylib) are classified as
+ * skips, not failures, so the deterministic assertions still gate the suite.
+ */
+
+const path = require('path');
+const {
+  Microphone,
+  Speaker,
+  DeviceError,
+  OrtError,
+} = require(path.join(__dirname, '..', 'npm', 'decibri', 'src', 'decibri.js'));
+
+let passed = 0;
+let failed = 0;
+let skipped = 0;
+
+function assert(condition, label) {
+  if (condition) {
+    passed++;
+  } else {
+    console.log(`  FAIL: ${label}`);
+    failed++;
+  }
+}
+
+async function assertRejects(fn, errorType, messagePart, label) {
+  try {
+    await fn();
+    console.log(`  FAIL: ${label}: expected ${errorType.name} rejection but resolved`);
+    failed++;
+  } catch (e) {
+    if (!(e instanceof errorType)) {
+      console.log(`  FAIL: ${label}: expected ${errorType.name}, got ${e.constructor.name}: ${e.message}`);
+      failed++;
+    } else if (!e.message.includes(messagePart)) {
+      console.log(`  FAIL: ${label}: message mismatch`);
+      console.log(`    expected to contain: ${messagePart}`);
+      console.log(`    actual: ${e.message}`);
+      failed++;
+    } else {
+      passed++;
+    }
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Treat a rejection that is clearly environmental (no audio device, or an ORT
+// dylib that is not present in a dev workspace) as a skip rather than a failure.
+function isEnvironmental(err) {
+  return err instanceof DeviceError || err instanceof OrtError;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 1: deterministic resolve and reject (no hardware assumptions)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+async function testDeterministic() {
+  console.log('--- Group 1: deterministic resolve / reject ---');
+
+  // Resolves to a constructed, not-yet-running instance.
+  try {
+    const m = await Microphone.open({ sampleRate: 16000, channels: 1 });
+    assert(m instanceof Microphone, 'Microphone.open() resolves to a Microphone');
+    assert(m.isOpen === false, 'opened Microphone is not yet capturing');
+    assert(m.vadScore === 0, 'opened Microphone vadScore starts at 0');
+    m.stop();
+  } catch (e) {
+    if (isEnvironmental(e)) {
+      console.log(`  SKIP: Microphone.open() default device unavailable: ${e.message}`);
+      skipped++;
+    } else {
+      console.log(`  FAIL: Microphone.open() should resolve: ${e.constructor.name}: ${e.message}`);
+      failed++;
+    }
+  }
+
+  try {
+    const s = await Speaker.open({ sampleRate: 16000, channels: 1 });
+    assert(s instanceof Speaker, 'Speaker.open() resolves to a Speaker');
+    assert(s.isPlaying === false, 'opened Speaker is not yet playing');
+    s.stop();
+  } catch (e) {
+    if (isEnvironmental(e)) {
+      console.log(`  SKIP: Speaker.open() default device unavailable: ${e.message}`);
+      skipped++;
+    } else {
+      console.log(`  FAIL: Speaker.open() should resolve: ${e.constructor.name}: ${e.message}`);
+      failed++;
+    }
+  }
+
+  // Invalid options reject (async), not throw synchronously.
+  await assertRejects(
+    () => Microphone.open({ sampleRate: 0 }),
+    RangeError,
+    'sample rate must be between 1000 and 384000',
+    'Microphone.open bad sampleRate'
+  );
+  await assertRejects(
+    () => Microphone.open({ dtype: 'wav' }),
+    TypeError,
+    "dtype must be 'int16' or 'float32'",
+    'Microphone.open bad dtype'
+  );
+  await assertRejects(
+    () => Microphone.open({ vad: true }),
+    TypeError,
+    'vad: true is no longer supported',
+    'Microphone.open legacy vad'
+  );
+  await assertRejects(
+    () => Speaker.open({ channels: 33 }),
+    RangeError,
+    'channels must be between 1 and 32',
+    'Speaker.open bad channels'
+  );
+
+  // Missing Silero model rejects before any native work.
+  await assertRejects(
+    () => Microphone.open({ vad: 'silero', modelPath: '/nonexistent/model.onnx' }),
+    Error,
+    'Silero VAD model not found',
+    'Microphone.open missing model'
+  );
+
+  // Native open failure (unknown device) rejects with a DeviceError carrying the
+  // frozen message and code. Exercises native compute -> reject -> wrapNativeError.
+  await assertRejects(
+    () => Microphone.open({ device: '__nonexistent__' }),
+    DeviceError,
+    'No microphone found matching "__nonexistent__"',
+    'Microphone.open unknown device'
+  );
+  await assertRejects(
+    () => Speaker.open({ device: '__nonexistent__' }),
+    DeviceError,
+    'No speaker found matching "__nonexistent__"',
+    'Speaker.open unknown device'
+  );
+
+  console.log('  Group 1 done\n');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 2: additive guarantee (sync constructors unchanged)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+async function testAdditive() {
+  console.log('--- Group 2: additive (sync constructors unchanged) ---');
+
+  try {
+    const m = new Microphone({ sampleRate: 16000, channels: 1 });
+    assert(m instanceof Microphone, 'sync new Microphone() still constructs');
+    m.stop();
+    const s = new Speaker({ sampleRate: 16000, channels: 1 });
+    assert(s instanceof Speaker, 'sync new Speaker() still constructs');
+    s.stop();
+  } catch (e) {
+    if (isEnvironmental(e)) {
+      console.log(`  SKIP: sync construction needs a device: ${e.message}`);
+      skipped++;
+    } else {
+      console.log(`  FAIL: sync construction broke: ${e.constructor.name}: ${e.message}`);
+      failed++;
+    }
+  }
+
+  console.log('  Group 2 done\n');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 3: end-to-end capture from an opened instance (hardware)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+async function testCaptureCycle() {
+  console.log('--- Group 3: capture from Microphone.open() (2 seconds) ---');
+
+  let mic;
+  try {
+    mic = await Microphone.open({ sampleRate: 16000, channels: 1 });
+  } catch (e) {
+    if (isEnvironmental(e)) {
+      console.log(`  SKIP: no microphone available: ${e.message}`);
+      skipped++;
+      console.log('  Group 3 done\n');
+      return;
+    }
+    throw e;
+  }
+
+  let chunks = 0;
+  mic.on('data', () => { chunks++; });
+
+  let errored = false;
+  mic.on('error', (err) => { console.log(`  mic error: ${err.message}`); errored = true; });
+
+  await sleep(2000);
+  mic.stop();
+  await sleep(100);
+
+  assert(!errored, 'no error during capture from opened instance');
+  assert(chunks > 0, `received at least one chunk from opened instance (got ${chunks})`);
+
+  console.log('  Group 3 done\n');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 4: playback from an opened instance (hardware)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+async function testPlaybackCycle() {
+  console.log('--- Group 4: playback from Speaker.open() (440Hz, 1 second) ---');
+
+  let speaker;
+  try {
+    speaker = await Speaker.open({ sampleRate: 16000, channels: 1 });
+  } catch (e) {
+    if (isEnvironmental(e)) {
+      console.log(`  SKIP: no speaker available: ${e.message}`);
+      skipped++;
+      console.log('  Group 4 done\n');
+      return;
+    }
+    throw e;
+  }
+
+  const samples = 16000;
+  const buffer = Buffer.alloc(samples * 2);
+  for (let i = 0; i < samples; i++) {
+    const sample = Math.sin(2 * Math.PI * 440 * (i / 16000)) * 0.3;
+    buffer.writeInt16LE(Math.round(sample * 32767), i * 2);
+  }
+
+  await new Promise((resolve) => {
+    let done = false;
+    const finish = () => { if (!done) { done = true; resolve(); } };
+    speaker.write(buffer);
+    speaker.end();
+    speaker.on('finish', () => {
+      assert(!speaker.isPlaying, 'isPlaying false after finish (opened instance)');
+      finish();
+    });
+    speaker.on('error', (err) => {
+      console.log(`  FAIL: playback error: ${err.message}`);
+      failed++;
+      finish();
+    });
+  });
+
+  console.log('  Group 4 done\n');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Runner
+// ═══════════════════════════════════════════════════════════════════════════════
+
+async function main() {
+  console.log('decibri async open() test suite\n');
+
+  await testDeterministic();
+  await testAdditive();
+  await testCaptureCycle();
+  await testPlaybackCycle();
+
+  console.log('═══════════════════════════════════════');
+  console.log(`  Passed:  ${passed}`);
+  console.log(`  Failed:  ${failed}`);
+  console.log(`  Skipped: ${skipped}`);
+  console.log('═══════════════════════════════════════');
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('FATAL:', err);
+  process.exit(1);
+});

--- a/tests/test-async-write-drain.js
+++ b/tests/test-async-write-drain.js
@@ -1,0 +1,214 @@
+'use strict';
+
+/**
+ * Async write/drain tests: Speaker.writeAsync() and Speaker.drainAsync().
+ *
+ * These methods perform the blocking parts of playback off the event loop: the
+ * backpressure wait on the native channel (write) and the drain poll loop
+ * (drain). The audio stream stays on its own thread; only the thread-safe
+ * channel and atomic drain flags are touched off the event loop. They are an
+ * additive, non-blocking alternative to the synchronous Writable path
+ * (write() / pipe() / end()), which is unchanged.
+ *
+ * Group 1 (deterministic, no hardware) asserts the no-op resolves and the
+ * reject path. Group 2 plays a real tone through the async path and needs a
+ * speaker; like the other output suites it is local-only. Environmental
+ * failures (no output device) are classified as skips.
+ */
+
+const path = require('path');
+const {
+  Speaker,
+  DecibriError,
+} = require(path.join(__dirname, '..', 'npm', 'decibri', 'src', 'decibri.js'));
+
+let passed = 0;
+let failed = 0;
+let skipped = 0;
+
+function assert(condition, label) {
+  if (condition) {
+    passed++;
+  } else {
+    console.log(`  FAIL: ${label}`);
+    failed++;
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isEnvironmental(err) {
+  // A missing or unusable output device surfaces as a DecibriError family
+  // member (DeviceError) or a stream-open failure. Treat those as skips.
+  return err instanceof DecibriError;
+}
+
+function generateSineWave(sampleRate, frequency, durationSec, amplitude) {
+  const samples = sampleRate * durationSec;
+  const buffer = Buffer.alloc(samples * 2); // int16
+  for (let i = 0; i < samples; i++) {
+    const t = i / sampleRate;
+    const sample = Math.sin(2 * Math.PI * frequency * t) * amplitude;
+    buffer.writeInt16LE(Math.round(sample * 32767), i * 2);
+  }
+  return buffer;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 1: deterministic (no hardware assumptions)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+async function testDeterministic() {
+  console.log('--- Group 1: deterministic write/drain ---');
+
+  const s = new Speaker({ sampleRate: 16000, channels: 1 });
+
+  // The methods return Promises.
+  const wp = s.writeAsync(Buffer.alloc(0));
+  assert(typeof wp.then === 'function', 'writeAsync() returns a Promise');
+  await wp;
+  assert(true, 'writeAsync(empty) resolves without opening the stream');
+
+  // drainAsync with nothing written resolves immediately (no-op).
+  await s.drainAsync();
+  assert(true, 'drainAsync() with no stream resolves');
+
+  s.stop();
+
+  // Reject path: an invalid argument rejects the Promise rather than throwing
+  // synchronously. (A non-Buffer cannot be marshaled by the native method.)
+  let rejected = false;
+  let rejErr;
+  try {
+    await s.writeAsync(42);
+  } catch (e) {
+    rejected = true;
+    rejErr = e;
+  }
+  assert(rejected, 'writeAsync(non-buffer) rejects');
+  assert(rejErr instanceof Error, 'rejection is an Error');
+  console.log(`  (write reject class: ${rejErr && rejErr.constructor.name}: ${rejErr && rejErr.message})`);
+
+  // Additive guarantee: the synchronous write/drain path is unchanged.
+  {
+    const s2 = new Speaker({ sampleRate: 16000, channels: 1 });
+    s2.write(Buffer.alloc(0));
+    s2.stop();
+    assert(true, 'sync write/stop still works alongside the async path');
+  }
+
+  console.log('  Group 1 done\n');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 2: real playback through the async path (hardware)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+async function testAsyncPlayback() {
+  console.log('--- Group 2: playback via writeAsync + drainAsync (440Hz, 1 second) ---');
+
+  let speaker;
+  try {
+    speaker = await Speaker.open({ sampleRate: 16000, channels: 1 });
+  } catch (e) {
+    if (isEnvironmental(e)) {
+      console.log(`  SKIP: no speaker available: ${e.message}`);
+      skipped++;
+      console.log('  Group 2 done\n');
+      return;
+    }
+    throw e;
+  }
+
+  try {
+    const buffer = generateSineWave(16000, 440, 1, 0.3);
+    await speaker.writeAsync(buffer);
+    assert(true, 'writeAsync(tone) resolves');
+
+    await speaker.drainAsync();
+    assert(!speaker.isPlaying, 'isPlaying is false after drainAsync resolves');
+  } catch (e) {
+    if (isEnvironmental(e)) {
+      console.log(`  SKIP: playback unavailable: ${e.message}`);
+      skipped++;
+    } else {
+      console.log(`  FAIL: async playback errored: ${e.constructor.name}: ${e.message}`);
+      failed++;
+    }
+  }
+
+  console.log('  Group 2 done\n');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 3: multiple sequential async writes preserve order and resolve
+// ═══════════════════════════════════════════════════════════════════════════════
+
+async function testSequentialWrites() {
+  console.log('--- Group 3: sequential writeAsync chunks (hardware) ---');
+
+  let speaker;
+  try {
+    speaker = new Speaker({ sampleRate: 16000, channels: 1 });
+  } catch (e) {
+    if (isEnvironmental(e)) {
+      console.log(`  SKIP: no speaker available: ${e.message}`);
+      skipped++;
+      console.log('  Group 3 done\n');
+      return;
+    }
+    throw e;
+  }
+
+  try {
+    // Three 200ms chunks written sequentially via the async path.
+    const chunk = generateSineWave(16000, 330, 0.2, 0.25);
+    for (let i = 0; i < 3; i++) {
+      await speaker.writeAsync(chunk);
+    }
+    await speaker.drainAsync();
+    assert(!speaker.isPlaying, 'not playing after draining sequential writes');
+  } catch (e) {
+    if (isEnvironmental(e)) {
+      console.log(`  SKIP: sequential playback unavailable: ${e.message}`);
+      skipped++;
+    } else {
+      console.log(`  FAIL: sequential async writes errored: ${e.constructor.name}: ${e.message}`);
+      failed++;
+    }
+  }
+
+  await sleep(100);
+  speaker.stop();
+
+  console.log('  Group 3 done\n');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Runner
+// ═══════════════════════════════════════════════════════════════════════════════
+
+async function main() {
+  console.log('decibri async write/drain test suite\n');
+
+  await testDeterministic();
+  await testAsyncPlayback();
+  await testSequentialWrites();
+
+  console.log('═══════════════════════════════════════');
+  console.log(`  Passed:  ${passed}`);
+  console.log(`  Failed:  ${failed}`);
+  console.log(`  Skipped: ${skipped}`);
+  console.log('═══════════════════════════════════════');
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('FATAL:', err);
+  process.exit(1);
+});

--- a/tests/test-ci.js
+++ b/tests/test-ci.js
@@ -419,10 +419,53 @@ async function asyncOpenTests() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// Summary (runs after the async group resolves)
+// Group 9: async write/drain (deterministic, no hardware required)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// Asserts what is deterministic without an output device: the no-op paths
+// resolve and the methods return Promises. A real playback round trip through
+// writeAsync/drainAsync (which opens the output stream) is in the hardware tier
+// in tests/test-async-write-drain.js.
+
+async function asyncWriteDrainTests() {
+  console.log('--- Group 9: async write/drain ---');
+
+  const s = new Speaker({ sampleRate: 16000, channels: 1 });
+
+  // The methods return Promises.
+  const wp = s.writeAsync(Buffer.alloc(0));
+  assert(typeof wp.then === 'function', 'writeAsync() returns a Promise');
+  const dp = s.drainAsync();
+  assert(typeof dp.then === 'function', 'drainAsync() returns a Promise');
+
+  // An empty write resolves without opening the stream (no device needed).
+  await wp;
+  assert(true, 'writeAsync(empty) resolves');
+
+  // drainAsync with nothing written is a no-op that resolves immediately.
+  await dp;
+  assert(true, 'drainAsync() with no stream resolves');
+
+  s.stop();
+
+  // Additive guarantee: the synchronous write/drain path is unchanged. A
+  // zero-byte sync write is still an accepted no-op, end() still drains.
+  {
+    const s2 = new Speaker({ sampleRate: 16000, channels: 1 });
+    s2.write(Buffer.alloc(0));
+    s2.stop();
+    assert(true, 'sync write/stop still works alongside the async path');
+  }
+
+  console.log('  Group 9 done\n');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Summary (runs after the async groups resolve)
 // ═══════════════════════════════════════════════════════════════════════════════
 
 asyncOpenTests()
+  .then(asyncWriteDrainTests)
   .then(() => {
     console.log('═══════════════════════════════════════');
     console.log(`  Passed:  ${passed}`);
@@ -433,6 +476,6 @@ asyncOpenTests()
     }
   })
   .catch((err) => {
-    console.error('  FATAL: async open() tests threw unexpectedly:', err);
+    console.error('  FATAL: async tests threw unexpectedly:', err);
     process.exit(1);
   });

--- a/tests/test-ci.js
+++ b/tests/test-ci.js
@@ -44,6 +44,26 @@ function assert(condition, label) {
   }
 }
 
+async function assertRejects(fn, errorType, messagePart) {
+  try {
+    await fn();
+    console.log(`  FAIL: expected ${errorType.name} rejection but the promise resolved`);
+    failed++;
+  } catch (e) {
+    if (!(e instanceof errorType)) {
+      console.log(`  FAIL: expected ${errorType.name} rejection, got ${e.constructor.name}: ${e.message}`);
+      failed++;
+    } else if (!e.message.includes(messagePart)) {
+      console.log(`  FAIL: rejection message mismatch`);
+      console.log(`    expected to contain: ${messagePart}`);
+      console.log(`    actual: ${e.message}`);
+      failed++;
+    } else {
+      passed++;
+    }
+  }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Group 1: Microphone constructor error messages
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -316,14 +336,103 @@ try {
 console.log('  Group 7 done\n');
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// Summary
+// Group 8: async open() factories (deterministic, no hardware required)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// Asserts what is deterministic: the factory resolves to a working instance and
+// rejects with the right error class on bad input. The non-blocking property
+// (that open() does not stall the event loop) is validated by design and by the
+// hardware tier in tests/test-async-open.js; it is not asserted here.
+
+async function asyncOpenTests() {
+  console.log('--- Group 8: async open() factories ---');
+
+  // Microphone.open() resolves to a working instance (default device, no model).
+  // Mirrors the synchronous construction already exercised in Group 5; if the CI
+  // runner can construct a Microphone synchronously, the async factory resolves
+  // the same way.
+  {
+    const m = await Microphone.open({ sampleRate: 16000, channels: 1 });
+    assert(m instanceof Microphone, 'Microphone.open() resolves to a Microphone');
+    assert(m.isOpen === false, 'opened Microphone is not yet capturing');
+    assert(m.vadScore === 0, 'opened Microphone vadScore starts at 0');
+    m.stop();
+  }
+
+  // Speaker.open() resolves to a working instance.
+  {
+    const s = await Speaker.open({ sampleRate: 16000, channels: 1 });
+    assert(s instanceof Speaker, 'Speaker.open() resolves to a Speaker');
+    assert(s.isPlaying === false, 'opened Speaker is not yet playing');
+    s.stop();
+  }
+
+  // Invalid options reject (not throw synchronously) with a built-in error.
+  await assertRejects(
+    () => Microphone.open({ sampleRate: 0 }),
+    RangeError,
+    'sample rate must be between 1000 and 384000'
+  );
+  await assertRejects(
+    () => Microphone.open({ dtype: 'wav' }),
+    TypeError,
+    "dtype must be 'int16' or 'float32'"
+  );
+  await assertRejects(
+    () => Speaker.open({ channels: 33 }),
+    RangeError,
+    'channels must be between 1 and 32'
+  );
+
+  // A missing Silero model rejects before any native work (wrapper-side check).
+  await assertRejects(
+    () => Microphone.open({ vad: 'silero', modelPath: '/nonexistent/model.onnx' }),
+    Error,
+    'Silero VAD model not found'
+  );
+
+  // A native open failure (unknown device name) rejects with a DeviceError that
+  // carries the frozen message and code. Exercises the native compute -> reject
+  // -> wrapNativeError path. Deterministic on CI: nothing matches the name.
+  await assertRejects(
+    () => Microphone.open({ device: '__nonexistent__' }),
+    DeviceError,
+    'No microphone found matching "__nonexistent__"'
+  );
+  await assertRejects(
+    () => Speaker.open({ device: '__nonexistent__' }),
+    DeviceError,
+    'No speaker found matching "__nonexistent__"'
+  );
+
+  // Additive guarantee: the synchronous constructor still works unchanged.
+  {
+    const m = new Microphone({ sampleRate: 16000, channels: 1 });
+    assert(m instanceof Microphone, 'sync new Microphone() still works alongside open()');
+    m.stop();
+    const s = new Speaker({ sampleRate: 16000, channels: 1 });
+    assert(s instanceof Speaker, 'sync new Speaker() still works alongside open()');
+    s.stop();
+  }
+
+  console.log('  Group 8 done\n');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Summary (runs after the async group resolves)
 // ═══════════════════════════════════════════════════════════════════════════════
 
-console.log('═══════════════════════════════════════');
-console.log(`  Passed:  ${passed}`);
-console.log(`  Failed:  ${failed}`);
-console.log('═══════════════════════════════════════');
-
-if (failed > 0) {
-  process.exit(1);
-}
+asyncOpenTests()
+  .then(() => {
+    console.log('═══════════════════════════════════════');
+    console.log(`  Passed:  ${passed}`);
+    console.log(`  Failed:  ${failed}`);
+    console.log('═══════════════════════════════════════');
+    if (failed > 0) {
+      process.exit(1);
+    }
+  })
+  .catch((err) => {
+    console.error('  FATAL: async open() tests threw unexpectedly:', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
Adds a non-blocking async I/O surface to the Node binding, at parity with Python's async classes. Additive and non-breaking: the synchronous API is unchanged.

Added:
- Microphone.open() and Speaker.open() async factories (non-blocking construction; resolve to a constructed instance)
- Speaker.writeAsync() and Speaker.drainAsync() (perform the blocking send and drain off the event loop)
- A SpeakerSink handle in the core: a lock-free handle to the send and drain primitives, so the off-event-loop work never holds a lock the main thread needs for stop or isPlaying

All five packages bumped to 4.1.0 in lockstep. version() now reports binding 4.1.0 (the native core stays 4.0.1; no core release is cut in this path). CHANGELOG, README async section, and an additive migration note included.