### PR TITLE
release(browser): decibri 4.2.0 (browser audio playback)

### DIFF
--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -11,6 +11,12 @@ For other decibri packages, see:
 
 ## [Unreleased]
 
+## [4.2.0] - 2026-05-31
+
+### Added
+
+- Browser `Speaker` for audio playback through the Web Audio API: `start()`, async `write(chunk)`, async `drain()`, `stop()`, and an `isPlaying` getter, with `int16` and `float32` input and resampling from the source rate to the output rate. Playback is started from a user gesture, as browsers require. This adds playback to the browser build alongside the existing browser `Microphone` capture. The release is browser-only and additive: the Node.js API and behavior are unchanged.
+
 ## [4.1.0] - 2026-05-31
 
 ### Added

--- a/npm/decibri/MIGRATION.md
+++ b/npm/decibri/MIGRATION.md
@@ -5,6 +5,20 @@ vocabulary that matches the Rust and Python packages, and tidies several option
 and return shapes. This guide lists every breaking change with before and after
 code.
 
+## New in 4.2.0 (additive, nothing to migrate)
+
+decibri 4.2.0 is a browser-only, additive release. Code written for 4.1.0 keeps
+working unchanged; there is nothing to migrate. The release adds audio playback
+to the browser build:
+
+- A browser `Speaker` that plays audio through the Web Audio API: `start()`,
+  async `write(chunk)`, async `drain()`, `stop()`, and `isPlaying`, with int16
+  and float32 input and resampling from the source rate to the output rate. It
+  is started from a user gesture, as browsers require. The browser `Microphone`
+  (capture) and the entire Node.js API are unchanged.
+
+See the browser Speaker section of the README for examples.
+
 ## New in 4.1.0 (additive, nothing to migrate)
 
 decibri 4.1.0 is a non-breaking, additive release. Code written for 4.0.0 keeps

--- a/npm/decibri/README.md
+++ b/npm/decibri/README.md
@@ -50,6 +50,19 @@ mic.on('data', (chunk) => { /* Int16Array of PCM samples */ });
 await mic.start(); // requires user gesture in Safari
 ```
 
+### Browser playback
+
+```javascript
+import { Speaker } from 'decibri'; // browser entry via conditional export
+
+const speaker = new Speaker({ sampleRate: 16000 });
+playButton.onclick = async () => {
+  await speaker.write(int16Chunk); // Int16Array of PCM samples
+  await speaker.drain();           // resolves when playback finishes
+  speaker.stop();
+};
+```
+
 ### Pipe capture to playback (echo)
 
 ```javascript
@@ -216,6 +229,37 @@ The browser runs energy-mode VAD only, so its `vad` option accepts `false` or `'
 | Sample rate | Native device rate | Resampled from native rate |
 | VAD | `'silero'` or `'energy'` | `'energy'` only |
 
+### `new Speaker(options?)` (browser)
+
+Browser audio playback through the Web Audio API. Playback is async (Promise based) and must be started from a user gesture so the browser allows audio.
+
+```javascript
+import { Speaker } from 'decibri'; // browser entry via conditional export
+
+const speaker = new Speaker({ sampleRate: 16000 });
+
+playButton.onclick = async () => {
+  await speaker.write(int16Chunk); // Int16Array of PCM samples
+  await speaker.drain();           // resolves when playback finishes
+  speaker.stop();
+};
+```
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `sampleRate` | number | 16000 | Sample rate of the audio you write (resampled to the output rate) |
+| `channels` | number | 1 | Output channels (a mono stream plays on every channel) |
+| `dtype` | `'int16'` \| `'float32'` | `'int16'` | Encoding of the samples you write |
+| `workletUrl` | string | inline blob | Custom worklet URL for strict CSP |
+
+- `start()` creates and resumes the audio output. Optional: `write()` starts it on the first call. Either must run in a user gesture (a click or tap); a context blocked by the autoplay policy surfaces a clear error.
+- `write(chunk)` resolves when the samples are queued. It waits when the buffer is full, so awaiting it paces playback. Await calls sequentially to preserve order.
+- `drain()` resolves when the queued audio has finished playing, immediately if nothing is queued.
+- `stop()` halts immediately and discards anything queued.
+- `isPlaying` reports whether audio is currently queued and playing.
+
+To verify playback in real browsers, open `examples/browser-speaker-test.html` (see `examples/README.md`).
+
 ## Voice Activity Detection
 
 ### Energy mode
@@ -277,6 +321,8 @@ node node_modules/decibri/examples/wav-capture.js
 node node_modules/decibri/examples/websocket-server.js   # terminal 1
 node node_modules/decibri/examples/websocket-stream.js   # terminal 2
 ```
+
+For the browser, `examples/browser-speaker-test.html` is a page for manually verifying audio playback in each browser. See `examples/README.md` for how to serve it on desktop and mobile.
 
 ## Migrating from 3.x
 

--- a/npm/decibri/examples/README.md
+++ b/npm/decibri/examples/README.md
@@ -1,0 +1,79 @@
+# decibri examples
+
+Runnable examples for decibri. The Node.js examples run with `node`; the browser
+example is an HTML page you open in a browser.
+
+## Node.js examples
+
+| File | What it does | Notes |
+| --- | --- | --- |
+| `wav-capture.js` | Captures audio and writes a valid WAV file | No extra dependencies |
+| `websocket-server.js` | Receives raw PCM chunks and logs byte counts | Requires `npm install ws` |
+| `websocket-stream.js` | Streams raw PCM audio to a WebSocket server | Requires `npm install ws` |
+
+```bash
+node wav-capture.js
+node websocket-server.js   # terminal 1
+node websocket-stream.js   # terminal 2
+```
+
+## Browser audio playback test (`browser-speaker-test.html`)
+
+A page for manually verifying that the browser Speaker plays real audio in each
+browser. It loads the real browser build (`decibri.browser.js`, a bundle of the
+package's browser entry) and plays generated tones so you can listen for a clean
+signal, glitches, correct pitch after resampling, and immediate stop.
+
+Browser audio needs a secure context, so the page must be served over
+`localhost` or `https`. Opening it as a `file://` URL will not load the audio
+engine.
+
+### Desktop
+
+From this `examples` directory, serve it over localhost and open the printed URL
+in each browser you want to test:
+
+```bash
+npx serve .
+# or
+npx http-server . -p 8080
+```
+
+Then open `http://localhost:<port>/browser-speaker-test.html` in Chrome, Firefox,
+Edge, and Safari, and tap the buttons.
+
+### Mobile (same WiFi)
+
+Serve on your computer as above, find your machine's LAN IP, and open
+`http://<machine-ip>:<port>/browser-speaker-test.html` on the phone (on the same
+network).
+
+iOS Safari treats a plain `http://<LAN-IP>` address as an insecure context and
+will refuse to start audio. For iOS, expose the local server over `https` with a
+tunnel and open the tunnel URL on the phone:
+
+```bash
+npx localtunnel --port 8080
+# open the printed https://... URL on the phone, then add /browser-speaker-test.html
+```
+
+### What to check in each browser
+
+- 440 Hz tone: a clean, steady tone with no buzz or distortion.
+- Continuous (3 s): smooth, with no gaps, clicks, or dropouts.
+- Resampled from 16 kHz: the same pitch as the 440 Hz tone button (confirms
+  resampling does not shift pitch).
+- Stop: playback halts immediately when tapped mid-playback.
+- Gesture requirement: nothing plays until you tap a button; if the browser
+  blocks audio, a clear error appears in the on-page log.
+- Both formats: repeat with the int16 and float32 toggle.
+
+### Regenerating the browser bundle
+
+`decibri.browser.js` is generated from the package's browser entry
+(`../src/browser/index.js`). Regenerate it after changing the browser source
+with any bundler that resolves the package's `browser` entry, for example:
+
+```bash
+npx esbuild ../src/browser/index.js --bundle --format=iife --global-name=decibri --outfile=decibri.browser.js
+```

--- a/npm/decibri/examples/browser-speaker-test.html
+++ b/npm/decibri/examples/browser-speaker-test.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>decibri browser audio playback test</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, sans-serif; max-width: 680px; margin: 40px auto; padding: 0 20px; color: #222; }
+    h1 { font-size: 1.4rem; margin-bottom: 8px; }
+    p.intro { font-size: 0.9rem; color: #555; margin-bottom: 16px; line-height: 1.5; }
+    .format-toggle { margin-bottom: 16px; font-size: 0.9rem; }
+    .format-toggle label { margin-right: 12px; cursor: pointer; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+    button { padding: 10px 16px; font-size: 0.9rem; border: 1px solid #ccc; border-radius: 4px; cursor: pointer; background: #f8f8f8; }
+    button:hover { background: #e8e8e8; }
+    button.stop { border-color: #f44336; color: #c62828; }
+    .hint { display: block; font-size: 0.75rem; color: #888; margin-top: 2px; }
+    .stats { font-size: 0.85rem; color: #666; margin-bottom: 12px; }
+    #log { background: #1a1a1a; color: #0f0; font-family: monospace; font-size: 0.8rem; padding: 12px; border-radius: 4px; height: 320px; overflow-y: auto; white-space: pre-wrap; word-break: break-all; }
+  </style>
+</head>
+<body>
+  <h1>decibri browser audio playback test</h1>
+  <p class="intro">
+    Tap a button to play audio through the browser Speaker, then listen and watch the log.
+    Playback must start from a tap (the browser only allows audio after a user gesture), so
+    nothing plays until you tap. Serve this page over <strong>localhost</strong> or
+    <strong>https</strong>; opening it as a <code>file://</code> URL will not work. See
+    <code>examples/README.md</code> for serve and mobile instructions.
+  </p>
+
+  <div class="format-toggle">
+    <strong>Format:</strong>
+    <label><input type="radio" name="dtype" value="int16" checked> int16</label>
+    <label><input type="radio" name="dtype" value="float32"> float32</label>
+  </div>
+
+  <div class="controls">
+    <div>
+      <button id="btn-tone">Play 440 Hz tone</button>
+      <span class="hint">about 1.5 s. Should be a clean, steady tone.</span>
+    </div>
+    <div>
+      <button id="btn-continuous">Play 3 s continuous</button>
+      <span class="hint">Listen for any gaps, clicks, or dropouts.</span>
+    </div>
+    <div>
+      <button id="btn-resampled">Play 440 Hz from 16 kHz</button>
+      <span class="hint">Forces resampling. Should match the first button's pitch.</span>
+    </div>
+    <div>
+      <button id="btn-stop" class="stop">Stop</button>
+      <span class="hint">Should halt immediately.</span>
+    </div>
+  </div>
+
+  <div class="stats" id="stats">Idle.</div>
+  <div id="log"></div>
+
+  <!--
+    This page loads the real browser Speaker from examples/decibri.browser.js, a
+    generated bundle of the package's browser entry (src/browser/index.js). It is
+    the actual shipped code, not a copy. See examples/README.md to regenerate it.
+  -->
+  <script src="./decibri.browser.js"></script>
+  <script>
+    const { Speaker } = decibri;
+
+    const logEl = document.getElementById('log');
+    const statsEl = document.getElementById('stats');
+
+    let current = null;
+
+    function log(msg) {
+      const ts = new Date().toISOString().slice(11, 23);
+      logEl.textContent += `[${ts}] ${msg}\n`;
+      logEl.scrollTop = logEl.scrollHeight;
+    }
+
+    function setStats(text) {
+      const playing = current ? current.isPlaying : false;
+      statsEl.textContent = `${text}  |  isPlaying: ${playing}`;
+    }
+
+    function getDtype() {
+      return document.querySelector('input[name="dtype"]:checked').value;
+    }
+
+    // Generate a sine tone at `rate` Hz with short fades to avoid edge clicks.
+    function genTone(freq, seconds, rate, dtype) {
+      const n = Math.floor(rate * seconds);
+      const amp = 0.25;
+      const fade = Math.min(Math.floor(rate * 0.005), Math.floor(n / 2));
+      const f32 = new Float32Array(n);
+      for (let i = 0; i < n; i++) {
+        let env = 1;
+        if (i < fade) env = i / fade;
+        else if (i >= n - fade) env = (n - 1 - i) / fade;
+        f32[i] = Math.sin(2 * Math.PI * freq * i / rate) * amp * env;
+      }
+      if (dtype === 'float32') return f32;
+      const i16 = new Int16Array(n);
+      for (let i = 0; i < n; i++) {
+        i16[i] = Math.max(-32768, Math.min(32767, Math.round(f32[i] * 32767)));
+      }
+      return i16;
+    }
+
+    function stopCurrent() {
+      if (current) {
+        current.stop();
+        log('stop()');
+        current = null;
+        setStats('Stopped.');
+      }
+    }
+
+    async function play(label, freq, seconds, srcRate) {
+      stopCurrent();
+      const dtype = getDtype();
+      log(`${label}: ${seconds}s of ${freq} Hz, source ${srcRate} Hz, dtype=${dtype}`);
+      setStats('Starting...');
+      const speaker = new Speaker({ sampleRate: srcRate, dtype });
+      current = speaker;
+      try {
+        const tone = genTone(freq, seconds, srcRate, dtype);
+        await speaker.write(tone);
+        log(`queued ${tone.length} samples, waiting for playback to finish...`);
+        setStats('Playing...');
+        await speaker.drain();
+        log('drained (playback finished)');
+        setStats('Finished.');
+        // Only tear down if a newer play has not replaced this one.
+        if (current === speaker) {
+          speaker.stop();
+          current = null;
+        }
+      } catch (err) {
+        log('ERROR: ' + (err && err.message ? err.message : String(err)));
+        setStats('Error (see log).');
+      }
+    }
+
+    document.getElementById('btn-tone').addEventListener('click', () => {
+      play('440 Hz tone', 440, 1.5, 44100);
+    });
+    document.getElementById('btn-continuous').addEventListener('click', () => {
+      play('continuous', 440, 3, 44100);
+    });
+    document.getElementById('btn-resampled').addEventListener('click', () => {
+      play('resampled from 16 kHz', 440, 1.5, 16000);
+    });
+    document.getElementById('btn-stop').addEventListener('click', stopCurrent);
+
+    log('Ready. Tap a button to play.');
+  </script>
+</body>
+</html>

--- a/npm/decibri/examples/decibri.browser.js
+++ b/npm/decibri/examples/decibri.browser.js
@@ -1,0 +1,594 @@
+// decibri browser bundle. GENERATED from src/browser/index.js. Do not edit by hand; see examples/README.md to regenerate.
+"use strict";
+var decibri = (function() {
+	//#region \0rolldown/runtime.js
+	var __commonJSMin = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
+	//#endregion
+	//#region ../development/decibri/rust/decibri/repository/decibri/npm/decibri/src/browser/emitter.js
+	var require_emitter = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+		/**
+		* Minimal event emitter for browsers.
+		*
+		* Provides .on() / .off() / .once() / .emit() with the same API pattern
+		* as Node.js EventEmitter. Used instead of browser-native EventTarget to
+		* preserve API parity with the Node.js decibri (.on('data', cb) pattern).
+		*
+		* Ported from decibri-web emitter.ts. Logic identical, types removed.
+		*/
+		var Emitter = class {
+			constructor() {
+				this._listeners = /* @__PURE__ */ new Map();
+			}
+			on(event, fn) {
+				let set = this._listeners.get(event);
+				if (!set) {
+					set = /* @__PURE__ */ new Set();
+					this._listeners.set(event, set);
+				}
+				set.add(fn);
+				return this;
+			}
+			off(event, fn) {
+				const set = this._listeners.get(event);
+				if (!set) return this;
+				if (set.delete(fn)) return this;
+				for (const listener of set) if (listener._original === fn) {
+					set.delete(listener);
+					return this;
+				}
+				return this;
+			}
+			once(event, fn) {
+				const wrapper = (...args) => {
+					this.off(event, wrapper);
+					fn(...args);
+				};
+				wrapper._original = fn;
+				return this.on(event, wrapper);
+			}
+			emit(event, ...args) {
+				const set = this._listeners.get(event);
+				if (!set || set.size === 0) return false;
+				for (const fn of set) fn(...args);
+				return true;
+			}
+			removeAllListeners(event) {
+				if (event !== void 0) this._listeners.delete(event);
+				else this._listeners.clear();
+				return this;
+			}
+		};
+		module.exports = { Emitter };
+	}));
+	//#endregion
+	//#region ../development/decibri/rust/decibri/repository/decibri/npm/decibri/src/browser/worklet-inline.js
+	var require_worklet_inline = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+		module.exports = { WORKLET_SOURCE: "var u=class extends AudioWorkletProcessor{constructor(r){super();let e=r.processorOptions;this.framesPerBuffer=e.framesPerBuffer,this.format=e.format,this.ratio=e.nativeSampleRate/e.targetSampleRate,this.needsResample=e.nativeSampleRate!==e.targetSampleRate,this.position=0,this.buffer=new Float32Array(this.framesPerBuffer),this.bufferIndex=0}process(r,e,s){let t=r[0]?.[0];if(!t||t.length===0)return!0;let f;this.needsResample?f=this.resample(t):f=t;let a=0;for(;a<f.length;){let i=this.framesPerBuffer-this.bufferIndex,o=f.length-a,n=Math.min(i,o);this.buffer.set(f.subarray(a,a+n),this.bufferIndex),this.bufferIndex+=n,a+=n,this.bufferIndex>=this.framesPerBuffer&&this.flush()}return!0}resample(r){let e=r.length,s=0,t=this.position;for(;t<e-1;)s++,t+=this.ratio;let f=new Float32Array(s);t=this.position;for(let a=0;a<s;a++){let i=Math.floor(t),o=t-i;f[a]=r[i]*(1-o)+r[i+1]*o,t+=this.ratio}return this.position=Math.max(0,t-e),f}flush(){let r;if(this.format===\"int16\"){let e=new Int16Array(this.framesPerBuffer);for(let s=0;s<this.framesPerBuffer;s++)e[s]=Math.max(-32768,Math.min(32767,Math.round(this.buffer[s]*32768)));r=e.buffer}else r=this.buffer.slice(0,this.framesPerBuffer).buffer;this.port.postMessage(r,[r]),this.buffer=new Float32Array(this.framesPerBuffer),this.bufferIndex=0}};registerProcessor(\"decibri-processor\",u);\n" };
+	}));
+	//#endregion
+	//#region ../development/decibri/rust/decibri/repository/decibri/npm/decibri/src/browser/decibri-browser.js
+	var require_decibri_browser = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+		const { Emitter } = require_emitter();
+		const { WORKLET_SOURCE } = require_worklet_inline();
+		const VERSION = "4.0.0";
+		/**
+		* Browser microphone capture.
+		*
+		* Uses getUserMedia + AudioWorklet for real-time audio capture in browsers.
+		* Emits 'data' events with Int16Array or Float32Array chunks.
+		*
+		* Ported from decibri-web decibri.ts. Logic identical, types removed.
+		*
+		* @example
+		* const { Microphone } = require('decibri'); // browser entry via conditional export
+		* const mic = new Microphone({ sampleRate: 16000 });
+		* mic.on('data', (chunk) => { // chunk is Int16Array });
+		* await mic.start();
+		* // later...
+		* mic.stop();
+		*/
+		var Microphone = class extends Emitter {
+			constructor(options = {}) {
+				super();
+				this._audioContext = null;
+				this._stream = null;
+				this._sourceNode = null;
+				this._workletNode = null;
+				this._started = false;
+				this._starting = null;
+				this._stopRequested = false;
+				const vad = options.vad ?? false;
+				if (vad === false) this._vad = false;
+				else if (vad === true) throw new TypeError("vad: true is no longer supported. Specify the mode explicitly: vad: 'energy'.");
+				else if (vad === "energy") this._vad = true;
+				else throw new TypeError(`Invalid vad value: ${JSON.stringify(vad)}. Expected false or 'energy'.`);
+				this._vadThreshold = options.vadThreshold ?? .01;
+				this._vadHoldoff = options.vadHoldoff ?? 300;
+				this._vadScore = 0;
+				this._isSpeaking = false;
+				this._silenceTimer = null;
+				this._sampleRate = options.sampleRate ?? 16e3;
+				this._channels = options.channels ?? 1;
+				this._framesPerBuffer = options.framesPerBuffer ?? 1600;
+				this._device = options.device;
+				this._dtype = options.dtype ?? "int16";
+				this._echoCancellation = options.echoCancellation ?? true;
+				this._noiseSuppression = options.noiseSuppression ?? true;
+				this._workletUrl = options.workletUrl;
+				if (this._sampleRate < 1e3 || this._sampleRate > 384e3) throw new TypeError(`sample rate must be between 1000 and 384000, got ${this._sampleRate}`);
+				if (this._channels < 1 || this._channels > 32) throw new TypeError(`channels must be between 1 and 32, got ${this._channels}`);
+				if (this._framesPerBuffer < 64 || this._framesPerBuffer > 65536) throw new TypeError(`frames per buffer must be between 64 and 65536, got ${this._framesPerBuffer}`);
+				if (this._dtype !== "int16" && this._dtype !== "float32") throw new TypeError("dtype must be 'int16' or 'float32'");
+				if (this._vadThreshold < 0 || this._vadThreshold > 1) throw new TypeError(`vadThreshold must be between 0 and 1, got ${this._vadThreshold}`);
+				if (this._vadHoldoff < 0) throw new TypeError(`vadHoldoff must be >= 0, got ${this._vadHoldoff}`);
+			}
+			/**
+			* Start microphone capture.
+			* Requests microphone permission and sets up the audio pipeline.
+			* Must be called from a user gesture context in Safari.
+			* No-op if already started. Returns the existing promise if a start
+			* is already in progress.
+			*/
+			start() {
+				if (this._started) return Promise.resolve();
+				if (this._starting) return this._starting;
+				this._starting = this._doStart().finally(() => {
+					this._starting = null;
+				});
+				return this._starting;
+			}
+			/**
+			* Stop microphone capture and release all resources.
+			* Safe to call multiple times or before start().
+			* After stop(), calling start() again creates a fresh session.
+			*/
+			stop() {
+				if (!this._started) {
+					if (this._starting) this._stopRequested = true;
+					return;
+				}
+				this._started = false;
+				if (this._stream) this._stream.getTracks().forEach((t) => t.stop());
+				if (this._sourceNode) this._sourceNode.disconnect();
+				if (this._workletNode) {
+					this._workletNode.disconnect();
+					this._workletNode.port.close();
+				}
+				if (this._audioContext) this._audioContext.close();
+				if (this._silenceTimer !== null) {
+					clearTimeout(this._silenceTimer);
+					this._silenceTimer = null;
+				}
+				this._isSpeaking = false;
+				this._audioContext = null;
+				this._stream = null;
+				this._sourceNode = null;
+				this._workletNode = null;
+				this.emit("end");
+				this.emit("close");
+			}
+			/** Whether the microphone is currently capturing. */
+			get isOpen() {
+				return this._started;
+			}
+			/**
+			* Most recent VAD score: the normalized RMS of the last chunk in `'energy'`
+			* mode, or 0 when VAD is disabled or before the first chunk is processed.
+			* @returns {number}
+			*/
+			get vadScore() {
+				return this._vadScore;
+			}
+			/**
+			* List available audio input devices.
+			* Device labels may be empty until microphone permission is granted.
+			*/
+			static async devices() {
+				return (await navigator.mediaDevices.enumerateDevices()).filter((d) => d.kind === "audioinput").map((d) => ({
+					deviceId: d.deviceId,
+					label: d.label,
+					groupId: d.groupId
+				}));
+			}
+			/** Version information. */
+			static version() {
+				return { decibri: VERSION };
+			}
+			async _doStart() {
+				this._audioContext = new AudioContext();
+				const nativeSampleRate = this._audioContext.sampleRate;
+				await this._audioContext.resume();
+				const audioConstraints = {
+					channelCount: this._channels,
+					echoCancellation: this._echoCancellation,
+					noiseSuppression: this._noiseSuppression
+				};
+				if (this._device) audioConstraints.deviceId = { exact: this._device };
+				try {
+					this._stream = await navigator.mediaDevices.getUserMedia({ audio: audioConstraints });
+				} catch (err) {
+					await this._audioContext.close();
+					this._audioContext = null;
+					const error = this._mapError(err);
+					this.emit("error", error);
+					throw error;
+				}
+				let blobUrl = null;
+				const workletUrl = this._workletUrl ?? (blobUrl = this._createBlobUrl());
+				try {
+					await this._audioContext.audioWorklet.addModule(workletUrl);
+				} catch (err) {
+					if (blobUrl) URL.revokeObjectURL(blobUrl);
+					this._stream.getTracks().forEach((t) => t.stop());
+					this._stream = null;
+					await this._audioContext.close();
+					this._audioContext = null;
+					const error = /* @__PURE__ */ new Error("Failed to load audio worklet: " + (err instanceof Error ? err.message : String(err)));
+					this.emit("error", error);
+					throw error;
+				}
+				if (blobUrl) URL.revokeObjectURL(blobUrl);
+				this._sourceNode = this._audioContext.createMediaStreamSource(this._stream);
+				this._workletNode = new AudioWorkletNode(this._audioContext, "decibri-processor", { processorOptions: {
+					framesPerBuffer: this._framesPerBuffer,
+					format: this._dtype,
+					nativeSampleRate,
+					targetSampleRate: this._sampleRate
+				} });
+				this._workletNode.port.onmessage = (event) => {
+					const buffer = event.data;
+					const chunk = this._dtype === "int16" ? new Int16Array(buffer) : new Float32Array(buffer);
+					this.emit("data", chunk);
+					if (this._vad) this._processVad(chunk);
+				};
+				this._sourceNode.connect(this._workletNode);
+				this._started = true;
+				if (this._stopRequested) {
+					this._stopRequested = false;
+					this.stop();
+				}
+			}
+			_createBlobUrl() {
+				const blob = new Blob([WORKLET_SOURCE], { type: "application/javascript" });
+				return URL.createObjectURL(blob);
+			}
+			_mapError(err) {
+				if (err instanceof DOMException) switch (err.name) {
+					case "NotAllowedError": return /* @__PURE__ */ new Error("Microphone permission denied");
+					case "NotFoundError": return /* @__PURE__ */ new Error("No microphone found");
+					default: return /* @__PURE__ */ new Error("Microphone access failed: " + err.message);
+				}
+				return err instanceof Error ? err : new Error(String(err));
+			}
+			_processVad(chunk) {
+				const rms = this._computeRms(chunk);
+				this._vadScore = rms;
+				if (rms >= this._vadThreshold) {
+					if (this._silenceTimer !== null) {
+						clearTimeout(this._silenceTimer);
+						this._silenceTimer = null;
+					}
+					if (!this._isSpeaking) {
+						this._isSpeaking = true;
+						this.emit("speech");
+					}
+				} else if (this._isSpeaking && this._silenceTimer === null) this._silenceTimer = setTimeout(() => {
+					this._isSpeaking = false;
+					this._silenceTimer = null;
+					this.emit("silence");
+				}, this._vadHoldoff);
+			}
+			_computeRms(chunk) {
+				let sum = 0;
+				const n = chunk.length;
+				if (n === 0) return 0;
+				if (chunk instanceof Float32Array) for (let i = 0; i < n; i++) sum += chunk[i] * chunk[i];
+				else for (let i = 0; i < n; i++) {
+					const s = chunk[i] / 32768;
+					sum += s * s;
+				}
+				return Math.sqrt(sum / n);
+			}
+		};
+		module.exports = { Microphone };
+	}));
+	//#endregion
+	//#region ../development/decibri/rust/decibri/repository/decibri/npm/decibri/src/browser/output-worklet-inline.js
+	var require_output_worklet_inline = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+		module.exports = { OUTPUT_WORKLET_SOURCE: "class R{constructor(t){this.capacity=t,this.buffer=new Float32Array(t),this.writeIndex=0,this.readIndex=0,this.size=0}get availableRead(){return this.size}get availableWrite(){return this.capacity-this.size}get isEmpty(){return this.size===0}get isFull(){return this.size===this.capacity}write(t){let e=Math.min(t.length,this.availableWrite);for(let s=0;s<e;s++)this.buffer[this.writeIndex]=t[s],this.writeIndex=this.writeIndex+1===this.capacity?0:this.writeIndex+1;return this.size+=e,e}readInto(t,e,s){let i=Math.min(s,this.size);for(let f=0;f<i;f++)t[e+f]=this.buffer[this.readIndex],this.readIndex=this.readIndex+1===this.capacity?0:this.readIndex+1;return this.size-=i,i}clear(){this.writeIndex=0,this.readIndex=0,this.size=0}}class P extends AudioWorkletProcessor{constructor(t){super();let e=t&&t.processorOptions||{},s=e.ringCapacity??96000;this.ring=new R(s),this.hadData=!1,this.port.onmessage=i=>this._onmessage(i)}_onmessage(t){let e=t.data;if(e&&e.type===\"flush\"){this.ring.clear(),this.hadData=!1;return}if(e instanceof ArrayBuffer){let s=new Float32Array(e),i=this.ring.write(s);i>0&&(this.hadData=!0),this.port.postMessage({type:\"level\",queued:this.ring.availableRead,capacity:this.ring.capacity,accepted:i,requested:s.length})}}process(t,e,s){let i=e[0];if(!i||i.length===0)return!0;let f=i[0].length,a=this.ring.readInto(i[0],0,f);for(let o=a;o<f;o++)i[0][o]=0;for(let o=1;o<i.length;o++)i[o].set(i[0]);return this.hadData&&this.ring.isEmpty&&(this.hadData=!1,this.port.postMessage({type:\"drained\"})),!0}}P.RingBuffer=R;registerProcessor(\"decibri-output-processor\",P);\n" };
+	}));
+	//#endregion
+	//#region ../development/decibri/rust/decibri/repository/decibri/npm/decibri/src/browser/decibri-output-browser.js
+	var require_decibri_output_browser = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+		const { OUTPUT_WORKLET_SOURCE } = require_output_worklet_inline();
+		const BUFFER_SECONDS = 2;
+		/**
+		* Linear-interpolation resampler, the inverse of the capture worklet's: it
+		* takes samples at the user's rate and produces samples at the context rate.
+		* Carries a fractional position across calls so successive writes stay
+		* continuous. Logic mirrors worklet-processor.js resample(), with from and to
+		* swapped (from = user rate, to = context rate).
+		*/
+		var Resampler = class {
+			constructor(fromRate, toRate) {
+				this.ratio = fromRate / toRate;
+				this.position = 0;
+			}
+			process(input) {
+				if (this.ratio === 1) return input;
+				const inputLength = input.length;
+				let count = 0;
+				let pos = this.position;
+				while (pos < inputLength - 1) {
+					count++;
+					pos += this.ratio;
+				}
+				const output = new Float32Array(count);
+				pos = this.position;
+				for (let i = 0; i < count; i++) {
+					const idx = Math.floor(pos);
+					const frac = pos - idx;
+					output[i] = input[idx] * (1 - frac) + input[idx + 1] * frac;
+					pos += this.ratio;
+				}
+				this.position = Math.max(0, pos - inputLength);
+				return output;
+			}
+		};
+		/**
+		* Browser audio playback.
+		*
+		* Plays PCM audio through the Web Audio API. Samples are converted to float32
+		* and resampled to the context rate on the main thread, then fed to an output
+		* AudioWorklet that drains them to the speakers. This is the inverse of the
+		* browser Microphone: the Microphone captures input and emits chunks; the
+		* Speaker accepts chunks and plays them.
+		*
+		* Playback is async throughout, as the browser requires: write() resolves when
+		* the samples are queued (after backpressure when the queue is full) and
+		* drain() resolves when the queued audio has finished playing. The first
+		* write() (or start()) must run in a user gesture so the browser allows audio.
+		*
+		* @example
+		* const { Speaker } = require('decibri'); // browser entry via conditional export
+		* const speaker = new Speaker({ sampleRate: 16000 });
+		* button.onclick = async () => {
+		*   await speaker.write(int16Chunk); // Int16Array of PCM samples
+		*   await speaker.drain();
+		*   speaker.stop();
+		* };
+		*/
+		var Speaker = class {
+			constructor(options = {}) {
+				this._audioContext = null;
+				this._workletNode = null;
+				this._resampler = null;
+				this._started = false;
+				this._starting = null;
+				this._stopRequested = false;
+				this._lastAck = null;
+				this._capacity = 0;
+				this._contextRate = 0;
+				this._unplayed = false;
+				this._pendingDrains = [];
+				this._sampleRate = options.sampleRate ?? 16e3;
+				this._channels = options.channels ?? 1;
+				this._dtype = options.dtype ?? "int16";
+				this._workletUrl = options.workletUrl;
+				if (this._sampleRate < 1e3 || this._sampleRate > 384e3) throw new TypeError(`sample rate must be between 1000 and 384000, got ${this._sampleRate}`);
+				if (this._channels < 1 || this._channels > 32) throw new TypeError(`channels must be between 1 and 32, got ${this._channels}`);
+				if (this._dtype !== "int16" && this._dtype !== "float32") throw new TypeError("dtype must be 'int16' or 'float32'");
+			}
+			/**
+			* Create and resume the AudioContext and load the output worklet.
+			*
+			* Must be called from a user gesture context so the browser allows audio.
+			* Optional: write() starts playback on its own if start() was not called, but
+			* calling start() from a click handler is the reliable way to unlock audio
+			* before samples are ready. No-op if already started; returns the in-flight
+			* promise if a start is already in progress.
+			*
+			* @returns {Promise<void>}
+			*/
+			start() {
+				if (this._started) return Promise.resolve();
+				if (this._starting) return this._starting;
+				this._starting = this._doStart().finally(() => {
+					this._starting = null;
+				});
+				return this._starting;
+			}
+			/**
+			* Play PCM audio. Resolves when the samples are queued.
+			*
+			* Converts the chunk to context-rate float32 (int16 to float32 if needed,
+			* then resample), and feeds it to the output worklet. When the queue is full
+			* it applies backpressure: the returned promise does not resolve until there
+			* is room, so a caller that awaits write() is paced to playback. Starts
+			* playback on the first call (gesture-sensitive).
+			*
+			* Await calls sequentially to preserve sample order. An empty chunk resolves
+			* immediately. Writing after stop() starts a fresh playback session.
+			*
+			* @param {Int16Array|Float32Array|ArrayBuffer} chunk PCM samples in the
+			*   configured dtype.
+			* @returns {Promise<void>}
+			*/
+			async write(chunk) {
+				await this.start();
+				if (!this._started) throw new Error("Speaker is stopped");
+				const float32 = this._convert(chunk);
+				if (float32.length === 0) return;
+				let offset = 0;
+				while (offset < float32.length) {
+					const sliceLen = Math.min(float32.length - offset, this._capacity);
+					await this._reserve(sliceLen);
+					if (!this._started) throw new Error("Speaker is stopped");
+					const slice = float32.slice(offset, offset + sliceLen);
+					this._workletNode.port.postMessage(slice.buffer, [slice.buffer]);
+					this._lastAck = {
+						queued: this._estimateQueue() + sliceLen,
+						time: this._now()
+					};
+					this._unplayed = true;
+					offset += sliceLen;
+				}
+			}
+			/**
+			* Wait for all queued audio to finish playing.
+			*
+			* Resolves when the worklet reports its queue drained. Resolves immediately
+			* if nothing is queued (nothing written, or playback already caught up).
+			*
+			* @returns {Promise<void>}
+			*/
+			drain() {
+				if (!this._started || !this._unplayed) return Promise.resolve();
+				return new Promise((resolve) => {
+					this._pendingDrains.push(resolve);
+				});
+			}
+			/**
+			* Immediate stop. Discards queued audio and releases all resources.
+			* Safe to call multiple times or before start(). After stop(), write() or
+			* start() begins a fresh session.
+			*/
+			stop() {
+				if (!this._started) {
+					if (this._starting) this._stopRequested = true;
+					return;
+				}
+				this._started = false;
+				if (this._workletNode) {
+					try {
+						this._workletNode.port.postMessage({ type: "flush" });
+					} catch {}
+					this._workletNode.disconnect();
+					this._workletNode.port.onmessage = null;
+					this._workletNode.port.close();
+				}
+				if (this._audioContext) this._audioContext.close();
+				const drains = this._pendingDrains;
+				this._pendingDrains = [];
+				for (const resolve of drains) resolve();
+				this._audioContext = null;
+				this._workletNode = null;
+				this._resampler = null;
+				this._lastAck = null;
+				this._unplayed = false;
+			}
+			/** Whether audio is currently queued and playing. */
+			get isPlaying() {
+				return this._started && this._unplayed;
+			}
+			async _doStart() {
+				this._audioContext = new AudioContext();
+				this._contextRate = this._audioContext.sampleRate;
+				await this._audioContext.resume();
+				if (this._audioContext.state === "suspended") {
+					await this._audioContext.close();
+					this._audioContext = null;
+					throw new Error("Audio playback is blocked until a user gesture resumes the audio context");
+				}
+				let blobUrl = null;
+				const workletUrl = this._workletUrl ?? (blobUrl = this._createBlobUrl());
+				try {
+					await this._audioContext.audioWorklet.addModule(workletUrl);
+				} catch (err) {
+					if (blobUrl) URL.revokeObjectURL(blobUrl);
+					await this._audioContext.close();
+					this._audioContext = null;
+					throw new Error("Failed to load audio worklet: " + (err instanceof Error ? err.message : String(err)));
+				}
+				if (blobUrl) URL.revokeObjectURL(blobUrl);
+				this._capacity = Math.round(this._contextRate * BUFFER_SECONDS);
+				this._resampler = new Resampler(this._sampleRate, this._contextRate);
+				this._lastAck = null;
+				this._unplayed = false;
+				this._workletNode = new AudioWorkletNode(this._audioContext, "decibri-output-processor", {
+					numberOfInputs: 0,
+					numberOfOutputs: 1,
+					outputChannelCount: [this._channels],
+					processorOptions: { ringCapacity: this._capacity }
+				});
+				this._workletNode.port.onmessage = (event) => this._onMessage(event);
+				this._workletNode.connect(this._audioContext.destination);
+				this._started = true;
+				if (this._stopRequested) {
+					this._stopRequested = false;
+					this.stop();
+				}
+			}
+			_onMessage(event) {
+				const msg = event.data;
+				if (!msg) return;
+				if (msg.type === "level") {
+					this._lastAck = {
+						queued: msg.queued,
+						time: this._now()
+					};
+					this._capacity = msg.capacity;
+				} else if (msg.type === "drained") {
+					this._unplayed = false;
+					const drains = this._pendingDrains;
+					this._pendingDrains = [];
+					for (const resolve of drains) resolve();
+				}
+			}
+			_createBlobUrl() {
+				const blob = new Blob([OUTPUT_WORKLET_SOURCE], { type: "application/javascript" });
+				return URL.createObjectURL(blob);
+			}
+			_now() {
+				return this._audioContext ? this._audioContext.currentTime : 0;
+			}
+			_estimateQueue() {
+				if (!this._lastAck) return 0;
+				const elapsed = this._now() - this._lastAck.time;
+				const played = Math.max(0, elapsed) * this._contextRate;
+				return Math.max(0, this._lastAck.queued - played);
+			}
+			async _reserve(samples) {
+				while (this._started) {
+					const overflow = this._estimateQueue() + samples - this._capacity;
+					if (overflow <= 0) return;
+					const waitMs = Math.max(1, overflow / this._contextRate * 1e3);
+					await new Promise((resolve) => setTimeout(resolve, waitMs));
+				}
+			}
+			_convert(chunk) {
+				let float32;
+				if (this._dtype === "int16") {
+					const int16 = this._asInt16(chunk);
+					float32 = new Float32Array(int16.length);
+					for (let i = 0; i < int16.length; i++) float32[i] = int16[i] / 32768;
+				} else float32 = this._asFloat32(chunk);
+				return this._resampler.process(float32);
+			}
+			_asInt16(chunk) {
+				if (chunk instanceof Int16Array) return chunk;
+				if (chunk instanceof ArrayBuffer) return new Int16Array(chunk);
+				if (ArrayBuffer.isView(chunk)) return new Int16Array(chunk.buffer, chunk.byteOffset, Math.floor(chunk.byteLength / 2));
+				throw new TypeError("write() expects an Int16Array, ArrayBuffer, or typed array for int16 dtype");
+			}
+			_asFloat32(chunk) {
+				if (chunk instanceof Float32Array) return chunk;
+				if (chunk instanceof ArrayBuffer) return new Float32Array(chunk);
+				if (ArrayBuffer.isView(chunk)) return new Float32Array(chunk.buffer, chunk.byteOffset, Math.floor(chunk.byteLength / 4));
+				throw new TypeError("write() expects a Float32Array, ArrayBuffer, or typed array for float32 dtype");
+			}
+		};
+		module.exports = { Speaker };
+	}));
+	//#endregion
+	return (/* @__PURE__ */ __commonJSMin(((exports, module) => {
+		const { Microphone } = require_decibri_browser();
+		const { Speaker } = require_decibri_output_browser();
+		const { Emitter } = require_emitter();
+		module.exports = {
+			Microphone,
+			Speaker,
+			Emitter
+		};
+	})))();
+})();

--- a/npm/decibri/examples/decibri.browser.js
+++ b/npm/decibri/examples/decibri.browser.js
@@ -4,7 +4,7 @@ var decibri = (function() {
 	//#region \0rolldown/runtime.js
 	var __commonJSMin = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
 	//#endregion
-	//#region ../development/decibri/rust/decibri/repository/decibri/npm/decibri/src/browser/emitter.js
+	//#region npm/decibri/src/browser/emitter.js
 	var require_emitter = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		/**
 		* Minimal event emitter for browsers.
@@ -61,16 +61,16 @@ var decibri = (function() {
 		module.exports = { Emitter };
 	}));
 	//#endregion
-	//#region ../development/decibri/rust/decibri/repository/decibri/npm/decibri/src/browser/worklet-inline.js
+	//#region npm/decibri/src/browser/worklet-inline.js
 	var require_worklet_inline = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		module.exports = { WORKLET_SOURCE: "var u=class extends AudioWorkletProcessor{constructor(r){super();let e=r.processorOptions;this.framesPerBuffer=e.framesPerBuffer,this.format=e.format,this.ratio=e.nativeSampleRate/e.targetSampleRate,this.needsResample=e.nativeSampleRate!==e.targetSampleRate,this.position=0,this.buffer=new Float32Array(this.framesPerBuffer),this.bufferIndex=0}process(r,e,s){let t=r[0]?.[0];if(!t||t.length===0)return!0;let f;this.needsResample?f=this.resample(t):f=t;let a=0;for(;a<f.length;){let i=this.framesPerBuffer-this.bufferIndex,o=f.length-a,n=Math.min(i,o);this.buffer.set(f.subarray(a,a+n),this.bufferIndex),this.bufferIndex+=n,a+=n,this.bufferIndex>=this.framesPerBuffer&&this.flush()}return!0}resample(r){let e=r.length,s=0,t=this.position;for(;t<e-1;)s++,t+=this.ratio;let f=new Float32Array(s);t=this.position;for(let a=0;a<s;a++){let i=Math.floor(t),o=t-i;f[a]=r[i]*(1-o)+r[i+1]*o,t+=this.ratio}return this.position=Math.max(0,t-e),f}flush(){let r;if(this.format===\"int16\"){let e=new Int16Array(this.framesPerBuffer);for(let s=0;s<this.framesPerBuffer;s++)e[s]=Math.max(-32768,Math.min(32767,Math.round(this.buffer[s]*32768)));r=e.buffer}else r=this.buffer.slice(0,this.framesPerBuffer).buffer;this.port.postMessage(r,[r]),this.buffer=new Float32Array(this.framesPerBuffer),this.bufferIndex=0}};registerProcessor(\"decibri-processor\",u);\n" };
 	}));
 	//#endregion
-	//#region ../development/decibri/rust/decibri/repository/decibri/npm/decibri/src/browser/decibri-browser.js
+	//#region npm/decibri/src/browser/decibri-browser.js
 	var require_decibri_browser = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		const { Emitter } = require_emitter();
 		const { WORKLET_SOURCE } = require_worklet_inline();
-		const VERSION = "4.0.0";
+		const VERSION = "4.2.0";
 		/**
 		* Browser microphone capture.
 		*
@@ -293,12 +293,12 @@ var decibri = (function() {
 		module.exports = { Microphone };
 	}));
 	//#endregion
-	//#region ../development/decibri/rust/decibri/repository/decibri/npm/decibri/src/browser/output-worklet-inline.js
+	//#region npm/decibri/src/browser/output-worklet-inline.js
 	var require_output_worklet_inline = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		module.exports = { OUTPUT_WORKLET_SOURCE: "class R{constructor(t){this.capacity=t,this.buffer=new Float32Array(t),this.writeIndex=0,this.readIndex=0,this.size=0}get availableRead(){return this.size}get availableWrite(){return this.capacity-this.size}get isEmpty(){return this.size===0}get isFull(){return this.size===this.capacity}write(t){let e=Math.min(t.length,this.availableWrite);for(let s=0;s<e;s++)this.buffer[this.writeIndex]=t[s],this.writeIndex=this.writeIndex+1===this.capacity?0:this.writeIndex+1;return this.size+=e,e}readInto(t,e,s){let i=Math.min(s,this.size);for(let f=0;f<i;f++)t[e+f]=this.buffer[this.readIndex],this.readIndex=this.readIndex+1===this.capacity?0:this.readIndex+1;return this.size-=i,i}clear(){this.writeIndex=0,this.readIndex=0,this.size=0}}class P extends AudioWorkletProcessor{constructor(t){super();let e=t&&t.processorOptions||{},s=e.ringCapacity??96000;this.ring=new R(s),this.hadData=!1,this.port.onmessage=i=>this._onmessage(i)}_onmessage(t){let e=t.data;if(e&&e.type===\"flush\"){this.ring.clear(),this.hadData=!1;return}if(e instanceof ArrayBuffer){let s=new Float32Array(e),i=this.ring.write(s);i>0&&(this.hadData=!0),this.port.postMessage({type:\"level\",queued:this.ring.availableRead,capacity:this.ring.capacity,accepted:i,requested:s.length})}}process(t,e,s){let i=e[0];if(!i||i.length===0)return!0;let f=i[0].length,a=this.ring.readInto(i[0],0,f);for(let o=a;o<f;o++)i[0][o]=0;for(let o=1;o<i.length;o++)i[o].set(i[0]);return this.hadData&&this.ring.isEmpty&&(this.hadData=!1,this.port.postMessage({type:\"drained\"})),!0}}P.RingBuffer=R;registerProcessor(\"decibri-output-processor\",P);\n" };
 	}));
 	//#endregion
-	//#region ../development/decibri/rust/decibri/repository/decibri/npm/decibri/src/browser/decibri-output-browser.js
+	//#region npm/decibri/src/browser/decibri-output-browser.js
 	var require_decibri_output_browser = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		const { OUTPUT_WORKLET_SOURCE } = require_output_worklet_inline();
 		const BUFFER_SECONDS = 2;

--- a/npm/decibri/package.json
+++ b/npm/decibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decibri",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Cross-platform audio capture, playback, and processing for Node.js and browsers",
   "main": "src/decibri.js",
   "types": "src/decibri.d.ts",
@@ -72,10 +72,10 @@
     "MIGRATION.md"
   ],
   "optionalDependencies": {
-    "@decibri/decibri-win32-x64-msvc": "4.1.0",
-    "@decibri/decibri-darwin-arm64": "4.1.0",
-    "@decibri/decibri-linux-x64-gnu": "4.1.0",
-    "@decibri/decibri-linux-arm64-gnu": "4.1.0"
+    "@decibri/decibri-win32-x64-msvc": "4.2.0",
+    "@decibri/decibri-darwin-arm64": "4.2.0",
+    "@decibri/decibri-linux-x64-gnu": "4.2.0",
+    "@decibri/decibri-linux-arm64-gnu": "4.2.0"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.7.0"

--- a/npm/decibri/src/browser/decibri-browser.js
+++ b/npm/decibri/src/browser/decibri-browser.js
@@ -6,7 +6,7 @@ const { WORKLET_SOURCE } = require('./worklet-inline.js');
 // Browser build version. Keep in sync with package.json on each release; the
 // browser bundle cannot read package.json at runtime the way the Node wrapper
 // does, so this is a maintained constant.
-const VERSION = '4.0.0';
+const VERSION = '4.2.0';
 
 /**
  * Browser microphone capture.

--- a/npm/decibri/src/browser/decibri-output-browser.js
+++ b/npm/decibri/src/browser/decibri-output-browser.js
@@ -1,0 +1,377 @@
+'use strict';
+
+const { OUTPUT_WORKLET_SOURCE } = require('./output-worklet-inline.js');
+
+// Seconds of audio the output ring buffer holds. The ring capacity is derived
+// from this and the context sample rate at start, so backpressure kicks in
+// before more than this much audio is queued ahead of playback.
+const BUFFER_SECONDS = 2;
+
+/**
+ * Linear-interpolation resampler, the inverse of the capture worklet's: it
+ * takes samples at the user's rate and produces samples at the context rate.
+ * Carries a fractional position across calls so successive writes stay
+ * continuous. Logic mirrors worklet-processor.js resample(), with from and to
+ * swapped (from = user rate, to = context rate).
+ */
+class Resampler {
+  constructor(fromRate, toRate) {
+    this.ratio = fromRate / toRate;
+    this.position = 0;
+  }
+
+  process(input) {
+    if (this.ratio === 1) return input;
+
+    const inputLength = input.length;
+
+    let count = 0;
+    let pos = this.position;
+    while (pos < inputLength - 1) {
+      count++;
+      pos += this.ratio;
+    }
+
+    const output = new Float32Array(count);
+    pos = this.position;
+
+    for (let i = 0; i < count; i++) {
+      const idx = Math.floor(pos);
+      const frac = pos - idx;
+      output[i] = input[idx] * (1 - frac) + input[idx + 1] * frac;
+      pos += this.ratio;
+    }
+
+    this.position = Math.max(0, pos - inputLength);
+
+    return output;
+  }
+}
+
+/**
+ * Browser audio playback.
+ *
+ * Plays PCM audio through the Web Audio API. Samples are converted to float32
+ * and resampled to the context rate on the main thread, then fed to an output
+ * AudioWorklet that drains them to the speakers. This is the inverse of the
+ * browser Microphone: the Microphone captures input and emits chunks; the
+ * Speaker accepts chunks and plays them.
+ *
+ * Playback is async throughout, as the browser requires: write() resolves when
+ * the samples are queued (after backpressure when the queue is full) and
+ * drain() resolves when the queued audio has finished playing. The first
+ * write() (or start()) must run in a user gesture so the browser allows audio.
+ *
+ * @example
+ * const { Speaker } = require('decibri'); // browser entry via conditional export
+ * const speaker = new Speaker({ sampleRate: 16000 });
+ * button.onclick = async () => {
+ *   await speaker.write(int16Chunk); // Int16Array of PCM samples
+ *   await speaker.drain();
+ *   speaker.stop();
+ * };
+ */
+class Speaker {
+  constructor(options = {}) {
+    // ── State ─────────────────────────────────────────────────────────────
+    this._audioContext = null;
+    this._workletNode = null;
+    this._resampler = null;
+    this._started = false;
+    this._starting = null;
+    this._stopRequested = false;
+
+    // Last authoritative ring level from a 'level' ack, with the context time
+    // it was observed, so the current depth can be estimated by decay.
+    this._lastAck = null;
+    // Ring capacity in samples, set at start from the context rate. The 'level'
+    // acks confirm it.
+    this._capacity = 0;
+    this._contextRate = 0;
+
+    // Whether audio queued for playback has not yet finished. Set on each feed,
+    // cleared when the worklet reports the ring drained.
+    this._unplayed = false;
+    this._pendingDrains = [];
+
+    // ── Options ───────────────────────────────────────────────────────────
+    this._sampleRate = options.sampleRate ?? 16000;
+    this._channels = options.channels ?? 1;
+    this._dtype = options.dtype ?? 'int16';
+    this._workletUrl = options.workletUrl;
+
+    // ── Validate (mirrors the browser Microphone error style: TypeError) ────
+    if (this._sampleRate < 1000 || this._sampleRate > 384000) {
+      throw new TypeError(`sample rate must be between 1000 and 384000, got ${this._sampleRate}`);
+    }
+    if (this._channels < 1 || this._channels > 32) {
+      throw new TypeError(`channels must be between 1 and 32, got ${this._channels}`);
+    }
+    if (this._dtype !== 'int16' && this._dtype !== 'float32') {
+      throw new TypeError("dtype must be 'int16' or 'float32'");
+    }
+  }
+
+  // ── Public API ────────────────────────────────────────────────────────────
+
+  /**
+   * Create and resume the AudioContext and load the output worklet.
+   *
+   * Must be called from a user gesture context so the browser allows audio.
+   * Optional: write() starts playback on its own if start() was not called, but
+   * calling start() from a click handler is the reliable way to unlock audio
+   * before samples are ready. No-op if already started; returns the in-flight
+   * promise if a start is already in progress.
+   *
+   * @returns {Promise<void>}
+   */
+  start() {
+    if (this._started) return Promise.resolve();
+    if (this._starting) return this._starting;
+
+    this._starting = this._doStart().finally(() => {
+      this._starting = null;
+    });
+
+    return this._starting;
+  }
+
+  /**
+   * Play PCM audio. Resolves when the samples are queued.
+   *
+   * Converts the chunk to context-rate float32 (int16 to float32 if needed,
+   * then resample), and feeds it to the output worklet. When the queue is full
+   * it applies backpressure: the returned promise does not resolve until there
+   * is room, so a caller that awaits write() is paced to playback. Starts
+   * playback on the first call (gesture-sensitive).
+   *
+   * Await calls sequentially to preserve sample order. An empty chunk resolves
+   * immediately. Writing after stop() starts a fresh playback session.
+   *
+   * @param {Int16Array|Float32Array|ArrayBuffer} chunk PCM samples in the
+   *   configured dtype.
+   * @returns {Promise<void>}
+   */
+  async write(chunk) {
+    await this.start();
+    if (!this._started) throw new Error('Speaker is stopped');
+
+    const float32 = this._convert(chunk);
+    if (float32.length === 0) return;
+
+    let offset = 0;
+    while (offset < float32.length) {
+      const sliceLen = Math.min(float32.length - offset, this._capacity);
+      await this._reserve(sliceLen);
+      if (!this._started) throw new Error('Speaker is stopped');
+
+      // slice() copies into its own buffer, so transferring it does not neuter
+      // the caller's array or the rest of this conversion.
+      const slice = float32.slice(offset, offset + sliceLen);
+      this._workletNode.port.postMessage(slice.buffer, [slice.buffer]);
+
+      // Anchor the queue estimate optimistically so back-to-back writes pace
+      // correctly before the worklet's 'level' ack lands; the ack refines it.
+      this._lastAck = { queued: this._estimateQueue() + sliceLen, time: this._now() };
+      this._unplayed = true;
+      offset += sliceLen;
+    }
+  }
+
+  /**
+   * Wait for all queued audio to finish playing.
+   *
+   * Resolves when the worklet reports its queue drained. Resolves immediately
+   * if nothing is queued (nothing written, or playback already caught up).
+   *
+   * @returns {Promise<void>}
+   */
+  drain() {
+    if (!this._started || !this._unplayed) return Promise.resolve();
+    return new Promise((resolve) => {
+      this._pendingDrains.push(resolve);
+    });
+  }
+
+  /**
+   * Immediate stop. Discards queued audio and releases all resources.
+   * Safe to call multiple times or before start(). After stop(), write() or
+   * start() begins a fresh session.
+   */
+  stop() {
+    if (!this._started) {
+      // If a start is in flight, tear it down once it finishes.
+      if (this._starting) this._stopRequested = true;
+      return;
+    }
+    this._started = false;
+
+    if (this._workletNode) {
+      try {
+        this._workletNode.port.postMessage({ type: 'flush' });
+      } catch {
+        // The port may already be closing; the context close below stops audio.
+      }
+      this._workletNode.disconnect();
+      this._workletNode.port.onmessage = null;
+      this._workletNode.port.close();
+    }
+
+    if (this._audioContext) this._audioContext.close();
+
+    // The queue was discarded; release anyone waiting on drain so they do not
+    // hang. Nothing more will play on this session.
+    const drains = this._pendingDrains;
+    this._pendingDrains = [];
+    for (const resolve of drains) resolve();
+
+    this._audioContext = null;
+    this._workletNode = null;
+    this._resampler = null;
+    this._lastAck = null;
+    this._unplayed = false;
+  }
+
+  /** Whether audio is currently queued and playing. */
+  get isPlaying() {
+    return this._started && this._unplayed;
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  async _doStart() {
+    // 1. Create the AudioContext at its native rate and resume it (Safari and
+    //    the autoplay policy both leave it suspended until resumed).
+    this._audioContext = new AudioContext();
+    this._contextRate = this._audioContext.sampleRate;
+
+    await this._audioContext.resume();
+
+    // A context still suspended after resume() means the browser blocked audio
+    // (no user gesture). Surface it rather than failing silently.
+    if (this._audioContext.state === 'suspended') {
+      await this._audioContext.close();
+      this._audioContext = null;
+      throw new Error('Audio playback is blocked until a user gesture resumes the audio context');
+    }
+
+    // 2. Load the output AudioWorklet processor.
+    let blobUrl = null;
+    const workletUrl = this._workletUrl ?? (blobUrl = this._createBlobUrl());
+
+    try {
+      await this._audioContext.audioWorklet.addModule(workletUrl);
+    } catch (err) {
+      if (blobUrl) URL.revokeObjectURL(blobUrl);
+      await this._audioContext.close();
+      this._audioContext = null;
+      throw new Error('Failed to load audio worklet: ' + (err instanceof Error ? err.message : String(err)));
+    }
+
+    if (blobUrl) URL.revokeObjectURL(blobUrl);
+
+    // 3. Size the ring and build the resampler now that the context rate is known.
+    this._capacity = Math.round(this._contextRate * BUFFER_SECONDS);
+    this._resampler = new Resampler(this._sampleRate, this._contextRate);
+    this._lastAck = null;
+    this._unplayed = false;
+
+    // 4. Build the output node and connect it TO the destination (the inverse
+    //    of capture, which deliberately does not connect to the destination).
+    this._workletNode = new AudioWorkletNode(this._audioContext, 'decibri-output-processor', {
+      numberOfInputs: 0,
+      numberOfOutputs: 1,
+      outputChannelCount: [this._channels],
+      processorOptions: { ringCapacity: this._capacity },
+    });
+
+    this._workletNode.port.onmessage = (event) => this._onMessage(event);
+    this._workletNode.connect(this._audioContext.destination);
+
+    this._started = true;
+
+    // If stop() was called while start() was in flight, tear down now.
+    if (this._stopRequested) {
+      this._stopRequested = false;
+      this.stop();
+    }
+  }
+
+  _onMessage(event) {
+    const msg = event.data;
+    if (!msg) return;
+
+    if (msg.type === 'level') {
+      // Authoritative ring depth at this moment; the capacity is confirmed too.
+      this._lastAck = { queued: msg.queued, time: this._now() };
+      this._capacity = msg.capacity;
+    } else if (msg.type === 'drained') {
+      this._unplayed = false;
+      const drains = this._pendingDrains;
+      this._pendingDrains = [];
+      for (const resolve of drains) resolve();
+    }
+  }
+
+  _createBlobUrl() {
+    const blob = new Blob([OUTPUT_WORKLET_SOURCE], { type: 'application/javascript' });
+    return URL.createObjectURL(blob);
+  }
+
+  _now() {
+    return this._audioContext ? this._audioContext.currentTime : 0;
+  }
+
+  // Estimate the ring depth right now: the last acked depth, decayed by the
+  // samples that have played since (the worklet consumes at the context rate).
+  _estimateQueue() {
+    if (!this._lastAck) return 0;
+    const elapsed = this._now() - this._lastAck.time;
+    const played = Math.max(0, elapsed) * this._contextRate;
+    return Math.max(0, this._lastAck.queued - played);
+  }
+
+  // Wait until the ring can accept `samples` more without overflowing, so a
+  // transferred feed is never partially dropped. Returns as soon as there is
+  // room; under pressure it sleeps for the time the surplus needs to drain.
+  async _reserve(samples) {
+    while (this._started) {
+      const overflow = this._estimateQueue() + samples - this._capacity;
+      if (overflow <= 0) return;
+      const waitMs = Math.max(1, (overflow / this._contextRate) * 1000);
+      await new Promise((resolve) => setTimeout(resolve, waitMs));
+    }
+  }
+
+  _convert(chunk) {
+    let float32;
+    if (this._dtype === 'int16') {
+      const int16 = this._asInt16(chunk);
+      float32 = new Float32Array(int16.length);
+      for (let i = 0; i < int16.length; i++) float32[i] = int16[i] / 32768;
+    } else {
+      float32 = this._asFloat32(chunk);
+    }
+    return this._resampler.process(float32);
+  }
+
+  _asInt16(chunk) {
+    if (chunk instanceof Int16Array) return chunk;
+    if (chunk instanceof ArrayBuffer) return new Int16Array(chunk);
+    if (ArrayBuffer.isView(chunk)) {
+      return new Int16Array(chunk.buffer, chunk.byteOffset, Math.floor(chunk.byteLength / 2));
+    }
+    throw new TypeError('write() expects an Int16Array, ArrayBuffer, or typed array for int16 dtype');
+  }
+
+  _asFloat32(chunk) {
+    if (chunk instanceof Float32Array) return chunk;
+    if (chunk instanceof ArrayBuffer) return new Float32Array(chunk);
+    if (ArrayBuffer.isView(chunk)) {
+      return new Float32Array(chunk.buffer, chunk.byteOffset, Math.floor(chunk.byteLength / 4));
+    }
+    throw new TypeError('write() expects a Float32Array, ArrayBuffer, or typed array for float32 dtype');
+  }
+}
+
+module.exports = { Speaker };

--- a/npm/decibri/src/browser/index.d.ts
+++ b/npm/decibri/src/browser/index.d.ts
@@ -166,3 +166,88 @@ export declare class Microphone {
   emit(event: string, ...args: any[]): boolean;
   removeAllListeners(event?: string): this;
 }
+
+/** Constructor options for the browser `Speaker` class. */
+export interface SpeakerOptions {
+  /**
+   * Sample rate of the audio you write, in Hz. Samples are resampled to the
+   * audio context's native rate before playback.
+   * @default 16000
+   * @range 1000–384000
+   */
+  sampleRate?: number;
+
+  /**
+   * Number of output channels. A mono stream is played on every channel.
+   * @default 1
+   * @range 1–32
+   */
+  channels?: number;
+
+  /**
+   * Sample encoding data type of the audio you write.
+   * - `'int16'`: Int16Array of PCM samples
+   * - `'float32'`: Float32Array of samples in [-1, 1]
+   * @default 'int16'
+   */
+  dtype?: 'int16' | 'float32';
+
+  /**
+   * Custom URL for the output AudioWorklet processor script.
+   * Use this for strict CSP environments that block blob URLs.
+   * Omit to use the default inline blob URL.
+   */
+  workletUrl?: string;
+}
+
+/**
+ * Browser audio playback via the Web Audio API + AudioWorklet.
+ *
+ * Plays PCM audio. Samples are converted to float32 and resampled to the
+ * context rate on the main thread, then fed to an output worklet that drains
+ * them to the speakers. Playback is async throughout, as the browser requires:
+ * `write()` resolves when the samples are queued and `drain()` resolves when
+ * the queued audio has finished playing. The first `write()` (or `start()`)
+ * must run in a user gesture so the browser allows audio.
+ *
+ * @example
+ * ```js
+ * import { Speaker } from 'decibri'; // browser entry via conditional export
+ *
+ * const speaker = new Speaker({ sampleRate: 16000 });
+ * button.onclick = async () => {
+ *   await speaker.write(int16Chunk); // Int16Array of PCM samples
+ *   await speaker.drain();
+ *   speaker.stop();
+ * };
+ * ```
+ */
+export declare class Speaker {
+  constructor(options?: SpeakerOptions);
+
+  /**
+   * Create and resume the AudioContext and load the output worklet.
+   * Must be called from a user gesture context so the browser allows audio.
+   * Optional: `write()` starts playback on its own if `start()` was not called.
+   */
+  start(): Promise<void>;
+
+  /**
+   * Play PCM audio. Resolves when the samples are queued, applying backpressure
+   * (the promise waits) when the playback queue is full. Await calls
+   * sequentially to preserve sample order.
+   */
+  write(chunk: Int16Array | Float32Array | ArrayBuffer): Promise<void>;
+
+  /**
+   * Wait for all queued audio to finish playing. Resolves immediately if
+   * nothing is queued.
+   */
+  drain(): Promise<void>;
+
+  /** Immediate stop. Discards queued audio and releases all resources. */
+  stop(): void;
+
+  /** Whether audio is currently queued and playing. */
+  readonly isPlaying: boolean;
+}

--- a/npm/decibri/src/browser/index.js
+++ b/npm/decibri/src/browser/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { Microphone } = require('./decibri-browser.js');
+const { Speaker } = require('./decibri-output-browser.js');
 const { Emitter } = require('./emitter.js');
 
-module.exports = { Microphone, Emitter };
+module.exports = { Microphone, Speaker, Emitter };

--- a/npm/decibri/src/browser/output-worklet-inline.js
+++ b/npm/decibri/src/browser/output-worklet-inline.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/**
+ * Minified output AudioWorklet processor source, embedded as a string for Blob
+ * URL loading.
+ *
+ * THIS IS THE CODE THAT ACTUALLY RUNS IN THE BROWSER.
+ * The readable version is in output-worklet-processor.js (documentation /
+ * reference only). If output-worklet-processor.js logic changes, this string
+ * MUST be regenerated.
+ *
+ * Logic identical to output-worklet-processor.js.
+ */
+const OUTPUT_WORKLET_SOURCE = "class R{constructor(t){this.capacity=t,this.buffer=new Float32Array(t),this.writeIndex=0,this.readIndex=0,this.size=0}get availableRead(){return this.size}get availableWrite(){return this.capacity-this.size}get isEmpty(){return this.size===0}get isFull(){return this.size===this.capacity}write(t){let e=Math.min(t.length,this.availableWrite);for(let s=0;s<e;s++)this.buffer[this.writeIndex]=t[s],this.writeIndex=this.writeIndex+1===this.capacity?0:this.writeIndex+1;return this.size+=e,e}readInto(t,e,s){let i=Math.min(s,this.size);for(let f=0;f<i;f++)t[e+f]=this.buffer[this.readIndex],this.readIndex=this.readIndex+1===this.capacity?0:this.readIndex+1;return this.size-=i,i}clear(){this.writeIndex=0,this.readIndex=0,this.size=0}}class P extends AudioWorkletProcessor{constructor(t){super();let e=t&&t.processorOptions||{},s=e.ringCapacity??96000;this.ring=new R(s),this.hadData=!1,this.port.onmessage=i=>this._onmessage(i)}_onmessage(t){let e=t.data;if(e&&e.type===\"flush\"){this.ring.clear(),this.hadData=!1;return}if(e instanceof ArrayBuffer){let s=new Float32Array(e),i=this.ring.write(s);i>0&&(this.hadData=!0),this.port.postMessage({type:\"level\",queued:this.ring.availableRead,capacity:this.ring.capacity,accepted:i,requested:s.length})}}process(t,e,s){let i=e[0];if(!i||i.length===0)return!0;let f=i[0].length,a=this.ring.readInto(i[0],0,f);for(let o=a;o<f;o++)i[0][o]=0;for(let o=1;o<i.length;o++)i[o].set(i[0]);return this.hadData&&this.ring.isEmpty&&(this.hadData=!1,this.port.postMessage({type:\"drained\"})),!0}}P.RingBuffer=R;registerProcessor(\"decibri-output-processor\",P);\n";
+
+module.exports = { OUTPUT_WORKLET_SOURCE };

--- a/npm/decibri/src/browser/output-worklet-processor.js
+++ b/npm/decibri/src/browser/output-worklet-processor.js
@@ -1,0 +1,168 @@
+/**
+ * AudioWorklet processor for decibri browser playback.
+ *
+ * THIS FILE IS THE READABLE SOURCE. It is NOT loaded at runtime.
+ * The minified version in output-worklet-inline.js is what actually runs.
+ * If you change logic here, you MUST regenerate output-worklet-inline.js.
+ *
+ * Runs in a dedicated audio thread. Pulls queued Float32 samples (already at
+ * the context sample rate) from a ring buffer and writes them to the output
+ * channels. On underrun (the ring buffer is empty) it outputs silence cleanly,
+ * with no throw and no glitch beyond the unavoidable gap. This is the inverse
+ * of the capture processor: capture reads input frames and posts them to the
+ * main thread; this pulls main-thread frames from the ring and writes output.
+ *
+ * This file cannot import other modules (AudioWorklet restriction).
+ *
+ * Mirrors worklet-processor.js (capture) in reverse.
+ */
+
+/**
+ * Fixed-capacity single-producer single-consumer ring buffer of Float32
+ * samples. The main thread writes (produces) via write(); the audio thread
+ * reads (consumes) via readInto(). Indices wrap around at capacity. A write
+ * that would overflow stores only what fits and returns the accepted count, so
+ * the producer can apply backpressure. A read past the stored data returns the
+ * real count read, so the consumer can fill the remainder with silence.
+ */
+class RingBuffer {
+  constructor(capacity) {
+    this.capacity = capacity;
+    this.buffer = new Float32Array(capacity);
+    this.writeIndex = 0;
+    this.readIndex = 0;
+    this.size = 0;
+  }
+
+  /** Number of samples currently queued for reading. */
+  get availableRead() {
+    return this.size;
+  }
+
+  /** Number of free slots a write can still accept. */
+  get availableWrite() {
+    return this.capacity - this.size;
+  }
+
+  get isEmpty() {
+    return this.size === 0;
+  }
+
+  get isFull() {
+    return this.size === this.capacity;
+  }
+
+  /**
+   * Write up to samples.length samples into the buffer. Returns the number
+   * actually written, which is less than samples.length when the buffer fills.
+   */
+  write(samples) {
+    const toWrite = Math.min(samples.length, this.availableWrite);
+    for (let i = 0; i < toWrite; i++) {
+      this.buffer[this.writeIndex] = samples[i];
+      this.writeIndex = this.writeIndex + 1 === this.capacity ? 0 : this.writeIndex + 1;
+    }
+    this.size += toWrite;
+    return toWrite;
+  }
+
+  /**
+   * Read up to count samples into target starting at offset. Returns the
+   * number actually read, which is less than count on underrun. Positions in
+   * target beyond the returned count are left untouched (the caller fills them
+   * with silence).
+   */
+  readInto(target, offset, count) {
+    const toRead = Math.min(count, this.size);
+    for (let i = 0; i < toRead; i++) {
+      target[offset + i] = this.buffer[this.readIndex];
+      this.readIndex = this.readIndex + 1 === this.capacity ? 0 : this.readIndex + 1;
+    }
+    this.size -= toRead;
+    return toRead;
+  }
+
+  /** Drop all queued samples and reset the pointers. */
+  clear() {
+    this.writeIndex = 0;
+    this.readIndex = 0;
+    this.size = 0;
+  }
+}
+
+class DecibriOutputProcessor extends AudioWorkletProcessor {
+  constructor(options) {
+    super();
+    const opts = (options && options.processorOptions) || {};
+    const capacity = opts.ringCapacity ?? 96000;
+    this.ring = new RingBuffer(capacity);
+    // Latches a single 'drained' notification per playout: set true when audio
+    // is queued, cleared (and the notification sent) when the ring next empties.
+    this.hadData = false;
+    this.port.onmessage = (event) => this._onmessage(event);
+  }
+
+  _onmessage(event) {
+    const data = event.data;
+
+    // Control message: drop the queue (stop / reset). No drain notification is
+    // sent for a flush; a flush is an explicit stop, not a natural playout end.
+    if (data && data.type === 'flush') {
+      this.ring.clear();
+      this.hadData = false;
+      return;
+    }
+
+    // Data message: a raw Float32 sample buffer (transferable), mirroring the
+    // capture worklet's raw-buffer format in reverse. The samples are already
+    // at the context sample rate; the main thread does any resample and dtype
+    // conversion before feeding.
+    if (data instanceof ArrayBuffer) {
+      const samples = new Float32Array(data);
+      const accepted = this.ring.write(samples);
+      if (accepted > 0) this.hadData = true;
+      // Backpressure ack: report the new fill level so the producer can pace
+      // its writes, and signal drops (accepted < requested means the ring was
+      // full and the surplus was discarded).
+      this.port.postMessage({
+        type: 'level',
+        queued: this.ring.availableRead,
+        capacity: this.ring.capacity,
+        accepted,
+        requested: samples.length,
+      });
+    }
+  }
+
+  process(_inputs, outputs, _parameters) {
+    const output = outputs[0];
+    if (!output || output.length === 0) return true;
+
+    const frames = output[0].length;
+    const got = this.ring.readInto(output[0], 0, frames);
+
+    // Underrun: fill the rest of the first channel with silence.
+    for (let i = got; i < frames; i++) output[0][i] = 0;
+
+    // Fan the mono stream out to any additional output channels.
+    for (let ch = 1; ch < output.length; ch++) {
+      output[ch].set(output[0]);
+    }
+
+    // Drain detection: notify the main thread once when the queue empties
+    // after having held audio, so the Speaker's drain() can resolve.
+    if (this.hadData && this.ring.isEmpty) {
+      this.hadData = false;
+      this.port.postMessage({ type: 'drained' });
+    }
+
+    // Keep the processor alive across underruns so playback can resume.
+    return true;
+  }
+}
+
+// Exposed so the test harness can exercise the ring buffer in isolation. The
+// runtime worklet never reads this property; it is a harmless static.
+DecibriOutputProcessor.RingBuffer = RingBuffer;
+
+registerProcessor('decibri-output-processor', DecibriOutputProcessor);

--- a/npm/platform-darwin-arm64/package.json
+++ b/npm/platform-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-darwin-arm64",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "os": ["darwin"],
   "cpu": ["arm64"],
   "main": "decibri.darwin-arm64.node",

--- a/npm/platform-linux-arm64-gnu/package.json
+++ b/npm/platform-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-arm64-gnu",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "os": ["linux"],
   "cpu": ["arm64"],
   "main": "decibri.linux-arm64-gnu.node",

--- a/npm/platform-linux-x64-gnu/package.json
+++ b/npm/platform-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-x64-gnu",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "os": ["linux"],
   "cpu": ["x64"],
   "main": "decibri.linux-x64-gnu.node",

--- a/npm/platform-win32-x64-msvc/package.json
+++ b/npm/platform-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-win32-x64-msvc",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "os": ["win32"],
   "cpu": ["x64"],
   "main": "decibri.win32-x64-msvc.node",

--- a/tests/browser/decibri-output-browser.test.js
+++ b/tests/browser/decibri-output-browser.test.js
@@ -1,0 +1,455 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Web Audio main-thread mocks ──────────────────────────────────────────────
+
+// Controllable audio clock so backpressure (which decays the queue estimate by
+// elapsed context time) can be driven deterministically.
+const mockTime = { value: 0 };
+
+const mockPort = {
+  postMessage: vi.fn(),
+  onmessage: null,
+  close: vi.fn(),
+};
+const mockWorkletNode = {
+  port: mockPort,
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+};
+
+let capturedWorkletOptions = null;
+const MockAudioWorkletNode = vi.fn().mockImplementation(function (_ctx, _name, options) {
+  capturedWorkletOptions = options;
+  return mockWorkletNode;
+});
+
+const mockDestination = {};
+const mockAddModule = vi.fn().mockResolvedValue(undefined);
+const mockContextClose = vi.fn().mockResolvedValue(undefined);
+let contextState = 'suspended';
+const mockContextResume = vi.fn().mockImplementation(async () => { contextState = 'running'; });
+
+const MockAudioContext = vi.fn().mockImplementation(function () {
+  return {
+    sampleRate: 48000,
+    get state() { return contextState; },
+    get currentTime() { return mockTime.value; },
+    resume: mockContextResume,
+    close: mockContextClose,
+    audioWorklet: { addModule: mockAddModule },
+    destination: mockDestination,
+  };
+});
+
+vi.stubGlobal('AudioContext', MockAudioContext);
+vi.stubGlobal('AudioWorkletNode', MockAudioWorkletNode);
+vi.stubGlobal('Blob', class MockBlob {
+  constructor(parts, options) { this.parts = parts; this.options = options; }
+});
+const OriginalURL = globalThis.URL;
+const MockURL = Object.assign(function (...args) { return new OriginalURL(...args); }, {
+  createObjectURL: vi.fn().mockReturnValue('blob:mock'),
+  revokeObjectURL: vi.fn(),
+  prototype: OriginalURL.prototype,
+});
+vi.stubGlobal('URL', MockURL);
+
+// Import after mocks
+const { Speaker } = await import('../../npm/decibri/src/browser/decibri-output-browser.js');
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function resetMocks() {
+  vi.clearAllMocks();
+  mockPort.onmessage = null;
+  capturedWorkletOptions = null;
+  mockTime.value = 0;
+  contextState = 'suspended';
+  mockContextResume.mockImplementation(async () => { contextState = 'running'; });
+  mockAddModule.mockResolvedValue(undefined);
+  mockContextClose.mockResolvedValue(undefined);
+}
+
+// The float32 buffer of the nth raw-ArrayBuffer feed posted to the worklet.
+function fedBuffer(n = 0) {
+  const calls = mockPort.postMessage.mock.calls.filter(c => c[0] instanceof ArrayBuffer);
+  return new Float32Array(calls[n][0]);
+}
+
+// ── Construction / validation ────────────────────────────────────────────────
+
+describe('Speaker constructor', () => {
+  beforeEach(resetMocks);
+
+  it('creates an instance with defaults', () => {
+    const speaker = new Speaker();
+    expect(speaker).toBeInstanceOf(Speaker);
+    expect(speaker.isPlaying).toBe(false);
+  });
+
+  it('accepts all options', () => {
+    const speaker = new Speaker({
+      sampleRate: 44100,
+      channels: 2,
+      dtype: 'float32',
+      workletUrl: '/output-worklet.js',
+    });
+    expect(speaker.isPlaying).toBe(false);
+  });
+});
+
+describe('Speaker constructor validation', () => {
+  beforeEach(resetMocks);
+
+  it('throws TypeError on invalid sampleRate', () => {
+    expect(() => new Speaker({ sampleRate: 0 })).toThrow(TypeError);
+    expect(() => new Speaker({ sampleRate: 0 })).toThrow('sample rate');
+    expect(() => new Speaker({ sampleRate: 500000 })).toThrow('sample rate');
+  });
+
+  it('throws TypeError on invalid channels', () => {
+    expect(() => new Speaker({ channels: 0 })).toThrow('channels');
+    expect(() => new Speaker({ channels: 33 })).toThrow('channels');
+  });
+
+  it('throws TypeError on invalid dtype', () => {
+    expect(() => new Speaker({ dtype: 'int8' })).toThrow("dtype must be 'int16' or 'float32'");
+  });
+
+  it('accepts int16 and float32 dtype', () => {
+    expect(() => new Speaker({ dtype: 'int16' })).not.toThrow();
+    expect(() => new Speaker({ dtype: 'float32' })).not.toThrow();
+  });
+});
+
+// ── start() ──────────────────────────────────────────────────────────────────
+
+describe('Speaker.start()', () => {
+  beforeEach(resetMocks);
+
+  it('creates, resumes the context and loads the output worklet', async () => {
+    const speaker = new Speaker();
+    await speaker.start();
+
+    expect(MockAudioContext).toHaveBeenCalledTimes(1);
+    expect(mockContextResume).toHaveBeenCalled();
+    expect(mockAddModule).toHaveBeenCalledWith('blob:mock');
+    speaker.stop();
+  });
+
+  it('builds an output node connected to the destination', async () => {
+    const speaker = new Speaker({ channels: 2 });
+    await speaker.start();
+
+    expect(MockAudioWorkletNode).toHaveBeenCalledWith(
+      expect.anything(),
+      'decibri-output-processor',
+      expect.objectContaining({
+        numberOfInputs: 0,
+        numberOfOutputs: 1,
+        outputChannelCount: [2],
+        processorOptions: { ringCapacity: 96000 },
+      }),
+    );
+    expect(mockWorkletNode.connect).toHaveBeenCalledWith(mockDestination);
+    speaker.stop();
+  });
+
+  it('uses a custom workletUrl when provided (CSP override)', async () => {
+    const speaker = new Speaker({ workletUrl: '/my-worklet.js' });
+    await speaker.start();
+    expect(mockAddModule).toHaveBeenCalledWith('/my-worklet.js');
+    expect(MockURL.createObjectURL).not.toHaveBeenCalled();
+    speaker.stop();
+  });
+
+  it('is a no-op if already started', async () => {
+    const speaker = new Speaker();
+    await speaker.start();
+    await speaker.start();
+    expect(MockAudioContext).toHaveBeenCalledTimes(1);
+    speaker.stop();
+  });
+
+  it('returns the same promise if a start is in progress', async () => {
+    const speaker = new Speaker();
+    const p1 = speaker.start();
+    const p2 = speaker.start();
+    expect(p1).toBe(p2);
+    await p1;
+    speaker.stop();
+  });
+
+  it('throws a clear error when the context stays suspended (autoplay blocked)', async () => {
+    mockContextResume.mockImplementationOnce(async () => { /* stays suspended */ });
+    const speaker = new Speaker();
+    await expect(speaker.start()).rejects.toThrow('blocked until a user gesture');
+    expect(mockContextClose).toHaveBeenCalled();
+  });
+
+  it('throws a clear error when the worklet fails to load', async () => {
+    mockAddModule.mockRejectedValueOnce(new Error('CSP blocked'));
+    const speaker = new Speaker();
+    await expect(speaker.start()).rejects.toThrow('Failed to load audio worklet');
+    expect(mockContextClose).toHaveBeenCalled();
+  });
+});
+
+// ── Conversion pipeline ──────────────────────────────────────────────────────
+
+describe('Speaker conversion pipeline', () => {
+  beforeEach(resetMocks);
+
+  it('converts int16 to float32 before feeding (no resample when rates match)', async () => {
+    const speaker = new Speaker({ sampleRate: 48000, dtype: 'int16' });
+    await speaker.write(new Int16Array([16384, -16384, 0, 32767]));
+
+    const f = fedBuffer();
+    expect(f.length).toBe(4);
+    expect(f[0]).toBeCloseTo(0.5);
+    expect(f[1]).toBeCloseTo(-0.5);
+    expect(f[2]).toBeCloseTo(0);
+    expect(f[3]).toBeCloseTo(32767 / 32768);
+    speaker.stop();
+  });
+
+  it('passes float32 through unchanged when rates match', async () => {
+    const speaker = new Speaker({ sampleRate: 48000, dtype: 'float32' });
+    await speaker.write(new Float32Array([0.1, -0.2, 0.3]));
+
+    const f = fedBuffer();
+    expect(f.length).toBe(3);
+    expect(f[0]).toBeCloseTo(0.1);
+    expect(f[1]).toBeCloseTo(-0.2);
+    expect(f[2]).toBeCloseTo(0.3);
+    speaker.stop();
+  });
+
+  it('resamples user rate up to the context rate at an exact 2x ratio (24000 -> 48000)', async () => {
+    const speaker = new Speaker({ sampleRate: 24000, dtype: 'float32' });
+    await speaker.write(new Float32Array(10).fill(0.5));
+
+    const f = fedBuffer();
+    // ratio 0.5 (exactly representable): a length-10 input yields 18 samples.
+    expect(f.length).toBe(18);
+    for (let i = 0; i < f.length; i++) expect(f[i]).toBeCloseTo(0.5, 4);
+    speaker.stop();
+  });
+
+  it('upsamples roughly 3x for 16000 -> 48000', async () => {
+    const speaker = new Speaker({ sampleRate: 16000, dtype: 'float32' });
+    await speaker.write(new Float32Array(10).fill(0.5));
+
+    const f = fedBuffer();
+    // About 3x the input (the exact count is set by deterministic float math).
+    expect(f.length).toBeGreaterThanOrEqual(27);
+    expect(f.length).toBeLessThanOrEqual(30);
+    for (let i = 0; i < f.length; i++) expect(f[i]).toBeCloseTo(0.5, 4);
+    speaker.stop();
+  });
+
+  it('feeds the worklet a transferable ArrayBuffer', async () => {
+    const speaker = new Speaker({ sampleRate: 48000, dtype: 'float32' });
+    await speaker.write(new Float32Array([0.1, 0.2]));
+
+    const dataCall = mockPort.postMessage.mock.calls.find(c => c[0] instanceof ArrayBuffer);
+    expect(dataCall[1]).toBeInstanceOf(Array);
+    expect(dataCall[1][0]).toBe(dataCall[0]);
+    speaker.stop();
+  });
+
+  it('resolves immediately on an empty chunk without feeding', async () => {
+    const speaker = new Speaker({ sampleRate: 48000, dtype: 'float32' });
+    await speaker.write(new Float32Array(0));
+    const dataCalls = mockPort.postMessage.mock.calls.filter(c => c[0] instanceof ArrayBuffer);
+    expect(dataCalls).toHaveLength(0);
+    speaker.stop();
+  });
+
+  it('throws for a wrong input type', async () => {
+    const speaker = new Speaker({ sampleRate: 48000, dtype: 'int16' });
+    await speaker.start();
+    await expect(speaker.write('not audio')).rejects.toThrow('Int16Array');
+    speaker.stop();
+  });
+});
+
+// ── write() backpressure ─────────────────────────────────────────────────────
+
+describe('Speaker.write() backpressure', () => {
+  beforeEach(resetMocks);
+
+  it('paces writes so the queue estimate does not overflow the ring', async () => {
+    vi.useFakeTimers();
+    try {
+      const speaker = new Speaker({ sampleRate: 48000, dtype: 'float32' }); // capacity 96000
+      await speaker.start();
+      mockTime.value = 0;
+
+      // First 50000 fits (estimate 0 -> 50000).
+      await speaker.write(new Float32Array(50000).fill(0.1));
+      expect(mockPort.postMessage.mock.calls.filter(c => c[0] instanceof ArrayBuffer)).toHaveLength(1);
+
+      // Second 50000 would overflow (50000 + 50000 > 96000): write must wait.
+      let resolved = false;
+      speaker.write(new Float32Array(50000).fill(0.2)).then(() => { resolved = true; });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+      expect(mockPort.postMessage.mock.calls.filter(c => c[0] instanceof ArrayBuffer)).toHaveLength(1);
+
+      // Advance the audio clock so enough has played, then let the timer fire.
+      mockTime.value = 0.2; // 9600 samples played -> estimate 40400, now fits
+      await vi.advanceTimersByTimeAsync(200);
+      expect(resolved).toBe(true);
+      expect(mockPort.postMessage.mock.calls.filter(c => c[0] instanceof ArrayBuffer)).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('applies backpressure when a level ack reports the ring full', async () => {
+    vi.useFakeTimers();
+    try {
+      const speaker = new Speaker({ sampleRate: 48000, dtype: 'float32' });
+      await speaker.start();
+      mockTime.value = 0;
+
+      // The worklet acks a full ring.
+      mockPort.onmessage({ data: { type: 'level', queued: 96000, capacity: 96000, accepted: 96000, requested: 96000 } });
+
+      let resolved = false;
+      speaker.write(new Float32Array(1000).fill(0.1)).then(() => { resolved = true; });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+
+      mockTime.value = 2.1; // more than the full ring has played
+      await vi.advanceTimersByTimeAsync(200);
+      expect(resolved).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// ── drain() ──────────────────────────────────────────────────────────────────
+
+describe('Speaker.drain()', () => {
+  beforeEach(resetMocks);
+
+  it('resolves immediately when nothing has been written', async () => {
+    const speaker = new Speaker();
+    await speaker.start();
+    await expect(speaker.drain()).resolves.toBeUndefined();
+    speaker.stop();
+  });
+
+  it('resolves immediately before start', async () => {
+    const speaker = new Speaker();
+    await expect(speaker.drain()).resolves.toBeUndefined();
+  });
+
+  it('resolves when the worklet reports the queue drained', async () => {
+    const speaker = new Speaker({ sampleRate: 48000, dtype: 'float32' });
+    await speaker.write(new Float32Array(100).fill(0.1));
+    expect(speaker.isPlaying).toBe(true);
+
+    let drained = false;
+    speaker.drain().then(() => { drained = true; });
+    await Promise.resolve();
+    expect(drained).toBe(false);
+
+    mockPort.onmessage({ data: { type: 'drained' } });
+    await Promise.resolve();
+    expect(drained).toBe(true);
+    expect(speaker.isPlaying).toBe(false);
+    speaker.stop();
+  });
+});
+
+// ── stop() ───────────────────────────────────────────────────────────────────
+
+describe('Speaker.stop()', () => {
+  beforeEach(resetMocks);
+
+  it('is a no-op before start', () => {
+    const speaker = new Speaker();
+    expect(() => speaker.stop()).not.toThrow();
+  });
+
+  it('flushes the worklet, tears down, and closes the context', async () => {
+    const speaker = new Speaker({ sampleRate: 48000, dtype: 'float32' });
+    await speaker.write(new Float32Array(100).fill(0.1));
+
+    speaker.stop();
+
+    expect(mockPort.postMessage).toHaveBeenCalledWith({ type: 'flush' });
+    expect(mockWorkletNode.disconnect).toHaveBeenCalled();
+    expect(mockPort.close).toHaveBeenCalled();
+    expect(mockContextClose).toHaveBeenCalled();
+    expect(speaker.isPlaying).toBe(false);
+  });
+
+  it('resolves a pending drain so it does not hang', async () => {
+    const speaker = new Speaker({ sampleRate: 48000, dtype: 'float32' });
+    await speaker.write(new Float32Array(100).fill(0.1));
+
+    let drained = false;
+    speaker.drain().then(() => { drained = true; });
+    await Promise.resolve();
+    expect(drained).toBe(false);
+
+    speaker.stop();
+    await Promise.resolve();
+    expect(drained).toBe(true);
+  });
+
+  it('is safe to call multiple times', async () => {
+    const speaker = new Speaker();
+    await speaker.start();
+    speaker.stop();
+    expect(() => speaker.stop()).not.toThrow();
+  });
+
+  it('allows a fresh session after stop', async () => {
+    const speaker = new Speaker({ sampleRate: 48000, dtype: 'float32' });
+    await speaker.write(new Float32Array(10).fill(0.1));
+    speaker.stop();
+
+    await speaker.write(new Float32Array(10).fill(0.2));
+    expect(MockAudioContext).toHaveBeenCalledTimes(2);
+    expect(speaker.isPlaying).toBe(true);
+    speaker.stop();
+  });
+});
+
+// ── isPlaying ────────────────────────────────────────────────────────────────
+
+describe('Speaker.isPlaying', () => {
+  beforeEach(resetMocks);
+
+  it('is false before start, true while audio is queued, false after drained', async () => {
+    const speaker = new Speaker({ sampleRate: 48000, dtype: 'float32' });
+    expect(speaker.isPlaying).toBe(false);
+
+    await speaker.write(new Float32Array(100).fill(0.1));
+    expect(speaker.isPlaying).toBe(true);
+
+    mockPort.onmessage({ data: { type: 'drained' } });
+    expect(speaker.isPlaying).toBe(false);
+    speaker.stop();
+  });
+});
+
+// ── Browser entry export ─────────────────────────────────────────────────────
+
+describe('browser entry exports Speaker', () => {
+  it('exposes Speaker alongside Microphone and Emitter', async () => {
+    const browser = await import('../../npm/decibri/src/browser/index.js');
+    const ns = browser.default ?? browser;
+    expect(typeof ns.Speaker).toBe('function');
+    expect(typeof ns.Microphone).toBe('function');
+    expect(typeof ns.Emitter).toBe('function');
+  });
+});

--- a/tests/browser/output-worklet-processor.test.js
+++ b/tests/browser/output-worklet-processor.test.js
@@ -1,0 +1,357 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// ── Mock AudioWorkletProcessor global ────────────────────────────────────────
+
+let registeredProcessor = null;
+
+class MockAudioWorkletProcessor {
+  constructor() {
+    this.port = { postMessage: vi.fn(), onmessage: null };
+  }
+}
+
+globalThis.AudioWorkletProcessor = MockAudioWorkletProcessor;
+globalThis.registerProcessor = (name, ctor) => {
+  registeredProcessor = { name, ctor };
+};
+
+// Import after mocks are in place (triggers registerProcessor)
+await import('../../npm/decibri/src/browser/output-worklet-processor.js');
+const inlineModule = await import('../../npm/decibri/src/browser/output-worklet-inline.js');
+const OUTPUT_WORKLET_SOURCE = inlineModule.OUTPUT_WORKLET_SOURCE || inlineModule.default?.OUTPUT_WORKLET_SOURCE;
+
+const RingBuffer = registeredProcessor.ctor.RingBuffer;
+
+function createProcessor(opts = {}) {
+  return new registeredProcessor.ctor({ processorOptions: opts });
+}
+
+// Build an `outputs` argument: a single output with `channels` Float32Arrays of
+// `frames` length each. Web Audio shape is outputs[outputIndex][channel].
+function makeOutputs(channels, frames) {
+  const out = [];
+  for (let c = 0; c < channels; c++) out.push(new Float32Array(frames));
+  return [out];
+}
+
+// ── RingBuffer ───────────────────────────────────────────────────────────────
+
+describe('RingBuffer basics', () => {
+  it('starts empty', () => {
+    const rb = new RingBuffer(4);
+    expect(rb.isEmpty).toBe(true);
+    expect(rb.isFull).toBe(false);
+    expect(rb.availableRead).toBe(0);
+    expect(rb.availableWrite).toBe(4);
+  });
+
+  it('write then read returns samples in order', () => {
+    const rb = new RingBuffer(8);
+    const written = rb.write(new Float32Array([0.1, 0.2, 0.3]));
+    expect(written).toBe(3);
+    expect(rb.availableRead).toBe(3);
+    expect(rb.availableWrite).toBe(5);
+
+    const out = new Float32Array(3);
+    const read = rb.readInto(out, 0, 3);
+    expect(read).toBe(3);
+    expect(out[0]).toBeCloseTo(0.1);
+    expect(out[1]).toBeCloseTo(0.2);
+    expect(out[2]).toBeCloseTo(0.3);
+    expect(rb.isEmpty).toBe(true);
+  });
+
+  it('reports full and accepts only what fits on overflow', () => {
+    const rb = new RingBuffer(4);
+    const written = rb.write(new Float32Array([1, 2, 3, 4, 5, 6]));
+    expect(written).toBe(4);
+    expect(rb.isFull).toBe(true);
+    expect(rb.availableWrite).toBe(0);
+
+    // A further write into a full buffer accepts nothing.
+    expect(rb.write(new Float32Array([7, 8]))).toBe(0);
+  });
+
+  it('reads only what is available on underrun and leaves the rest untouched', () => {
+    const rb = new RingBuffer(8);
+    rb.write(new Float32Array([0.5, 0.6]));
+
+    const out = new Float32Array(5).fill(-1);
+    const read = rb.readInto(out, 0, 5);
+    expect(read).toBe(2);
+    expect(out[0]).toBeCloseTo(0.5);
+    expect(out[1]).toBeCloseTo(0.6);
+    // Positions beyond the real samples are untouched (caller fills silence).
+    expect(out[2]).toBe(-1);
+    expect(out[3]).toBe(-1);
+    expect(out[4]).toBe(-1);
+  });
+
+  it('reads into target at an offset', () => {
+    const rb = new RingBuffer(8);
+    rb.write(new Float32Array([1, 2]));
+
+    const out = new Float32Array(4).fill(0);
+    const read = rb.readInto(out, 2, 2);
+    expect(read).toBe(2);
+    expect(out[0]).toBe(0);
+    expect(out[1]).toBe(0);
+    expect(out[2]).toBe(1);
+    expect(out[3]).toBe(2);
+  });
+
+  it('wraps around the capacity correctly', () => {
+    const rb = new RingBuffer(4);
+
+    // Fill 3, drain 2 to advance the read pointer.
+    rb.write(new Float32Array([1, 2, 3]));
+    const drain = new Float32Array(2);
+    rb.readInto(drain, 0, 2);
+    expect(rb.availableRead).toBe(1); // [3] remains, read/write indices advanced
+
+    // Write 3 more; this must wrap past the end of the backing array.
+    const written = rb.write(new Float32Array([4, 5, 6]));
+    expect(written).toBe(3);
+    expect(rb.availableRead).toBe(4);
+    expect(rb.isFull).toBe(true);
+
+    // Read all 4 back: must come out in FIFO order across the wrap.
+    const out = new Float32Array(4);
+    expect(rb.readInto(out, 0, 4)).toBe(4);
+    expect(Array.from(out)).toEqual([3, 4, 5, 6]);
+    expect(rb.isEmpty).toBe(true);
+  });
+
+  it('clear() drops all queued samples', () => {
+    const rb = new RingBuffer(4);
+    rb.write(new Float32Array([1, 2, 3]));
+    rb.clear();
+    expect(rb.isEmpty).toBe(true);
+    expect(rb.availableRead).toBe(0);
+    expect(rb.availableWrite).toBe(4);
+  });
+});
+
+// ── Processor registration ─────────────────────────────────────────────────
+
+describe('DecibriOutputProcessor registration', () => {
+  it('registers as decibri-output-processor', () => {
+    expect(registeredProcessor.name).toBe('decibri-output-processor');
+  });
+});
+
+// ── Message-port protocol: feeding samples ───────────────────────────────────
+
+describe('DecibriOutputProcessor feed protocol', () => {
+  it('enqueues a raw Float32 ArrayBuffer fed over the port', () => {
+    const proc = createProcessor();
+    const samples = new Float32Array([0.1, 0.2, 0.3, 0.4]);
+    proc.port.onmessage({ data: samples.buffer });
+
+    const outputs = makeOutputs(1, 4);
+    proc.process([], outputs, {});
+
+    const ch = outputs[0][0];
+    expect(ch[0]).toBeCloseTo(0.1);
+    expect(ch[1]).toBeCloseTo(0.2);
+    expect(ch[2]).toBeCloseTo(0.3);
+    expect(ch[3]).toBeCloseTo(0.4);
+  });
+
+  it('delivers samples in order across multiple feeds', () => {
+    const proc = createProcessor();
+    proc.port.onmessage({ data: new Float32Array([1, 2]).buffer });
+    proc.port.onmessage({ data: new Float32Array([3, 4]).buffer });
+
+    const outputs = makeOutputs(1, 4);
+    proc.process([], outputs, {});
+    expect(Array.from(outputs[0][0])).toEqual([1, 2, 3, 4]);
+  });
+
+  it('acks each feed with a level message', () => {
+    const proc = createProcessor({ ringCapacity: 100 });
+    proc.port.onmessage({ data: new Float32Array([1, 2, 3]).buffer });
+
+    expect(proc.port.postMessage).toHaveBeenCalledTimes(1);
+    const msg = proc.port.postMessage.mock.calls[0][0];
+    expect(msg).toEqual({
+      type: 'level',
+      queued: 3,
+      capacity: 100,
+      accepted: 3,
+      requested: 3,
+    });
+  });
+
+  it('reports dropped samples when the ring overflows (backpressure signal)', () => {
+    const proc = createProcessor({ ringCapacity: 2 });
+    proc.port.onmessage({ data: new Float32Array([1, 2, 3, 4]).buffer });
+
+    const msg = proc.port.postMessage.mock.calls[0][0];
+    expect(msg.accepted).toBe(2);
+    expect(msg.requested).toBe(4);
+    expect(msg.queued).toBe(2);
+    expect(msg.capacity).toBe(2);
+  });
+});
+
+// ── Underrun: silence, no throw ──────────────────────────────────────────────
+
+describe('DecibriOutputProcessor underrun', () => {
+  it('outputs pure silence when nothing has been fed', () => {
+    const proc = createProcessor();
+    const outputs = makeOutputs(1, 8);
+    const result = proc.process([], outputs, {});
+
+    expect(result).toBe(true);
+    expect(Array.from(outputs[0][0])).toEqual(new Array(8).fill(0));
+  });
+
+  it('fills the tail with silence on partial underrun', () => {
+    const proc = createProcessor();
+    proc.port.onmessage({ data: new Float32Array([0.5, 0.6]).buffer });
+
+    const outputs = makeOutputs(1, 4);
+    proc.process([], outputs, {});
+
+    const ch = outputs[0][0];
+    expect(ch[0]).toBeCloseTo(0.5);
+    expect(ch[1]).toBeCloseTo(0.6);
+    expect(ch[2]).toBe(0);
+    expect(ch[3]).toBe(0);
+  });
+
+  it('does not throw and returns true when output has no channels', () => {
+    const proc = createProcessor();
+    expect(proc.process([], [[]], {})).toBe(true);
+    expect(proc.process([], [], {})).toBe(true);
+  });
+
+  it('keeps the processor alive (returns true) across underruns', () => {
+    const proc = createProcessor();
+    const outputs = makeOutputs(1, 4);
+    expect(proc.process([], outputs, {})).toBe(true);
+    expect(proc.process([], outputs, {})).toBe(true);
+  });
+});
+
+// ── Multi-channel fan-out ────────────────────────────────────────────────────
+
+describe('DecibriOutputProcessor multi-channel', () => {
+  it('fans the mono stream out to every output channel', () => {
+    const proc = createProcessor();
+    proc.port.onmessage({ data: new Float32Array([0.1, 0.2, 0.3, 0.4]).buffer });
+
+    const outputs = makeOutputs(2, 4);
+    proc.process([], outputs, {});
+
+    expect(Array.from(outputs[0][0])).toEqual(Array.from(outputs[0][1]));
+    expect(outputs[0][1][0]).toBeCloseTo(0.1);
+    expect(outputs[0][1][3]).toBeCloseTo(0.4);
+  });
+});
+
+// ── Drain detection ──────────────────────────────────────────────────────────
+
+describe('DecibriOutputProcessor drain detection', () => {
+  it('emits drained exactly once when the queue empties after playout', () => {
+    const proc = createProcessor();
+    proc.port.onmessage({ data: new Float32Array([1, 2, 3, 4]).buffer });
+    proc.port.postMessage.mockClear(); // drop the feed-ack level message
+
+    const outputs = makeOutputs(1, 4);
+    proc.process([], outputs, {}); // reads all 4 -> empties -> drained
+
+    const drained = proc.port.postMessage.mock.calls.filter(c => c[0]?.type === 'drained');
+    expect(drained).toHaveLength(1);
+
+    // Further idle process() calls do not re-emit drained.
+    proc.process([], outputs, {});
+    proc.process([], outputs, {});
+    const drainedAfter = proc.port.postMessage.mock.calls.filter(c => c[0]?.type === 'drained');
+    expect(drainedAfter).toHaveLength(1);
+  });
+
+  it('does not emit drained before any audio is fed', () => {
+    const proc = createProcessor();
+    const outputs = makeOutputs(1, 4);
+    proc.process([], outputs, {});
+    const drained = proc.port.postMessage.mock.calls.filter(c => c[0]?.type === 'drained');
+    expect(drained).toHaveLength(0);
+  });
+
+  it('re-arms drain detection for a second playout', () => {
+    const proc = createProcessor();
+    const outputs = makeOutputs(1, 4);
+
+    proc.port.onmessage({ data: new Float32Array([1, 2]).buffer });
+    proc.process([], outputs, {}); // drains -> drained #1
+
+    proc.port.onmessage({ data: new Float32Array([3, 4]).buffer });
+    proc.process([], outputs, {}); // drains -> drained #2
+
+    const drained = proc.port.postMessage.mock.calls.filter(c => c[0]?.type === 'drained');
+    expect(drained).toHaveLength(2);
+  });
+});
+
+// ── Flush control message ────────────────────────────────────────────────────
+
+describe('DecibriOutputProcessor flush', () => {
+  it('clears the queue and outputs silence afterward', () => {
+    const proc = createProcessor();
+    proc.port.onmessage({ data: new Float32Array([1, 2, 3, 4]).buffer });
+    proc.port.onmessage({ data: { type: 'flush' } });
+
+    const outputs = makeOutputs(1, 4);
+    proc.process([], outputs, {});
+    expect(Array.from(outputs[0][0])).toEqual([0, 0, 0, 0]);
+  });
+
+  it('does not post a level ack or a drained notification for a flush', () => {
+    const proc = createProcessor();
+    proc.port.onmessage({ data: new Float32Array([1, 2, 3, 4]).buffer });
+    proc.port.postMessage.mockClear();
+
+    proc.port.onmessage({ data: { type: 'flush' } });
+    expect(proc.port.postMessage).not.toHaveBeenCalled();
+
+    // The flushed audio must not later surface as a drained event.
+    const outputs = makeOutputs(1, 4);
+    proc.process([], outputs, {});
+    const drained = proc.port.postMessage.mock.calls.filter(c => c[0]?.type === 'drained');
+    expect(drained).toHaveLength(0);
+  });
+});
+
+// ── Inline (runtime) source parity ───────────────────────────────────────────
+
+describe('output-worklet-inline parity', () => {
+  it('the minified runtime string registers the same processor and ring buffer', () => {
+    let captured = null;
+    // The inline source references AudioWorkletProcessor and registerProcessor
+    // as free globals; supply them as Function parameters.
+    const evaluate = new Function('AudioWorkletProcessor', 'registerProcessor', OUTPUT_WORKLET_SOURCE);
+    evaluate(MockAudioWorkletProcessor, (name, ctor) => { captured = { name, ctor }; });
+
+    expect(captured.name).toBe('decibri-output-processor');
+    expect(typeof captured.ctor.RingBuffer).toBe('function');
+
+    // Ring buffer from the minified source behaves identically.
+    const rb = new captured.ctor.RingBuffer(4);
+    expect(rb.write(new Float32Array([1, 2, 3]))).toBe(3);
+    const out = new Float32Array(3);
+    expect(rb.readInto(out, 0, 3)).toBe(3);
+    expect(Array.from(out)).toEqual([1, 2, 3]);
+
+    // Processor from the minified source drains the ring and zero-fills.
+    const proc = new captured.ctor({ processorOptions: {} });
+    proc.port.onmessage({ data: new Float32Array([0.5, 0.6]).buffer });
+    const outputs = makeOutputs(1, 4);
+    proc.process([], outputs, {});
+    expect(outputs[0][0][0]).toBeCloseTo(0.5);
+    expect(outputs[0][0][1]).toBeCloseTo(0.6);
+    expect(outputs[0][0][2]).toBe(0);
+    expect(outputs[0][0][3]).toBe(0);
+  });
+});


### PR DESCRIPTION
Adds a browser Speaker for audio playback through the Web Audio API, bringing the browser build to capture-and-playback parity with the Node binding. Additive and browser-only: the Node API and behavior are unchanged, and no Rust core release is involved.

Added:
- Browser Speaker: start(), async write(chunk), async drain(), stop(), isPlaying, with int16/float32 input and resampling from the source rate to the output rate, started from a user gesture
- An output audio worklet and ring buffer powering playback (silence on underrun, level-based backpressure, drain detection)
- A self-contained manual audio test page (examples/browser-speaker-test.html) and an examples guide for serving it on desktop and mobile
- README browser Speaker usage docs

All five packages bumped to 4.2.0 in lockstep with the platform pins. Browser version constant updated and the examples bundle regenerated. CHANGELOG and an additive migration note included.
