### PR TITLE
fix(rust): speaker stop/drain and device-release; release 4.3.0/0.4.0/4.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "decibri"
-version = "4.2.0"
+version = "4.3.0"
 dependencies = [
  "cpal",
  "crossbeam-channel",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "decibri-node"
-version = "4.2.0"
+version = "4.3.0"
 dependencies = [
  "decibri",
  "napi",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "decibri-python"
-version = "4.2.0"
+version = "4.3.0"
 dependencies = [
  "decibri",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.2.0"
+version = "4.3.0"
 edition = "2021"
 # MSRV empirically verified 2026-04-22: rustc 1.88 is the minimum version
 # that compiles the workspace. Floors: ort 2.0.0-rc.12 declares

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -8,6 +8,12 @@ For Rust core (`crates/decibri`) and npm binding (`bindings/node`) changes, see 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-06-10
+
+### Changed
+
+- Picks up the decibri Rust core speaker stop/drain fix and device-release-on-stop. `Speaker.drain()` and `AsyncSpeaker.drain()` are now repeatable, non-terminal flushes: a later `drain()` waits for its own audio instead of returning immediately. `stop()` discards queued audio and releases the audio device. The Python `stop()` already dropped the stream, so its observable behavior is unchanged; the `drain()` repeatability is the user-visible improvement.
+
 ## [0.3.0] - Unreleased
 
 ### Fixed

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "decibri"
-version = "0.3.0"
+version = "0.4.0"
 description = "Cross-platform audio capture, playback, and voice activity detection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/python/python/decibri/__init__.py
+++ b/bindings/python/python/decibri/__init__.py
@@ -51,7 +51,7 @@ from decibri.exceptions import (
     VadThresholdOutOfRange,
 )
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 
 def input_devices() -> list[MicrophoneInfo]:

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -422,7 +422,7 @@ fn build_version_info() -> VersionInfo {
     VersionInfo {
         decibri: env!("CARGO_PKG_VERSION").to_string(),
         audio_backend: format!("cpal {}", CPAL_VERSION),
-        binding: "0.3.0".to_string(),
+        binding: "0.4.0".to_string(),
     }
 }
 

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -16,7 +16,7 @@ import decibri
 
 
 def test_package_imports() -> None:
-    assert decibri.__version__ == "0.3.0"
+    assert decibri.__version__ == "0.4.0"
     # The bridges are hidden behind the private _decibri module. They are
     # NOT accessible at decibri.<X> top level (sync or async). The async
     # pair was never accessible at the top level; the sync pair
@@ -54,7 +54,7 @@ def test_version_decibri_matches_rust_core() -> None:
     # Literal equality is intentional. When the Rust workspace bumps past
     # 4.0.0 this assertion breaks deliberately, to force a conscious update of
     # the Python expectation alongside the Rust version bump.
-    assert _decibri.MicrophoneBridge.version().decibri == "4.2.0"
+    assert _decibri.MicrophoneBridge.version().decibri == "4.3.0"
 
 
 def test_version_audio_backend_matches_cpal() -> None:
@@ -70,9 +70,9 @@ def test_version_info_fields() -> None:
     from decibri import _decibri
 
     info = _decibri.MicrophoneBridge.version()
-    assert info.decibri == "4.2.0"
+    assert info.decibri == "4.3.0"
     assert info.audio_backend == "cpal 0.17"
-    assert info.binding == "0.3.0"
+    assert info.binding == "0.4.0"
 
 
 def test_version_info_is_frozen() -> None:

--- a/bindings/python/tests/test_wheel_smoke.py
+++ b/bindings/python/tests/test_wheel_smoke.py
@@ -29,7 +29,7 @@ def test_import_decibri() -> None:
     """The package imports successfully from the installed wheel."""
     assert decibri is not None
     assert hasattr(decibri, "__version__")
-    assert decibri.__version__ == "0.3.0"
+    assert decibri.__version__ == "0.4.0"
 
 
 def test_construct_decibri_default() -> None:

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -27,7 +27,7 @@ wheels = [
 
 [[package]]
 name = "decibri"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions" },

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -11,6 +11,10 @@ For other decibri packages, see:
 
 ## [Unreleased]
 
+### Changed
+
+- `MicrophoneStream::stop()` and `SpeakerStream::stop()` now release the audio device immediately: each drops the held `cpal::Stream`, so the OS frees the device (and the microphone-in-use indicator clears) on `stop()` rather than only when the handle is dropped. For direct Rust consumers, `stop()` now blocks briefly while the audio thread tears down instead of being an instant flag flip; post-stop behavior is otherwise unchanged (the existing `MicrophoneStreamClosed` / `SpeakerStreamClosed` semantics still apply). The Node and Python bindings already released the device on stop and are unaffected.
+
 ## [4.2.0] - Unreleased
 
 ### Fixed

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -11,9 +11,16 @@ For other decibri packages, see:
 
 ## [Unreleased]
 
+## [4.3.0] - 2026-06-10
+
+### Fixed
+
+- `SpeakerStream::stop()` now discards queued audio and goes silent immediately. Previously it appended empty sentinels behind the queued audio (and was a no-op when the channel was full), so audio played to completion after `stop()`.
+
 ### Changed
 
-- `MicrophoneStream::stop()` and `SpeakerStream::stop()` now release the audio device immediately: each drops the held `cpal::Stream`, so the OS frees the device (and the microphone-in-use indicator clears) on `stop()` rather than only when the handle is dropped. For direct Rust consumers, `stop()` now blocks briefly while the audio thread tears down instead of being an instant flag flip; post-stop behavior is otherwise unchanged (the existing `MicrophoneStreamClosed` / `SpeakerStreamClosed` semantics still apply). The Node and Python bindings already released the device on stop and are unaffected.
+- **Behavioral:** `SpeakerStream::drain()` is now a repeatable, non-terminal flush. It blocks until everything queued at call time has played, then leaves the stream usable, so a later `drain()` waits for its own audio and `send()` keeps working. Previously `drain()` incidentally ended the stream (it set `running = false`); code that relied on `drain()` as a stop must now call `stop()` explicitly. Applies to `SpeakerSink::drain()`. (In the Node binding, `end()` now flushes then stops, so the stream is still terminal after `end()`.)
+- `MicrophoneStream::stop()` and `SpeakerStream::stop()` now release the audio device immediately: each drops the held `cpal::Stream`, so the OS frees the device (and the microphone-in-use indicator clears) on `stop()` rather than only when the handle is dropped. For direct Rust consumers, `stop()` now blocks briefly while the audio thread tears down; post-stop error semantics are unchanged.
 
 ## [4.2.0] - Unreleased
 

--- a/crates/decibri/src/microphone.rs
+++ b/crates/decibri/src/microphone.rs
@@ -9,7 +9,7 @@
 #[cfg(feature = "capture")]
 use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(feature = "capture")]
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 #[cfg(feature = "capture")]
 use std::time::{Duration, Instant};
 
@@ -78,16 +78,24 @@ pub struct AudioChunk {
 /// Obtained from [`Microphone::start`]. Read audio with
 /// [`next_chunk`](Self::next_chunk) (blocking, with a timeout) or
 /// [`try_next_chunk`](Self::try_next_chunk) (non-blocking). Call
-/// [`stop`](Self::stop) to end capture, or drop the stream to release the
-/// device. The type is `!Sync`: keep it on one thread or wrap it in a mutex.
+/// [`stop`](Self::stop) to end capture and release the device; dropping the
+/// handle also releases it. The type is `Send + Sync`.
 #[cfg(feature = "capture")]
 pub struct MicrophoneStream {
-    /// Holds the cpal stream alive for the lifetime of this handle. Wrapped
-    /// in `Option` purely so the test-only `tests::test_stream()` helper can
-    /// construct a `MicrophoneStream` without a real audio device. Production
-    /// code always stores `Some(stream)`; drop semantics are identical (the
-    /// `Option`'s drop runs the inner `cpal::Stream`'s drop).
-    _stream: Option<cpal::Stream>,
+    /// Holds the cpal stream alive for the lifetime of this handle.
+    ///
+    /// `Mutex<Option<...>>` (not `Cell`/`RefCell`) so [`stop`](Self::stop) can
+    /// `take()` and drop the stream under `&self`, releasing the device, while
+    /// keeping this type `Send + Sync`. The Python binding requires `Sync`: its
+    /// `#[pyclass]` (`assert_pyclass_send_sync`) and `py.detach` both need the
+    /// stream type to be `Sync`, and `cpal::Stream` is itself `Send + Sync` on
+    /// every backend. `Cell`/`RefCell` are `!Sync` and would break
+    /// `decibri-python`. The lock is uncontended: only `stop()` and `drop` ever
+    /// touch this field; the cpal callback owns the channel sender, not this.
+    /// The `Option` also lets the test-only `tests::test_stream()` helper build
+    /// a handle with no real device (`Mutex::new(None)`); production stores
+    /// `Mutex::new(Some(stream))`.
+    _stream: Mutex<Option<cpal::Stream>>,
     receiver: Receiver<AudioChunk>,
     running: Arc<AtomicBool>,
     #[allow(dead_code)]
@@ -175,11 +183,12 @@ impl MicrophoneStream {
     /// threads can call [`stop`](Self::stop) concurrently to unblock this
     /// call within approximately 20 ms.
     ///
-    /// Implementation note: `stop()` does not disconnect the underlying
-    /// channel (the cpal `Stream` still holds the sender until the
-    /// `MicrophoneStream` is dropped), so this method internally polls both
-    /// the channel and [`is_open`](Self::is_open) at a short interval
-    /// rather than relying on channel disconnection alone to wake up.
+    /// Implementation note: this method polls both the channel and
+    /// [`is_open`](Self::is_open) at a short interval. An explicit
+    /// [`stop`](Self::stop) disconnects the channel (it drops the cpal `Stream`,
+    /// and with it the sender), which wakes a blocked wait promptly; the poll
+    /// additionally covers a driver-error stop, which flips
+    /// [`is_open`](Self::is_open) without dropping the stream.
     ///
     /// # Stability
     /// Part of decibri's stable FFI-consumer API surface.
@@ -234,17 +243,28 @@ impl MicrophoneStream {
         self.running.load(Ordering::Relaxed)
     }
 
-    /// Stop capturing audio.
+    /// Stop capturing audio and release the device.
     ///
-    /// Signals the capture callback to stop producing chunks. Already-buffered
-    /// chunks remain readable via [`try_next_chunk`](Self::try_next_chunk) or
-    /// [`next_chunk`](Self::next_chunk) until the buffer is drained, at which
-    /// point those methods return `Err(MicrophoneStreamClosed)`.
+    /// Flips the running flag, then drops the held `cpal::Stream`, so the OS
+    /// releases the input device (and the mic-in-use indicator clears) at once
+    /// rather than only when this handle is dropped. Dropping the stream also
+    /// disconnects the capture channel; chunks already buffered remain readable
+    /// via [`try_next_chunk`](Self::try_next_chunk) or
+    /// [`next_chunk`](Self::next_chunk) until the buffer is drained, after which
+    /// those methods return `Err(MicrophoneStreamClosed)`.
     ///
     /// May be called from any thread; wakes a concurrent
-    /// [`next_chunk`](Self::next_chunk) waiter within approximately 20 ms.
+    /// [`next_chunk`](Self::next_chunk) waiter promptly (the channel disconnect
+    /// unblocks it). Releasing the device blocks briefly while the audio thread
+    /// tears down.
     pub fn stop(&self) {
         self.running.store(false, Ordering::Relaxed);
+        // Drop the cpal stream to release the OS device now, not only on drop.
+        // Poison-tolerant: if a teardown elsewhere panicked while holding the
+        // lock, still clear the slot rather than panicking in stop().
+        if let Ok(mut guard) = self._stream.lock() {
+            *guard = None;
+        }
     }
 }
 
@@ -332,7 +352,7 @@ impl Microphone {
             .map_err(|e| DecibriError::StreamStartFailed(e.to_string()))?;
 
         Ok(MicrophoneStream {
-            _stream: Some(stream),
+            _stream: Mutex::new(Some(stream)),
             receiver,
             running,
             sample_rate,
@@ -353,7 +373,7 @@ mod tests {
         let (sender, receiver) = crossbeam_channel::unbounded::<AudioChunk>();
         let running = Arc::new(AtomicBool::new(true));
         let stream = MicrophoneStream {
-            _stream: None,
+            _stream: Mutex::new(None),
             receiver,
             running: running.clone(),
             sample_rate: 16000,
@@ -540,5 +560,33 @@ mod tests {
             [1.0, 2.0],
             "both chunks must be consumed exactly once with no duplicates or losses"
         );
+    }
+
+    /// Compile-time guard that `MicrophoneStream` is `Send + Sync`. The
+    /// `_stream` field is a `Mutex` to keep this bound; a future change to
+    /// `Cell`/`RefCell` would make the type `!Sync` and fail this test in the
+    /// core crate, rather than only surfacing as a `decibri-python` build break
+    /// (pyo3's `#[pyclass]` and `py.detach` both require `Sync`).
+    #[test]
+    fn test_microphone_stream_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<MicrophoneStream>();
+    }
+
+    /// `stop()` takes the held stream out from under the mutex (releasing the
+    /// device in production) and is idempotent. The test seam holds no real
+    /// device, so this asserts the slot is empty after stop and that a second
+    /// stop does not panic; the real `Some -> None` drop is exercised by the
+    /// binding suites and integration capture.
+    #[test]
+    fn test_stop_empties_stream_and_is_idempotent() {
+        let (stream, _sender, _running) = test_stream();
+        stream.stop();
+        assert!(!stream.is_open(), "stop() clears the running flag");
+        assert!(
+            stream._stream.lock().unwrap().is_none(),
+            "stop() leaves the stream slot empty (device released)"
+        );
+        stream.stop(); // idempotent: an already-empty slot must not panic
     }
 }

--- a/crates/decibri/src/speaker.rs
+++ b/crates/decibri/src/speaker.rs
@@ -8,7 +8,7 @@
 //! [`crate::microphone`].
 
 #[cfg(feature = "playback")]
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 #[cfg(feature = "playback")]
 use std::sync::Arc;
 
@@ -55,6 +55,123 @@ impl SpeakerConfig {
     }
 }
 
+/// Fill one cpal output buffer from the playback queue.
+///
+/// Extracted from the output callback so the playback logic can be unit-tested
+/// without a cpal device. When the stream is stopped (`running` is false) it
+/// discards anything still queued and emits silence, counting any drain
+/// sentinels it drops so a blocked [`SpeakerStream::drain`] still returns.
+/// Otherwise it plays the accumulator and then the channel, stashing any
+/// overflow back into `accum`, and bumps `sentinels_played` for each drain
+/// sentinel (an empty vec) it consumes.
+#[cfg(feature = "playback")]
+fn render_output(
+    data: &mut [f32],
+    accum: &mut Vec<f32>,
+    receiver: &Receiver<Vec<f32>>,
+    running: &AtomicBool,
+    sentinels_played: &AtomicUsize,
+) {
+    if !running.load(Ordering::Relaxed) {
+        // Stopped: drop everything queued and play silence. Count discarded
+        // sentinels so a concurrently blocked drain() is released.
+        accum.clear();
+        while let Ok(chunk) = receiver.try_recv() {
+            if chunk.is_empty() {
+                sentinels_played.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        data.fill(0.0);
+        return;
+    }
+
+    let mut written = 0;
+
+    // First, play any leftover from the accumulator.
+    if !accum.is_empty() {
+        let take = accum.len().min(data.len());
+        data[..take].copy_from_slice(&accum[..take]);
+        accum.drain(..take);
+        written += take;
+    }
+
+    // Then pull from the channel until the buffer is full.
+    while written < data.len() {
+        match receiver.try_recv() {
+            Ok(samples) => {
+                if samples.is_empty() {
+                    // Drain sentinel: a batch boundary. Record it so the matching
+                    // drain() returns, then keep filling from any audio queued
+                    // after it so playback stays gapless across drains.
+                    sentinels_played.fetch_add(1, Ordering::Relaxed);
+                    continue;
+                }
+                let need = data.len() - written;
+                if samples.len() <= need {
+                    data[written..written + samples.len()].copy_from_slice(&samples);
+                    written += samples.len();
+                } else {
+                    // More samples than fit: fill the buffer, stash the rest.
+                    data[written..].copy_from_slice(&samples[..need]);
+                    accum.extend_from_slice(&samples[need..]);
+                    written = data.len();
+                }
+            }
+            Err(_) => {
+                // Nothing queued: fill the remainder with silence.
+                data[written..].fill(0.0);
+                return;
+            }
+        }
+    }
+}
+
+/// Queue samples for playback. Shared by [`SpeakerStream::send`] and
+/// [`SpeakerSink::send`]. An empty buffer is a no-op. A stopped stream (or a
+/// disconnected channel) returns [`DecibriError::SpeakerStreamClosed`].
+#[cfg(feature = "playback")]
+fn send_impl(
+    sender: &Sender<Vec<f32>>,
+    running: &AtomicBool,
+    samples: Vec<f32>,
+) -> Result<(), DecibriError> {
+    if samples.is_empty() {
+        return Ok(());
+    }
+    if !running.load(Ordering::Relaxed) {
+        return Err(DecibriError::SpeakerStreamClosed);
+    }
+    sender
+        .send(samples)
+        .map_err(|_| DecibriError::SpeakerStreamClosed)
+}
+
+/// Block until the audio queued before this call has played. Shared by
+/// [`SpeakerStream::drain`] and [`SpeakerSink::drain`]. Reserves the next
+/// sentinel ticket, sends the sentinel, then waits until the output callback has
+/// consumed that many sentinels. Repeatable and non-terminal: it never ends the
+/// stream. Returns early if the stream has been stopped or its channel closed.
+#[cfg(feature = "playback")]
+fn drain_impl(
+    sender: &Sender<Vec<f32>>,
+    running: &AtomicBool,
+    sentinel_seq: &AtomicUsize,
+    sentinels_played: &AtomicUsize,
+) {
+    let target = sentinel_seq.fetch_add(1, Ordering::Relaxed) + 1;
+    if sender.send(Vec::new()).is_err() {
+        // Channel closed: nothing remains to play.
+        return;
+    }
+    while sentinels_played.load(Ordering::Relaxed) < target {
+        if !running.load(Ordering::Relaxed) {
+            // Stopped: queued audio is discarded, so there is nothing to await.
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+}
+
 /// An open playback stream you push `f32` samples to.
 ///
 /// Obtained from [`Speaker::start`]. Queue samples with [`send`](Self::send),
@@ -65,10 +182,17 @@ impl SpeakerConfig {
 /// or wrap it in a mutex.
 #[cfg(feature = "playback")]
 pub struct SpeakerStream {
-    _stream: cpal::Stream,
+    // `Option` so unit tests can construct a synthetic stream with no cpal
+    // device (`None`); always `Some` in production. Mirrors `MicrophoneStream`.
+    _stream: Option<cpal::Stream>,
     sender: Sender<Vec<f32>>,
     running: Arc<AtomicBool>,
-    drain_complete: Arc<AtomicBool>,
+    // Drain handshake. `drain()` reserves the next `sentinel_seq` ticket and
+    // sends an empty-vec sentinel; the output callback bumps `sentinels_played`
+    // each time it consumes one. A drain returns once `sentinels_played` reaches
+    // its ticket, so sequential drains each wait for their own audio.
+    sentinel_seq: Arc<AtomicUsize>,
+    sentinels_played: Arc<AtomicUsize>,
 }
 
 #[cfg(feature = "playback")]
@@ -100,24 +224,20 @@ impl SpeakerStream {
     /// three-state semantics (ok / empty-noop / closed) are guaranteed
     /// stable across 4.x; any change will be a breaking version bump.
     pub fn send(&self, samples: Vec<f32>) -> Result<(), DecibriError> {
-        if samples.is_empty() {
-            return Ok(());
-        }
-        self.sender
-            .send(samples)
-            .map_err(|_| DecibriError::SpeakerStreamClosed)
+        send_impl(&self.sender, &self.running, samples)
     }
 
-    /// Graceful drain: sends a sentinel (empty vec), then blocks until the
-    /// cpal callback has played all remaining samples and received the sentinel.
+    /// Block until everything queued at call time has played. Repeatable: the
+    /// stream stays open afterward, so further [`send`](Self::send) calls keep
+    /// working and a later `drain` waits for its own audio. Does not end the
+    /// stream. Returns early if the stream has been stopped.
     pub fn drain(&self) {
-        // Send empty vec as sentinel
-        let _ = self.sender.send(Vec::new());
-        // Poll until cpal callback sets drain_complete
-        while !self.drain_complete.load(Ordering::Relaxed) {
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        }
-        self.running.store(false, Ordering::Relaxed);
+        drain_impl(
+            &self.sender,
+            &self.running,
+            &self.sentinel_seq,
+            &self.sentinels_played,
+        );
     }
 
     /// Check whether the stream is still actively playing.
@@ -125,11 +245,15 @@ impl SpeakerStream {
         self.running.load(Ordering::Relaxed)
     }
 
-    /// Immediate stop. Discards remaining samples in the channel.
+    /// Immediate stop. The output goes silent within one callback cycle and all
+    /// queued audio is discarded; [`is_playing`](Self::is_playing) is false at
+    /// once and later non-empty [`send`](Self::send) calls return
+    /// [`DecibriError::SpeakerStreamClosed`]. The device is not released here;
+    /// drop the stream for that.
     pub fn stop(&self) {
+        // The output callback observes this flag, discards anything queued, and
+        // emits silence on its next cycle; it never plays stale audio again.
         self.running.store(false, Ordering::Relaxed);
-        // Drop all pending samples by draining the channel
-        while self.sender.try_send(Vec::new()).is_ok() {}
     }
 
     /// A cloneable, `Send` handle to this stream's sample channel and drain
@@ -149,7 +273,8 @@ impl SpeakerStream {
         SpeakerSink {
             sender: self.sender.clone(),
             running: self.running.clone(),
-            drain_complete: self.drain_complete.clone(),
+            sentinel_seq: self.sentinel_seq.clone(),
+            sentinels_played: self.sentinels_played.clone(),
         }
     }
 }
@@ -169,7 +294,8 @@ impl SpeakerStream {
 pub struct SpeakerSink {
     sender: Sender<Vec<f32>>,
     running: Arc<AtomicBool>,
-    drain_complete: Arc<AtomicBool>,
+    sentinel_seq: Arc<AtomicUsize>,
+    sentinels_played: Arc<AtomicUsize>,
 }
 
 #[cfg(feature = "playback")]
@@ -179,23 +305,19 @@ impl SpeakerSink {
     /// (backpressure), treats an empty vector as a no-op, and returns
     /// [`DecibriError::SpeakerStreamClosed`] once the stream has stopped.
     pub fn send(&self, samples: Vec<f32>) -> Result<(), DecibriError> {
-        if samples.is_empty() {
-            return Ok(());
-        }
-        self.sender
-            .send(samples)
-            .map_err(|_| DecibriError::SpeakerStreamClosed)
+        send_impl(&self.sender, &self.running, samples)
     }
 
-    /// Block until all queued samples have played. Identical semantics to
-    /// [`SpeakerStream::drain`]: sends a sentinel, polls the shared drain flag,
-    /// then marks the stream no longer playing.
+    /// Block until everything queued at call time has played. Identical
+    /// semantics to [`SpeakerStream::drain`]: repeatable, leaves the stream
+    /// open, and returns early if the stream has been stopped.
     pub fn drain(&self) {
-        let _ = self.sender.send(Vec::new());
-        while !self.drain_complete.load(Ordering::Relaxed) {
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        }
-        self.running.store(false, Ordering::Relaxed);
+        drain_impl(
+            &self.sender,
+            &self.running,
+            &self.sentinel_seq,
+            &self.sentinels_played,
+        );
     }
 }
 
@@ -242,8 +364,10 @@ impl Speaker {
             crossbeam_channel::bounded(32);
 
         let running = Arc::new(AtomicBool::new(true));
-        let drain_complete = Arc::new(AtomicBool::new(false));
-        let drain_complete_clone = drain_complete.clone();
+        let sentinel_seq = Arc::new(AtomicUsize::new(0));
+        let sentinels_played = Arc::new(AtomicUsize::new(0));
+        let running_cb = running.clone();
+        let sentinels_played_cb = sentinels_played.clone();
         let running_clone = running.clone();
 
         let sample_rate = self.config.sample_rate;
@@ -264,49 +388,13 @@ impl Speaker {
             .build_output_stream(
                 &stream_config,
                 move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
-                    let mut written = 0;
-
-                    // First, drain any leftover from the accumulator
-                    if !accum.is_empty() {
-                        let take = accum.len().min(data.len());
-                        data[..take].copy_from_slice(&accum[..take]);
-                        accum.drain(..take);
-                        written += take;
-                    }
-
-                    // Then pull from the channel until we've filled the buffer
-                    while written < data.len() {
-                        match receiver.try_recv() {
-                            Ok(samples) => {
-                                if samples.is_empty() {
-                                    // Sentinel: all data has been sent. Fill rest with silence.
-                                    for sample in &mut data[written..] {
-                                        *sample = 0.0;
-                                    }
-                                    drain_complete_clone.store(true, Ordering::Relaxed);
-                                    return;
-                                }
-                                let need = data.len() - written;
-                                if samples.len() <= need {
-                                    data[written..written + samples.len()]
-                                        .copy_from_slice(&samples);
-                                    written += samples.len();
-                                } else {
-                                    // More samples than needed: fill buffer, stash remainder
-                                    data[written..].copy_from_slice(&samples[..need]);
-                                    accum.extend_from_slice(&samples[need..]);
-                                    written = data.len();
-                                }
-                            }
-                            Err(_) => {
-                                // No data available: fill remaining with silence
-                                for sample in &mut data[written..] {
-                                    *sample = 0.0;
-                                }
-                                return;
-                            }
-                        }
-                    }
+                    render_output(
+                        data,
+                        &mut accum,
+                        &receiver,
+                        &running_cb,
+                        &sentinels_played_cb,
+                    );
                 },
                 move |err| {
                     eprintln!("decibri: audio output error: {err}");
@@ -321,10 +409,261 @@ impl Speaker {
             .map_err(|e| DecibriError::StreamStartFailed(e.to_string()))?;
 
         Ok(SpeakerStream {
-            _stream: stream,
+            _stream: Some(stream),
             sender,
             running,
-            drain_complete,
+            sentinel_seq,
+            sentinels_played,
         })
+    }
+}
+
+#[cfg(all(test, feature = "playback"))]
+mod tests {
+    use super::*;
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    /// Build a synthetic `SpeakerStream` with no cpal device, returning the
+    /// stream plus the receiving end of its channel and a clone of the
+    /// played-sentinel counter, so a test can drive the output callback by hand.
+    fn test_stream() -> (SpeakerStream, Receiver<Vec<f32>>, Arc<AtomicUsize>) {
+        let (sender, receiver) = crossbeam_channel::bounded::<Vec<f32>>(32);
+        let sentinels_played = Arc::new(AtomicUsize::new(0));
+        let stream = SpeakerStream {
+            _stream: None,
+            sender,
+            running: Arc::new(AtomicBool::new(true)),
+            sentinel_seq: Arc::new(AtomicUsize::new(0)),
+            sentinels_played: sentinels_played.clone(),
+        };
+        (stream, receiver, sentinels_played)
+    }
+
+    /// Run a single output-callback cycle against the synthetic stream and
+    /// return the buffer it produced.
+    fn render_once(
+        stream: &SpeakerStream,
+        accum: &mut Vec<f32>,
+        receiver: &Receiver<Vec<f32>>,
+        len: usize,
+    ) -> Vec<f32> {
+        let mut data = vec![0.0_f32; len];
+        render_output(
+            &mut data,
+            accum,
+            receiver,
+            &stream.running,
+            &stream.sentinels_played,
+        );
+        data
+    }
+
+    /// Render callback cycles until `sentinels_played` reaches `target`, with a
+    /// generous ceiling so a logic error fails the test instead of hanging it.
+    fn consume_until(
+        stream: &SpeakerStream,
+        accum: &mut Vec<f32>,
+        receiver: &Receiver<Vec<f32>>,
+        played: &AtomicUsize,
+        target: usize,
+    ) {
+        let mut data = vec![0.0_f32; 8];
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while played.load(Ordering::Relaxed) < target {
+            render_output(
+                &mut data,
+                accum,
+                receiver,
+                &stream.running,
+                &stream.sentinels_played,
+            );
+            assert!(
+                Instant::now() <= deadline,
+                "timed out waiting for {target} sentinel(s)"
+            );
+            thread::sleep(Duration::from_millis(1));
+        }
+    }
+
+    #[test]
+    fn test_render_plays_queued_audio_then_silence() {
+        let (stream, receiver, _played) = test_stream();
+        stream.send(vec![0.5_f32, 0.5, 0.5]).unwrap();
+
+        let mut accum = Vec::new();
+        let data = render_once(&stream, &mut accum, &receiver, 5);
+
+        assert_eq!(&data[..3], &[0.5, 0.5, 0.5], "queued audio is played");
+        assert_eq!(&data[3..], &[0.0, 0.0], "the remainder is silence");
+    }
+
+    #[test]
+    fn test_render_stashes_overflow_into_accumulator() {
+        let (stream, receiver, _played) = test_stream();
+        stream.send(vec![1.0_f32; 6]).unwrap();
+
+        let mut accum = Vec::new();
+        // Buffer smaller than the queued chunk: 4 play now, 2 are stashed.
+        let first = render_once(&stream, &mut accum, &receiver, 4);
+        assert_eq!(first, vec![1.0; 4]);
+        assert_eq!(
+            accum,
+            vec![1.0; 2],
+            "overflow is stashed for the next cycle"
+        );
+
+        // The next cycle plays the stash, then silence.
+        let second = render_once(&stream, &mut accum, &receiver, 4);
+        assert_eq!(&second[..2], &[1.0, 1.0]);
+        assert_eq!(&second[2..], &[0.0, 0.0]);
+        assert!(accum.is_empty());
+    }
+
+    #[test]
+    fn test_stop_discards_queued_audio() {
+        let (stream, receiver, _played) = test_stream();
+        stream.send(vec![0.5_f32; 50]).unwrap();
+        stream.send(vec![0.25_f32; 50]).unwrap();
+        stream.stop();
+
+        let mut accum = Vec::new();
+        let data = render_once(&stream, &mut accum, &receiver, 64);
+
+        assert!(
+            data.iter().all(|&s| s == 0.0),
+            "a stopped stream must emit only silence"
+        );
+        assert!(
+            receiver.try_recv().is_err(),
+            "stop() must discard queued audio, leaving the channel empty"
+        );
+        assert!(accum.is_empty(), "the accumulator must be cleared on stop");
+    }
+
+    #[test]
+    fn test_stop_discards_when_channel_full() {
+        let (stream, receiver, _played) = test_stream();
+        // Fill the bounded(32) channel to capacity.
+        for _ in 0..32 {
+            stream.send(vec![1.0_f32; 8]).unwrap();
+        }
+        stream.stop();
+
+        let mut accum = Vec::new();
+        let data = render_once(&stream, &mut accum, &receiver, 16);
+
+        assert!(
+            data.iter().all(|&s| s == 0.0),
+            "a full channel must still go silent after stop (regression: stop() \
+             used to no-op when the channel was full)"
+        );
+        assert!(
+            receiver.try_recv().is_err(),
+            "a full channel must be fully discarded after stop"
+        );
+    }
+
+    #[test]
+    fn test_is_playing_false_immediately_after_stop() {
+        let (stream, _receiver, _played) = test_stream();
+        assert!(stream.is_playing(), "a fresh stream reports playing");
+        stream.stop();
+        assert!(
+            !stream.is_playing(),
+            "is_playing() must be false the instant stop() returns"
+        );
+    }
+
+    #[test]
+    fn test_send_after_stop_returns_closed() {
+        let (stream, _receiver, _played) = test_stream();
+        stream.stop();
+
+        let err = stream.send(vec![1.0_f32; 4]).unwrap_err();
+        assert!(
+            matches!(err, DecibriError::SpeakerStreamClosed),
+            "a non-empty send() after stop() must fail with SpeakerStreamClosed"
+        );
+        assert!(
+            stream.send(Vec::new()).is_ok(),
+            "an empty send is a documented no-op even after stop"
+        );
+    }
+
+    #[test]
+    fn test_second_drain_waits_for_its_own_audio() {
+        let (stream, receiver, played) = test_stream();
+        let mut accum = Vec::new();
+
+        // Round 1: queue audio, drain on a worker, consume here.
+        stream.send(vec![1.0_f32; 4]).unwrap();
+        let sink1 = stream.sink();
+        let h1 = thread::spawn(move || sink1.drain());
+        consume_until(&stream, &mut accum, &receiver, &played, 1);
+        h1.join().unwrap();
+
+        // Round 2: with the old one-shot flag this drain returned instantly.
+        // Prove it now blocks until round-2 audio is actually consumed.
+        stream.send(vec![2.0_f32; 4]).unwrap();
+        let sink2 = stream.sink();
+        let done = Arc::new(AtomicBool::new(false));
+        let done_writer = done.clone();
+        let h2 = thread::spawn(move || {
+            sink2.drain();
+            done_writer.store(true, Ordering::Relaxed);
+        });
+
+        // Give the second drain a chance to (wrongly) finish early.
+        thread::sleep(Duration::from_millis(60));
+        assert!(
+            !done.load(Ordering::Relaxed),
+            "second drain must not return before its audio is consumed \
+             (stale-sentinel regression)"
+        );
+
+        consume_until(&stream, &mut accum, &receiver, &played, 2);
+        h2.join().unwrap();
+        assert!(
+            done.load(Ordering::Relaxed),
+            "second drain returns once its audio is consumed"
+        );
+    }
+
+    #[test]
+    fn test_send_after_drain_succeeds_and_stream_stays_open() {
+        let (stream, receiver, played) = test_stream();
+        let mut accum = Vec::new();
+
+        stream.send(vec![1.0_f32; 4]).unwrap();
+        let sink = stream.sink();
+        let h = thread::spawn(move || sink.drain());
+        consume_until(&stream, &mut accum, &receiver, &played, 1);
+        h.join().unwrap();
+
+        assert!(stream.is_playing(), "drain() must not end the stream");
+        assert!(
+            stream.send(vec![2.0_f32; 4]).is_ok(),
+            "send() after drain() must still succeed"
+        );
+    }
+
+    #[test]
+    fn test_sink_drain_is_repeatable() {
+        let (stream, receiver, played) = test_stream();
+        let mut accum = Vec::new();
+
+        for round in 1..=2usize {
+            let sink = stream.sink();
+            sink.send(vec![round as f32; 4]).unwrap();
+            let h = thread::spawn(move || sink.drain());
+            consume_until(&stream, &mut accum, &receiver, &played, round);
+            h.join().unwrap();
+        }
+        assert_eq!(
+            played.load(Ordering::Relaxed),
+            2,
+            "each drain through the sink waits for its own audio"
+        );
     }
 }

--- a/crates/decibri/src/speaker.rs
+++ b/crates/decibri/src/speaker.rs
@@ -10,7 +10,7 @@
 #[cfg(feature = "playback")]
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 #[cfg(feature = "playback")]
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 #[cfg(feature = "playback")]
 use cpal::traits::{DeviceTrait, StreamTrait};
@@ -177,14 +177,22 @@ fn drain_impl(
 /// Obtained from [`Speaker::start`]. Queue samples with [`send`](Self::send),
 /// which applies backpressure when the internal buffer is full. Call
 /// [`drain`](Self::drain) to block until everything queued has played, or
-/// [`stop`](Self::stop) to end immediately and discard what remains. Dropping
-/// the stream releases the device. The type is `!Sync`: keep it on one thread
-/// or wrap it in a mutex.
+/// [`stop`](Self::stop) to end immediately, discard what remains, and release
+/// the device. Dropping the stream also releases the device. The type is
+/// `Send + Sync`.
 #[cfg(feature = "playback")]
 pub struct SpeakerStream {
-    // `Option` so unit tests can construct a synthetic stream with no cpal
-    // device (`None`); always `Some` in production. Mirrors `MicrophoneStream`.
-    _stream: Option<cpal::Stream>,
+    // `Mutex<Option<...>>` (not `Cell`/`RefCell`) so `stop(&self)` can `take()`
+    // and drop the stream under `&self`, releasing the device, while keeping
+    // this type `Send + Sync`. The Python binding requires `Sync`: its
+    // `#[pyclass]` (`assert_pyclass_send_sync`) and `py.detach` both need the
+    // stream type to be `Sync`, and `cpal::Stream` is itself `Send + Sync` on
+    // every backend. `Cell`/`RefCell` are `!Sync` and would break
+    // `decibri-python`. The lock is uncontended: only `stop()` and `drop` ever
+    // touch this field; the cpal callback owns the channel receiver, not this.
+    // The `Option` also lets the test seam build a stream with no real device
+    // (`Mutex::new(None)`); production stores `Mutex::new(Some(stream))`.
+    _stream: Mutex<Option<cpal::Stream>>,
     sender: Sender<Vec<f32>>,
     running: Arc<AtomicBool>,
     // Drain handshake. `drain()` reserves the next `sentinel_seq` ticket and
@@ -245,15 +253,22 @@ impl SpeakerStream {
         self.running.load(Ordering::Relaxed)
     }
 
-    /// Immediate stop. The output goes silent within one callback cycle and all
-    /// queued audio is discarded; [`is_playing`](Self::is_playing) is false at
-    /// once and later non-empty [`send`](Self::send) calls return
-    /// [`DecibriError::SpeakerStreamClosed`]. The device is not released here;
-    /// drop the stream for that.
+    /// Immediate stop, releasing the device. The output goes silent at once and
+    /// all queued audio is discarded; [`is_playing`](Self::is_playing) is false
+    /// immediately and later non-empty [`send`](Self::send) calls (including via
+    /// a surviving [`SpeakerSink`]) return [`DecibriError::SpeakerStreamClosed`].
+    /// The held `cpal::Stream` is dropped here, so the OS releases the output
+    /// device on stop rather than only when the handle is dropped; this blocks
+    /// briefly while the audio thread tears down.
     pub fn stop(&self) {
-        // The output callback observes this flag, discards anything queued, and
-        // emits silence on its next cycle; it never plays stale audio again.
+        // Flag first: a surviving sink's send/drain key off this and short-circuit.
         self.running.store(false, Ordering::Relaxed);
+        // Then drop the cpal stream to release the OS device now, not only on
+        // drop. Poison-tolerant: if a teardown elsewhere panicked while holding
+        // the lock, still clear the slot rather than panicking in stop().
+        if let Ok(mut guard) = self._stream.lock() {
+            *guard = None;
+        }
     }
 
     /// A cloneable, `Send` handle to this stream's sample channel and drain
@@ -409,7 +424,7 @@ impl Speaker {
             .map_err(|e| DecibriError::StreamStartFailed(e.to_string()))?;
 
         Ok(SpeakerStream {
-            _stream: Some(stream),
+            _stream: Mutex::new(Some(stream)),
             sender,
             running,
             sentinel_seq,
@@ -431,7 +446,7 @@ mod tests {
         let (sender, receiver) = crossbeam_channel::bounded::<Vec<f32>>(32);
         let sentinels_played = Arc::new(AtomicUsize::new(0));
         let stream = SpeakerStream {
-            _stream: None,
+            _stream: Mutex::new(None),
             sender,
             running: Arc::new(AtomicBool::new(true)),
             sentinel_seq: Arc::new(AtomicUsize::new(0)),
@@ -665,5 +680,33 @@ mod tests {
             2,
             "each drain through the sink waits for its own audio"
         );
+    }
+
+    /// Compile-time guard that `SpeakerStream` is `Send + Sync`. The `_stream`
+    /// field is a `Mutex` to keep this bound; a future change to `Cell`/`RefCell`
+    /// would make the type `!Sync` and fail this test in the core crate, rather
+    /// than only surfacing as a `decibri-python` build break (pyo3's
+    /// `#[pyclass]` and `py.detach` both require `Sync`).
+    #[test]
+    fn test_speaker_stream_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<SpeakerStream>();
+    }
+
+    /// `stop()` takes the held stream out from under the mutex (releasing the
+    /// device in production) and is idempotent. The test seam holds no real
+    /// device, so this asserts the slot is empty after stop and that a second
+    /// stop does not panic; the real `Some -> None` drop is exercised by the
+    /// binding suites and integration playback.
+    #[test]
+    fn test_stop_empties_stream_and_is_idempotent() {
+        let (stream, _receiver, _played) = test_stream();
+        stream.stop();
+        assert!(!stream.is_playing(), "stop() clears the running flag");
+        assert!(
+            stream._stream.lock().unwrap().is_none(),
+            "stop() leaves the stream slot empty (device released)"
+        );
+        stream.stop(); // idempotent: an already-empty slot must not panic
     }
 }

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -11,6 +11,12 @@ For other decibri packages, see:
 
 ## [Unreleased]
 
+## [4.4.0] - 2026-06-10
+
+### Changed
+
+- `end()` on the Node `Speaker` now flushes then stops: it plays out the queued audio (drain) and then stops the stream, so `isPlaying` is false after `finish`. This keeps `end()` terminal now that the Rust core makes `drain()` a non-terminal, repeatable flush. As a result, `drainAsync()` is repeatable too (a later `drainAsync()` waits for its own audio instead of returning immediately). `stop()` releases the audio device via the updated core (the binding already dropped the native stream on stop, so no behavior change there). The rest of the API is unchanged.
+
 ## [4.3.0] - Unreleased
 
 ### Fixed

--- a/npm/decibri/package.json
+++ b/npm/decibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decibri",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Cross-platform audio capture, playback, and processing for Node.js and browsers",
   "main": "src/decibri.js",
   "types": "src/decibri.d.ts",
@@ -72,10 +72,10 @@
     "MIGRATION.md"
   ],
   "optionalDependencies": {
-    "@decibri/decibri-win32-x64-msvc": "4.3.0",
-    "@decibri/decibri-darwin-arm64": "4.3.0",
-    "@decibri/decibri-linux-x64-gnu": "4.3.0",
-    "@decibri/decibri-linux-arm64-gnu": "4.3.0"
+    "@decibri/decibri-win32-x64-msvc": "4.4.0",
+    "@decibri/decibri-darwin-arm64": "4.4.0",
+    "@decibri/decibri-linux-x64-gnu": "4.4.0",
+    "@decibri/decibri-linux-arm64-gnu": "4.4.0"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.7.0"

--- a/npm/decibri/src/browser/decibri-browser.js
+++ b/npm/decibri/src/browser/decibri-browser.js
@@ -6,7 +6,7 @@ const { WORKLET_SOURCE } = require('./worklet-inline.js');
 // Browser build version. Keep in sync with package.json on each release; the
 // browser bundle cannot read package.json at runtime the way the Node wrapper
 // does, so this is a maintained constant.
-const VERSION = '4.3.0';
+const VERSION = '4.4.0';
 
 /**
  * Browser microphone capture.

--- a/npm/decibri/src/decibri-output.js
+++ b/npm/decibri/src/decibri-output.js
@@ -150,7 +150,13 @@ class Speaker extends Writable {
   /** @internal Called by end() after all buffered writes complete. */
   _final(callback) {
     try {
+      // end() is terminal: flush all queued audio, then stop. drain() blocks
+      // until everything queued has played (it is a non-terminal flush in the
+      // core), and stop() then ends the stream so isPlaying is false once the
+      // audio has finished. The flush-then-stop order plays the tail to
+      // completion before stopping; reversing it would truncate the audio.
       this._native.drain();
+      this._native.stop();
       callback();
     } catch (err) {
       callback(err);

--- a/npm/platform-darwin-arm64/package.json
+++ b/npm/platform-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-darwin-arm64",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "os": ["darwin"],
   "cpu": ["arm64"],
   "main": "decibri.darwin-arm64.node",

--- a/npm/platform-linux-arm64-gnu/package.json
+++ b/npm/platform-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-arm64-gnu",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "os": ["linux"],
   "cpu": ["arm64"],
   "main": "decibri.linux-arm64-gnu.node",

--- a/npm/platform-linux-x64-gnu/package.json
+++ b/npm/platform-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-x64-gnu",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "os": ["linux"],
   "cpu": ["x64"],
   "main": "decibri.linux-x64-gnu.node",

--- a/npm/platform-win32-x64-msvc/package.json
+++ b/npm/platform-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-win32-x64-msvc",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "os": ["win32"],
   "cpu": ["x64"],
   "main": "decibri.win32-x64-msvc.node",


### PR DESCRIPTION
- crates/decibri/src/speaker.rs: stop() discards queued audio and goes silent immediately; drain() and SpeakerSink::drain() are repeatable non-terminal flushes (behavioral: drain() no longer ends the stream, call stop() to end)
- crates/decibri/src/speaker.rs, microphone.rs: stop() releases the audio device on both endpoints (drops the held cpal::Stream); _stream is Mutex<Option<cpal::Stream>> to keep both types Send + Sync; inaccurate !Sync doc comments corrected
- npm/decibri/src/decibri-output.js: end() flushes then stops so isPlaying is false after finish, audio plays to completion before stopping
- Cargo.toml, pyproject.toml, package.json (+4 platform), source-constant and test-literal sites: version bump crate 4.3.0, python 0.4.0, npm 4.4.0
- crates/decibri/CHANGELOG.md, npm/decibri/CHANGELOG.md, bindings/python/CHANGELOG.md: consolidated release entries