### PR TITLE
release(core): decibri 4.1.0 (SpeakerSink handle)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "decibri"
-version = "4.0.1"
+version = "4.1.0"
 dependencies = [
  "cpal",
  "crossbeam-channel",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "decibri-node"
-version = "4.0.1"
+version = "4.1.0"
 dependencies = [
  "decibri",
  "napi",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "decibri-python"
-version = "4.0.1"
+version = "4.1.0"
 dependencies = [
  "decibri",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.0.1"
+version = "4.1.0"
 edition = "2021"
 # MSRV empirically verified 2026-04-22: rustc 1.88 is the minimum version
 # that compiles the workspace. Floors: ort 2.0.0-rc.12 declares

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -54,7 +54,7 @@ def test_version_decibri_matches_rust_core() -> None:
     # Literal equality is intentional. When the Rust workspace bumps past
     # 4.0.0 this assertion breaks deliberately, to force a conscious update of
     # the Python expectation alongside the Rust version bump.
-    assert _decibri.MicrophoneBridge.version().decibri == "4.0.1"
+    assert _decibri.MicrophoneBridge.version().decibri == "4.1.0"
 
 
 def test_version_audio_backend_matches_cpal() -> None:
@@ -70,7 +70,7 @@ def test_version_info_fields() -> None:
     from decibri import _decibri
 
     info = _decibri.MicrophoneBridge.version()
-    assert info.decibri == "4.0.1"
+    assert info.decibri == "4.1.0"
     assert info.audio_backend == "cpal 0.17"
     assert info.binding == "0.2.1"
 

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -11,6 +11,8 @@ For other decibri packages, see:
 
 ## [Unreleased]
 
+## [4.1.0] - 2026-05-31
+
 ### Added
 
 - `SpeakerSink`: a cloneable, `Send + Sync` handle to a running `SpeakerStream`'s sample channel and drain state, obtained from `SpeakerStream::sink()`. It exposes `send()` and `drain()` with the same semantics as the stream's. `SpeakerStream` is `Send`; a `SpeakerSink` is a cheaper, lock-free companion that clones only the thread-safe primitives (the channel sender and the atomic flags), so callers can push samples or wait for drain from another thread (for example a worker pool) without holding the stream, and the off-thread work never blocks a holder of the stream that needs `stop()` or `is_playing()`. The stream must stay alive while a sink is in use; a `send` on a surviving sink after the stream is dropped returns `SpeakerStreamClosed`. Additive: `SpeakerStream` and its methods are unchanged.


### PR DESCRIPTION
Publishes the SpeakerSink handle to the core crate: a cloneable, lock-free handle to the speaker send and drain primitives, an additive, non-breaking addition to the public API (it was added during the Node async work but never released to crates.io). This brings crates.io in line with the source so Rust consumers can use it.

Bumps the workspace version 4.0.1 to 4.1.0 and rolls the changelog. Updates the two version assertions in the Python smoke test to match the new workspace version (the version is a single workspace source all crates inherit, so the bump changes what the Python extension reports).

Core crate release only: no npm release (the Node binding builds the core from path), no PyPI release (the Python package stays 0.2.1).