### PR TITLE
Hardening release: repo-review fixes; crate 4.3.1 / python 0.4.1 / npm 4.4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,17 +42,36 @@ jobs:
       - run: cargo audit
 
   test-rust:
-    name: Rust Tests
-    runs-on: ubuntu-latest
+    name: Rust Tests (${{ matrix.os }})
     needs: lint
+    strategy:
+      fail-fast: false
+      # The golden VAD anchors are pinned to values generated on Windows and
+      # carry a 1e-4 tolerance sized for cross-platform ORT CPU-kernel drift, so
+      # run them on every platform rather than ubuntu only. macOS in particular
+      # had no coverage of the pinned trajectories before.
+      matrix:
+        os: [ubuntu-latest, macos-14, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "rust"
-      - run: sudo apt-get update && sudo apt-get install -y libasound2-dev
-      - run: cargo test-decibri
+      - name: Install ALSA (Linux only)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - name: Tests (download-binaries; runs the golden VAD anchors)
+        run: cargo test-decibri
+      # Exercise the ort-load-dynamic load-failure path (compiled out by the
+      # test-decibri alias, which uses download-binaries). The failure-path
+      # tests pass a bad ort_library_path and assert the OrtPathInvalid
+      # pre-check fires, so they need no real ORT dylib. Runs on every OS,
+      # which matters most on Windows where the original init_from hang
+      # reproduced.
+      - name: ORT load-dynamic failure-path tests
+        run: cargo test -p decibri --no-default-features --features capture,playback,vad,denoise,gain,ort-load-dynamic --test vad_ort_load_failure
 
   feature-combinations:
     name: Feature Combinations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,8 @@ All commits, tags, and registry publishes are performed manually. If a task appe
 
 ## CI
 
-- `tests/test-ci.js` is the CI-safe test subset (~38 assertions, no hardware required). Run it with `node tests/test-ci.js`.
-- Hardware tests (`test-capture.js`, `test-api.js`, `test-output.js`, `test-vad-silero.js`) require a microphone/speaker and are local-only. They do NOT run in CI.
+- `tests/test-ci.js` is the CI-safe test subset (around 80 assertions across `assert`, `assertThrows`, and `assertRejects`, no hardware required). Run it with `node tests/test-ci.js`.
+- Hardware tests (`test-capture.js`, `test-api.js`, `test-output.js`, `test-vad-silero.js`, `test-async-open.js`, `test-async-write-drain.js`) require a microphone/speaker and are local-only. They do NOT run in CI.
 - Browser tests (`npx vitest run`) mock browser globals and run in Node.js. Safe for CI.
 - CI runs on every push to main and on PRs. See `.github/workflows/ci.yml`.
 - Pre-tag validation: run `publish-crates.yml`, `publish-npm.yml`, or `publish-pypi.yml` manually via `workflow_dispatch` from the Actions tab with the `publish` input unticked. Each workflow runs its build and validation steps without publishing.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "decibri"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "cpal",
  "crossbeam-channel",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "decibri-node"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "decibri",
  "napi",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "decibri-python"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "decibri",
  "numpy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,9 +225,7 @@ version = "4.3.0"
 dependencies = [
  "cpal",
  "crossbeam-channel",
- "dasp_sample",
  "ort",
- "parking_lot",
  "thiserror 2.0.18",
 ]
 
@@ -589,15 +587,6 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -1002,29 +991,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "pem-rfc7468"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,15 +1176,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,12 +1226,6 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.3.0"
+version = "4.3.1"
 edition = "2021"
 # MSRV empirically verified 2026-04-22: rustc 1.88 is the minimum version
 # that compiles the workspace. Floors: ort 2.0.0-rc.12 declares

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,7 @@ repository = "https://github.com/decibri/decibri"
 
 [workspace.dependencies]
 cpal = "0.17"
-dasp_sample = "0.11"
 thiserror = "2"
-parking_lot = "0.12"
 crossbeam-channel = "0.5"
 # ort 2.0.0-rc.12 targets ONNX Runtime C API version 24 (ORT_API_VERSION = 24).
 # We bundle ONNX Runtime 1.24.4 tarballs into each npm platform package.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let microphone = Microphone::new(MicrophoneConfig::default())?;
     let stream = microphone.start()?;
     while let Ok(Some(chunk)) = stream.next_chunk(None) {
-        println!("Got {} bytes", chunk.data.len());
+        println!("Got {} samples", chunk.data.len());
     }
     Ok(())
 }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,7 +36,7 @@ Decibri ships prebuilt native binaries for four platforms (Windows x64, macOS AR
 
 - npm publishing uses [Trusted Publishing via OIDC](https://docs.npmjs.com/trusted-publishers/). No long-lived npm tokens are stored in the repository or CI system. Each publish uses a short-lived, workflow-specific credential issued by npm.
 - All npm packages (`decibri`, `@decibri/decibri-win32-x64-msvc`, `@decibri/decibri-darwin-arm64`, `@decibri/decibri-linux-x64-gnu`, `@decibri/decibri-linux-arm64-gnu`) are configured to require 2FA and disallow legacy token publishing.
-- The Rust crate on crates.io is published from the same CI pipeline with a scoped, crate-specific token stored as a GitHub Actions secret.
+- The Rust crate on crates.io is published from the same CI pipeline using keyless [Trusted Publishing via OIDC](https://crates.io/docs/trusted-publishing): a short-lived, crate-specific publish token is issued per run by exchanging a GitHub OIDC token (via `rust-lang/crates-io-auth-action`). No long-lived crates.io token is stored in the repository or CI system.
 
 ### Provenance and attestation
 
@@ -57,10 +57,10 @@ This security policy applies to the following versions:
 
 | Version | Supported                |
 |:-------:|:------------------------:|
-| 3.x     | :white_check_mark: Yes   |
-| < 3.0   | :x: No longer supported  |
+| 4.x     | :white_check_mark: Yes   |
+| < 4.0   | :x: No longer supported  |
 
-Security fixes are applied to the latest 3.x release only. Version 1.x (C++/PortAudio implementation) is no longer maintained. Version 2.x was never published.
+Security fixes are applied to the latest 4.x release only. Version 1.x (C++/PortAudio implementation) is no longer maintained. Version 2.x was never published. Version 3.x is superseded by 4.x.
 
 ## CVE Policy
 

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use std::thread;
+use std::time::Duration;
 
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::ThreadsafeFunctionCallMode;
@@ -62,12 +63,12 @@ pub struct DecibriOptions {
 #[napi]
 pub struct DecibriBridge {
     capture: Option<Microphone>,
-    stream: Option<MicrophoneStream>,
+    stream: Option<Arc<MicrophoneStream>>,
     format: SampleFormat,
     frames_per_buffer: u32,
     channels: u16,
     running: Arc<AtomicBool>,
-    pump_handle: Option<thread::JoinHandle<()>>,
+    pump_handle: Option<thread::JoinHandle<Option<SileroVad>>>,
     vad: Option<SileroVad>,
     vad_probability: Arc<AtomicU32>,
 }
@@ -235,8 +236,22 @@ impl DecibriBridge {
             .as_ref()
             .ok_or_else(|| Error::new(Status::GenericFailure, "Capture not initialized"))?;
 
-        let stream = capture.start().map_err(to_napi_error)?;
+        // Reclaim the VAD from a previous pump that finished without stop()
+        // (for example after a device error ended capture), so this start runs
+        // with VAD again. After a clean stop() this take() yields None.
+        if let Some(handle) = self.pump_handle.take() {
+            self.vad = handle.join().ok().flatten();
+        }
+        // Start each session from a clean VAD probability rather than a value
+        // left over from a previous session.
+        self.vad_probability
+            .store(0.0f32.to_bits(), Ordering::Relaxed);
+
+        // Keep the core stream behind an `Arc` so the pump thread can poll its
+        // `is_open` / `take_last_error` while the bridge still owns it.
+        let stream = Arc::new(capture.start().map_err(to_napi_error)?);
         let receiver = stream.receiver().clone();
+        let pump_stream = stream.clone();
 
         self.running.store(true, Ordering::Relaxed);
         let running = self.running.clone();
@@ -244,7 +259,8 @@ impl DecibriBridge {
         let target_samples = self.frames_per_buffer as usize * self.channels as usize;
         let vad_probability = self.vad_probability.clone();
 
-        // Move VAD into the pump thread (SileroVad is Send)
+        // Move VAD into the pump thread (SileroVad is Send); it is handed back
+        // when the pump exits so a later start() can reuse it.
         let mut vad = self.vad.take();
 
         // Create a threadsafe function to call back into JS from the pump thread.
@@ -260,8 +276,13 @@ impl DecibriBridge {
             // so this ensures the API contract (exact chunk size) is honoured.
             let mut accum: Vec<f32> = Vec::with_capacity(target_samples);
 
+            // Timed receive so a device error (which closes the core stream
+            // without disconnecting our channel) is noticed within one interval
+            // instead of blocking forever. Matches the core's ~20 ms wakeup.
+            const POLL: Duration = Duration::from_millis(20);
+
             while running.load(Ordering::Relaxed) {
-                match receiver.recv() {
+                match receiver.recv_timeout(POLL) {
                     Ok(chunk) => {
                         accum.extend_from_slice(&chunk.data);
 
@@ -287,13 +308,31 @@ impl DecibriBridge {
                             );
                         }
                     }
-                    Err(_) => {
-                        // Channel closed. Capture stopped.
-                        // Discard partial buffer (matches C++ PortAudio behaviour).
-                        break;
+                    Err(e) => {
+                        // A plain timeout while the device is healthy: keep
+                        // waiting. But if the channel disconnected, or the core
+                        // stream closed (a driver error flips its `is_open` and
+                        // records a typed cause without our `stop()` running),
+                        // surface it instead of freezing with isOpen still true.
+                        if e.is_disconnected() || !pump_stream.is_open() {
+                            if let Some(err) = pump_stream.take_last_error() {
+                                // Device/driver failure: deliver the typed error
+                                // to the JS callback so it raises 'error' rather
+                                // than silently stalling.
+                                tsfn.call(
+                                    Err(to_napi_error(err)),
+                                    ThreadsafeFunctionCallMode::NonBlocking,
+                                );
+                            }
+                            running.store(false, Ordering::Relaxed);
+                            break;
+                        }
                     }
                 }
             }
+
+            // Hand the VAD back to the bridge (it was moved in via take()).
+            vad
         });
 
         self.stream = Some(stream);
@@ -313,14 +352,24 @@ impl DecibriBridge {
         self.stream = None;
 
         if let Some(handle) = self.pump_handle.take() {
-            let _ = handle.join();
+            // Reclaim the VAD the pump hands back so a later start() keeps VAD
+            // (start() moved it into the pump via take()).
+            self.vad = handle.join().ok().flatten();
         }
+
+        // Clear the probability so a restarted bridge does not read a stale
+        // pre-stop score before its first new inference.
+        self.vad_probability
+            .store(0.0f32.to_bits(), Ordering::Relaxed);
     }
 
     /// Whether the microphone is currently capturing.
     #[napi(getter)]
     pub fn is_open(&self) -> bool {
-        self.running.load(Ordering::Relaxed)
+        // Reflect the core stream's real state: a device/driver error closes
+        // the core stream, so `isOpen` reports `false` rather than the bridge's
+        // own flag staying `true` until the pump notices.
+        self.stream.as_ref().is_some_and(|s| s.is_open())
     }
 
     /// Latest VAD speech probability (0.0 to 1.0). Updated by pump thread.
@@ -440,6 +489,7 @@ fn to_napi_error(e: decibri::error::DecibriError) -> Error {
         | PermissionDenied
         | MicrophoneStreamClosed
         | SpeakerStreamClosed
+        | DeviceFailed(_)
         | OrtInitFailed { .. }
         | OrtLoadFailed { .. }
         | OrtPathInvalid { .. }

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -489,7 +489,7 @@ fn to_napi_error(e: decibri::error::DecibriError) -> Error {
         | PermissionDenied
         | MicrophoneStreamClosed
         | SpeakerStreamClosed
-        | DeviceFailed(_)
+        | DeviceFailed { .. }
         | OrtInitFailed { .. }
         | OrtLoadFailed { .. }
         | OrtPathInvalid { .. }

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -97,7 +97,11 @@ fn build_microphone_parts(options: Option<DecibriOptions>) -> Result<MicrophoneP
     let opts = options.unwrap_or_default();
 
     let sample_rate = opts.sample_rate.unwrap_or(16000);
-    let channels = opts.channels.unwrap_or(1) as u16;
+    let channels: u16 = opts
+        .channels
+        .unwrap_or(1)
+        .try_into()
+        .map_err(|_| Error::new(Status::InvalidArg, "invalid channel count".to_string()))?;
     let frames_per_buffer = opts.frames_per_buffer.unwrap_or(1600);
 
     let format_str = opts.format.as_deref().unwrap_or("int16");
@@ -514,7 +518,11 @@ fn build_speaker_parts(options: Option<DecibriOutputOptions>) -> Result<SpeakerP
     let opts = options.unwrap_or_default();
 
     let sample_rate = opts.sample_rate.unwrap_or(16000);
-    let channels = opts.channels.unwrap_or(1) as u16;
+    let channels: u16 = opts
+        .channels
+        .unwrap_or(1)
+        .try_into()
+        .map_err(|_| Error::new(Status::InvalidArg, "invalid channel count".to_string()))?;
 
     let format_str = opts.format.as_deref().unwrap_or("int16");
     let format = match format_str {

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Picks up the decibri Rust core speaker stop/drain fix and device-release-on-stop. `Speaker.drain()` and `AsyncSpeaker.drain()` are now repeatable, non-terminal flushes: a later `drain()` waits for its own audio instead of returning immediately. `stop()` discards queued audio and releases the audio device. The Python `stop()` already dropped the stream, so its observable behavior is unchanged; the `drain()` repeatability is the user-visible improvement.
 
-## [0.3.0] - Unreleased
+## [0.3.0] - 2026-06-07
 
 ### Fixed
 

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -8,6 +8,16 @@ For Rust core (`crates/decibri`) and npm binding (`bindings/node`) changes, see 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-06-11
+
+### Fixed
+
+- Picks up the Rust core hardening: `Speaker.drain()` / `AsyncSpeaker.drain()` no longer hang if the stream is dropped without `stop()`; malformed VAD models raise a typed error instead of crashing the process; and the fork-after-init guard now fires when a Silero VAD is constructed in a forked child, not only at inference.
+
+### Changed
+
+- The microphone capture channel is now bounded in the core, so a stalled reader drops audio to keep memory bounded rather than growing without limit.
+
 ## [0.4.0] - 2026-06-10
 
 ### Changed

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -28,7 +28,7 @@ crate-type = ["cdylib"]
 # features across both bindings silently; diverging overrides produce a build
 # that neither binding tests in isolation. Both bindings inherit decibri's
 # default features (capture, playback, vad, denoise, gain, ort-load-dynamic).
-decibri = { version = "4.0.1", path = "../../crates/decibri" }
+decibri = { version = "4.3", path = "../../crates/decibri" }
 
 # PyO3 0.28 is the first MSRV-1.83 release line with the attach / detach /
 # initialize API renames; aligns with workspace MSRV 1.88 (headroom preserved).

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "decibri"
-version = "0.4.0"
+version = "0.4.1"
 description = "Cross-platform audio capture, playback, and voice activity detection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/python/python/decibri/__init__.py
+++ b/bindings/python/python/decibri/__init__.py
@@ -51,7 +51,7 @@ from decibri.exceptions import (
     VadThresholdOutOfRange,
 )
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 
 def input_devices() -> list[MicrophoneInfo]:

--- a/bindings/python/python/decibri/_classes.py
+++ b/bindings/python/python/decibri/_classes.py
@@ -279,7 +279,8 @@ class Microphone:
         raise ``AlreadyBorrowed`` (a pyo3 ``RuntimeError`` from the
         bridge's ``RefCell`` borrow). This is a known 0.1.0 limitation
         pinned by ``test_sync_stop_from_other_thread_raises_already_borrowed``;
-        a thread-safe shutdown path is scheduled for 0.2.0. Workarounds:
+        a thread-safe shutdown path is planned for a future release.
+        Workarounds:
         use ``AsyncMicrophone`` (sibling-task cancellation works
         correctly), or call ``stop()`` from the same thread that owns
         the iteration loop.

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -422,7 +422,7 @@ fn build_version_info() -> VersionInfo {
     VersionInfo {
         decibri: env!("CARGO_PKG_VERSION").to_string(),
         audio_backend: format!("cpal {}", CPAL_VERSION),
-        binding: "0.4.0".to_string(),
+        binding: "0.4.1".to_string(),
     }
 }
 

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -16,7 +16,7 @@ import decibri
 
 
 def test_package_imports() -> None:
-    assert decibri.__version__ == "0.4.0"
+    assert decibri.__version__ == "0.4.1"
     # The bridges are hidden behind the private _decibri module. They are
     # NOT accessible at decibri.<X> top level (sync or async). The async
     # pair was never accessible at the top level; the sync pair
@@ -54,7 +54,7 @@ def test_version_decibri_matches_rust_core() -> None:
     # Literal equality is intentional. When the Rust workspace bumps past
     # 4.0.0 this assertion breaks deliberately, to force a conscious update of
     # the Python expectation alongside the Rust version bump.
-    assert _decibri.MicrophoneBridge.version().decibri == "4.3.0"
+    assert _decibri.MicrophoneBridge.version().decibri == "4.3.1"
 
 
 def test_version_audio_backend_matches_cpal() -> None:
@@ -70,9 +70,9 @@ def test_version_info_fields() -> None:
     from decibri import _decibri
 
     info = _decibri.MicrophoneBridge.version()
-    assert info.decibri == "4.3.0"
+    assert info.decibri == "4.3.1"
     assert info.audio_backend == "cpal 0.17"
-    assert info.binding == "0.4.0"
+    assert info.binding == "0.4.1"
 
 
 def test_version_info_is_frozen() -> None:

--- a/bindings/python/tests/test_wheel_smoke.py
+++ b/bindings/python/tests/test_wheel_smoke.py
@@ -29,7 +29,7 @@ def test_import_decibri() -> None:
     """The package imports successfully from the installed wheel."""
     assert decibri is not None
     assert hasattr(decibri, "__version__")
-    assert decibri.__version__ == "0.4.0"
+    assert decibri.__version__ == "0.4.1"
 
 
 def test_construct_decibri_default() -> None:

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -27,7 +27,7 @@ wheels = [
 
 [[package]]
 name = "decibri"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions" },

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -11,6 +11,24 @@ For other decibri packages, see:
 
 ## [Unreleased]
 
+## [4.3.1] - 2026-06-11
+
+### Fixed
+
+- `SpeakerStream::drain()` no longer hangs when the stream is dropped without `stop()`. A new `Drop` clears the running flag, so a drain parked in its wait loop (on the stream or on a `SpeakerSink` sharing it) returns instead of polling forever.
+- Malformed VAD models (correct tensor names but wrong shapes) now return a typed `OnnxBackendFailed` error instead of panicking the process.
+- The fork-after-ORT-init guard now also fires when a Silero VAD is constructed in a forked child, not only at the first inference, so `ForkAfterOrtInit` is raised before any ORT session is built on inherited state.
+
+### Added
+
+- `DecibriError::DeviceFailed`, a typed error carrying the cpal error text for a device or driver failure during streaming. `MicrophoneStream` and `SpeakerStream` gained `take_last_error()` so a consumer that sees a closed stream can tell a driver failure from an explicit `stop()`.
+- `MicrophoneStream::sample_rate()`, `channels()`, and `overrun_count()` accessors.
+
+### Changed
+
+- The microphone capture channel is now bounded: a stalled consumer drops the newest buffers (counted via `overrun_count()`) rather than growing memory without bound, and the realtime callback never blocks.
+- Removed the unused `parking_lot` and `dasp_sample` dependencies.
+
 ## [4.3.0] - 2026-06-10
 
 ### Fixed

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -21,7 +21,7 @@ For other decibri packages, see:
 
 ### Added
 
-- `DecibriError::DeviceFailed`, a typed error carrying the cpal error text for a device or driver failure during streaming. `MicrophoneStream` and `SpeakerStream` gained `take_last_error()` so a consumer that sees a closed stream can tell a driver failure from an explicit `stop()`.
+- `DecibriError::DeviceFailed`, a typed error carrying the underlying cpal stream error as a structured source for a device or driver failure during streaming. `MicrophoneStream` and `SpeakerStream` gained `take_last_error()` so a consumer that sees a closed stream can tell a driver failure from an explicit `stop()`.
 - `MicrophoneStream::sample_rate()`, `channels()`, and `overrun_count()` accessors.
 
 ### Changed

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -22,7 +22,7 @@ For other decibri packages, see:
 - **Behavioral:** `SpeakerStream::drain()` is now a repeatable, non-terminal flush. It blocks until everything queued at call time has played, then leaves the stream usable, so a later `drain()` waits for its own audio and `send()` keeps working. Previously `drain()` incidentally ended the stream (it set `running = false`); code that relied on `drain()` as a stop must now call `stop()` explicitly. Applies to `SpeakerSink::drain()`. (In the Node binding, `end()` now flushes then stops, so the stream is still terminal after `end()`.)
 - `MicrophoneStream::stop()` and `SpeakerStream::stop()` now release the audio device immediately: each drops the held `cpal::Stream`, so the OS frees the device (and the microphone-in-use indicator clears) on `stop()` rather than only when the handle is dropped. For direct Rust consumers, `stop()` now blocks briefly while the audio thread tears down; post-stop error semantics are unchanged.
 
-## [4.2.0] - Unreleased
+## [4.2.0] - 2026-06-07
 
 ### Fixed
 

--- a/crates/decibri/Cargo.toml
+++ b/crates/decibri/Cargo.toml
@@ -53,8 +53,6 @@ rocm = ["ort?/rocm"]
 
 [dependencies]
 cpal = { workspace = true, optional = true }
-dasp_sample = { workspace = true }
 thiserror = { workspace = true }
-parking_lot = { workspace = true }
 crossbeam-channel = { workspace = true, optional = true }
 ort = { workspace = true, optional = true }

--- a/crates/decibri/README.md
+++ b/crates/decibri/README.md
@@ -152,7 +152,7 @@ The common types are re-exported at the crate root, so `use decibri::Microphone;
 
 ## Thread safety
 
-All public types are `Send` and suitable for cross-thread handoff. `MicrophoneStream` and `SpeakerStream` are `!Sync` because they hold a live platform audio stream internally; wrap them in a mutex or move them into a dedicated thread for shared access.
+All public types are `Send` and suitable for cross-thread handoff. `MicrophoneStream` and `SpeakerStream` are also `Sync` (they hold their live platform audio stream behind an internal mutex), so they can be shared across threads, for example via an `Arc`, without external synchronization.
 
 ## Platform support
 

--- a/crates/decibri/src/error.rs
+++ b/crates/decibri/src/error.rs
@@ -98,6 +98,20 @@ pub enum DecibriError {
     #[error("Speaker stream is closed")]
     SpeakerStreamClosed,
 
+    /// An active audio stream failed at the device or driver level while
+    /// running (device unplugged, driver reset, exclusive-mode preemption).
+    ///
+    /// Distinct from [`Self::StreamOpenFailed`] / [`Self::StreamStartFailed`],
+    /// which fire at open/start time: this is reported by the cpal error
+    /// callback during streaming. The payload carries the underlying cpal
+    /// error text as a `String` (matching the open/start variants, so no cpal
+    /// type leaks into the public enum). After it fires the stream is treated
+    /// as closed; a consumer that sees `MicrophoneStreamClosed` /
+    /// `SpeakerStreamClosed` can call `take_last_error()` on the stream to
+    /// retrieve this cause. Additive variant permitted by `#[non_exhaustive]`.
+    #[error("decibri: audio device error: {0}")]
+    DeviceFailed(String),
+
     // ── VAD config validation ──────────────────────────────────────────
     /// Payload carries the offending sample rate; not formatted into the
     /// Display string to keep the message text stable.

--- a/crates/decibri/src/error.rs
+++ b/crates/decibri/src/error.rs
@@ -103,14 +103,20 @@ pub enum DecibriError {
     ///
     /// Distinct from [`Self::StreamOpenFailed`] / [`Self::StreamStartFailed`],
     /// which fire at open/start time: this is reported by the cpal error
-    /// callback during streaming. The payload carries the underlying cpal
-    /// error text as a `String` (matching the open/start variants, so no cpal
-    /// type leaks into the public enum). After it fires the stream is treated
-    /// as closed; a consumer that sees `MicrophoneStreamClosed` /
-    /// `SpeakerStreamClosed` can call `take_last_error()` on the stream to
-    /// retrieve this cause. Additive variant permitted by `#[non_exhaustive]`.
-    #[error("decibri: audio device error: {0}")]
-    DeviceFailed(String),
+    /// callback during streaming. The underlying `cpal::StreamError` is carried
+    /// boxed as a `#[source]` (the same pattern as [`Self::OnnxBackendFailed`]),
+    /// so a consumer can walk `error.source()` (and downcast to
+    /// `cpal::StreamError`) to distinguish a cause such as device-not-available
+    /// from a backend-specific driver error, with no cpal type appearing in this
+    /// enum's public signature. After it fires the stream is treated as closed;
+    /// a consumer that sees `MicrophoneStreamClosed` / `SpeakerStreamClosed` can
+    /// call `take_last_error()` on the stream to retrieve this cause. Additive
+    /// variant permitted by `#[non_exhaustive]`.
+    #[error("decibri: audio device error: {source}")]
+    DeviceFailed {
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 
     // ── VAD config validation ──────────────────────────────────────────
     /// Payload carries the offending sample rate; not formatted into the
@@ -292,5 +298,23 @@ impl DecibriError {
         {
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error as _;
+
+    #[test]
+    fn device_failed_carries_structured_source() {
+        let inner = std::io::Error::other("device gone");
+        let err = DecibriError::DeviceFailed {
+            source: Box::new(inner),
+        };
+        // Display renders the source's message in the frozen style.
+        assert_eq!(err.to_string(), "decibri: audio device error: device gone");
+        // The cause is structured and walkable, not merely stringified.
+        assert!(err.source().is_some());
     }
 }

--- a/crates/decibri/src/lib.rs
+++ b/crates/decibri/src/lib.rs
@@ -128,9 +128,10 @@
 //! # Thread safety
 //!
 //! All public types are `Send` and suitable for cross-thread handoff.
-//! [`microphone::MicrophoneStream`] and [`speaker::SpeakerStream`] are `!Sync`
-//! because they hold a live platform audio stream internally; wrap them in a
-//! mutex or move them into a dedicated thread for shared access.
+//! [`microphone::MicrophoneStream`] and [`speaker::SpeakerStream`] are also
+//! `Sync` (they hold their live platform audio stream behind an internal
+//! mutex), so they can be shared across threads, for example via an `Arc`,
+//! without external synchronization.
 //!
 //! # Stability
 //!

--- a/crates/decibri/src/microphone.rs
+++ b/crates/decibri/src/microphone.rs
@@ -100,6 +100,12 @@ pub struct MicrophoneStream {
     running: Arc<AtomicBool>,
     sample_rate: u32,
     channels: u16,
+    // Last device/driver error reported by the cpal error callback while
+    // streaming, retrievable via [`take_last_error`](Self::take_last_error).
+    // Lets a consumer that sees a closed stream distinguish a driver failure
+    // from an explicit `stop()`. The cpal callback writes it; consumers drain
+    // it. Uncontended in practice (written at most once, on failure).
+    last_error: Arc<Mutex<Option<DecibriError>>>,
 }
 
 #[cfg(feature = "capture")]
@@ -251,6 +257,17 @@ impl MicrophoneStream {
         self.channels
     }
 
+    /// Take the last device/driver error reported while streaming, if any.
+    ///
+    /// When the cpal error callback fires (device unplug, driver failure) it
+    /// records a typed [`DecibriError::DeviceFailed`] and closes the stream.
+    /// Reading it here drains it (returns `None` afterwards), letting a
+    /// consumer that observes a closed stream tell a driver failure apart from
+    /// an explicit [`stop`](Self::stop).
+    pub fn take_last_error(&self) -> Option<DecibriError> {
+        self.last_error.lock().ok().and_then(|mut slot| slot.take())
+    }
+
     /// Stop capturing audio and release the device.
     ///
     /// Flips the running flag, then drops the held `cpal::Stream`, so the OS
@@ -330,6 +347,8 @@ impl Microphone {
         };
 
         let err_running = running.clone();
+        let last_error = Arc::new(Mutex::new(None));
+        let err_last_error = last_error.clone();
 
         let stream = self
             .device
@@ -348,7 +367,13 @@ impl Microphone {
                     let _ = sender.send(chunk);
                 },
                 move |err| {
-                    eprintln!("decibri: audio stream error: {err}");
+                    // Record a typed cause so a consumer that sees the stream
+                    // close can distinguish a driver failure from stop().
+                    let typed = DecibriError::DeviceFailed(err.to_string());
+                    eprintln!("{typed}");
+                    if let Ok(mut slot) = err_last_error.lock() {
+                        *slot = Some(typed);
+                    }
                     err_running.store(false, Ordering::Relaxed);
                 },
                 None, // No timeout
@@ -365,6 +390,7 @@ impl Microphone {
             running,
             sample_rate,
             channels,
+            last_error,
         })
     }
 }
@@ -386,6 +412,7 @@ mod tests {
             running: running.clone(),
             sample_rate: 16000,
             channels: 1,
+            last_error: Arc::new(Mutex::new(None)),
         };
         (stream, sender, running)
     }

--- a/crates/decibri/src/microphone.rs
+++ b/crates/decibri/src/microphone.rs
@@ -76,9 +76,14 @@ pub struct AudioChunk {
 /// Bound on the capture channel. A stalled consumer cannot grow memory without
 /// limit: once this many `AudioChunk`s are queued, the realtime callback drops
 /// new chunks (counting them, see [`MicrophoneStream::overrun_count`]) rather
-/// than blocking the audio thread or allocating without bound. Sized generously
-/// (each chunk is one cpal buffer, roughly 100 ms at the 16 kHz / 1600-frame
-/// default) so normal consumer jitter never drops, only a genuine stall does.
+/// than blocking the audio thread or allocating without bound.
+///
+/// This is a memory bound, not a fixed-duration guarantee. One queued item is
+/// one cpal callback buffer, whose duration is backend-dependent: on WASAPI cpal
+/// ignores `BufferSize::Fixed` and delivers the driver period (often ~10 ms, not
+/// `frames_per_buffer`), so 64 items can be anywhere from well under a second to
+/// several seconds of audio. It is sized so a consumer that keeps pace never
+/// drops; only a genuine stall does.
 #[cfg(feature = "capture")]
 const CAPTURE_CHANNEL_CAPACITY: usize = 64;
 

--- a/crates/decibri/src/microphone.rs
+++ b/crates/decibri/src/microphone.rs
@@ -7,7 +7,7 @@
 //! playback counterpart is [`crate::speaker`].
 
 #[cfg(feature = "capture")]
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 #[cfg(feature = "capture")]
 use std::sync::{Arc, Mutex};
 #[cfg(feature = "capture")]
@@ -16,7 +16,7 @@ use std::time::{Duration, Instant};
 #[cfg(feature = "capture")]
 use cpal::traits::{DeviceTrait, StreamTrait};
 #[cfg(feature = "capture")]
-use crossbeam_channel::{Receiver, RecvTimeoutError, Sender, TryRecvError};
+use crossbeam_channel::{Receiver, RecvTimeoutError, Sender, TryRecvError, TrySendError};
 
 use crate::device::DeviceSelector;
 use crate::error::DecibriError;
@@ -73,6 +73,15 @@ pub struct AudioChunk {
     pub channels: u16,
 }
 
+/// Bound on the capture channel. A stalled consumer cannot grow memory without
+/// limit: once this many `AudioChunk`s are queued, the realtime callback drops
+/// new chunks (counting them, see [`MicrophoneStream::overrun_count`]) rather
+/// than blocking the audio thread or allocating without bound. Sized generously
+/// (each chunk is one cpal buffer, roughly 100 ms at the 16 kHz / 1600-frame
+/// default) so normal consumer jitter never drops, only a genuine stall does.
+#[cfg(feature = "capture")]
+const CAPTURE_CHANNEL_CAPACITY: usize = 64;
+
 /// An open capture stream you pull [`AudioChunk`]s from.
 ///
 /// Obtained from [`Microphone::start`]. Read audio with
@@ -106,6 +115,11 @@ pub struct MicrophoneStream {
     // from an explicit `stop()`. The cpal callback writes it; consumers drain
     // it. Uncontended in practice (written at most once, on failure).
     last_error: Arc<Mutex<Option<DecibriError>>>,
+    // Count of capture buffers dropped because the channel was full (a stalled
+    // consumer). Incremented by the realtime callback, read via
+    // [`overrun_count`](Self::overrun_count). Bounds memory by dropping rather
+    // than queuing without limit.
+    overruns: Arc<AtomicU64>,
 }
 
 #[cfg(feature = "capture")]
@@ -268,6 +282,13 @@ impl MicrophoneStream {
         self.last_error.lock().ok().and_then(|mut slot| slot.take())
     }
 
+    /// Total number of capture buffers dropped because the channel was full
+    /// (a consumer that could not keep up). Stays 0 while the consumer keeps
+    /// pace; a rising count means audio is being dropped to bound memory.
+    pub fn overrun_count(&self) -> u64 {
+        self.overruns.load(Ordering::Relaxed)
+    }
+
     /// Stop capturing audio and release the device.
     ///
     /// Flips the running flag, then drops the held `cpal::Stream`, so the OS
@@ -331,7 +352,7 @@ impl Microphone {
     /// Start capturing audio. Returns a stream handle with a receiver for audio chunks.
     pub fn start(&self) -> Result<MicrophoneStream, DecibriError> {
         let (sender, receiver): (Sender<AudioChunk>, Receiver<AudioChunk>) =
-            crossbeam_channel::unbounded();
+            crossbeam_channel::bounded(CAPTURE_CHANNEL_CAPACITY);
 
         let running = Arc::new(AtomicBool::new(true));
         let running_clone = running.clone();
@@ -349,6 +370,8 @@ impl Microphone {
         let err_running = running.clone();
         let last_error = Arc::new(Mutex::new(None));
         let err_last_error = last_error.clone();
+        let overruns = Arc::new(AtomicU64::new(0));
+        let overruns_cb = overruns.clone();
 
         let stream = self
             .device
@@ -363,8 +386,18 @@ impl Microphone {
                         sample_rate,
                         channels,
                     };
-                    // If the receiver is dropped, just discard.
-                    let _ = sender.send(chunk);
+                    // Non-blocking send: the cpal callback must never block the
+                    // realtime audio thread. On a full channel (a stalled
+                    // consumer) drop this chunk and count it rather than growing
+                    // memory without bound; a disconnected receiver also just
+                    // discards.
+                    match sender.try_send(chunk) {
+                        Ok(()) => {}
+                        Err(TrySendError::Full(_)) => {
+                            overruns_cb.fetch_add(1, Ordering::Relaxed);
+                        }
+                        Err(TrySendError::Disconnected(_)) => {}
+                    }
                 },
                 move |err| {
                     // Record a typed cause so a consumer that sees the stream
@@ -391,6 +424,7 @@ impl Microphone {
             sample_rate,
             channels,
             last_error,
+            overruns,
         })
     }
 }
@@ -413,6 +447,7 @@ mod tests {
             sample_rate: 16000,
             channels: 1,
             last_error: Arc::new(Mutex::new(None)),
+            overruns: Arc::new(AtomicU64::new(0)),
         };
         (stream, sender, running)
     }

--- a/crates/decibri/src/microphone.rs
+++ b/crates/decibri/src/microphone.rs
@@ -98,9 +98,7 @@ pub struct MicrophoneStream {
     _stream: Mutex<Option<cpal::Stream>>,
     receiver: Receiver<AudioChunk>,
     running: Arc<AtomicBool>,
-    #[allow(dead_code)]
     sample_rate: u32,
-    #[allow(dead_code)]
     channels: u16,
 }
 
@@ -241,6 +239,16 @@ impl MicrophoneStream {
     /// Check whether the stream is still actively capturing.
     pub fn is_open(&self) -> bool {
         self.running.load(Ordering::Relaxed)
+    }
+
+    /// The sample rate (Hz) this stream was opened with.
+    pub fn sample_rate(&self) -> u32 {
+        self.sample_rate
+    }
+
+    /// The channel count this stream was opened with.
+    pub fn channels(&self) -> u16 {
+        self.channels
     }
 
     /// Stop capturing audio and release the device.

--- a/crates/decibri/src/microphone.rs
+++ b/crates/decibri/src/microphone.rs
@@ -407,7 +407,9 @@ impl Microphone {
                 move |err| {
                     // Record a typed cause so a consumer that sees the stream
                     // close can distinguish a driver failure from stop().
-                    let typed = DecibriError::DeviceFailed(err.to_string());
+                    let typed = DecibriError::DeviceFailed {
+                        source: Box::new(err),
+                    };
                     eprintln!("{typed}");
                     if let Ok(mut slot) = err_last_error.lock() {
                         *slot = Some(typed);

--- a/crates/decibri/src/onnx.rs
+++ b/crates/decibri/src/onnx.rs
@@ -150,6 +150,13 @@ fn do_ort_init(_path: Option<&Path>) -> Result<bool, ort::Error> {
 pub(crate) fn init_ort_once(path: Option<&Path>) -> Result<(), DecibriError> {
     // Fast path: ORT already initialized.
     if ORT_INIT.get().is_some() {
+        // Guard fork-after-init at construction time, not only at inference: in
+        // a forked child the inherited OnceLock makes this the fast path, and
+        // building a session against inherited ORT state is the exact unsafe
+        // operation `check_pid_for_ort` exists to prevent. Without this the
+        // typed `ForkAfterOrtInit` would not fire until the first inference,
+        // after the unsafe session build had already run.
+        check_pid_for_ort()?;
         return Ok(());
     }
 

--- a/crates/decibri/src/onnx.rs
+++ b/crates/decibri/src/onnx.rs
@@ -85,9 +85,9 @@ static ORT_INIT: OnceLock<Option<PathBuf>> = OnceLock::new();
 /// [`check_pid_for_ort`]; a mismatch indicates the process forked after
 /// init and ONNX Runtime's internal state is no longer safe to use.
 ///
-/// Recorded inside the `OnceLock::get_or_init` callback in
-/// [`init_ort_once`] so the pid stamp is paired with the successful ORT
-/// init, not set speculatively before init returned.
+/// Recorded via [`OnceLock::set`] in the `Ok` arm of [`init_ort_once`] (after
+/// `do_ort_init` returns successfully) so the pid stamp is paired with the
+/// successful ORT init, not set speculatively before init returned.
 static ORT_INIT_PID: OnceLock<u32> = OnceLock::new();
 
 /// Wrap an ORT init failure with a decibri-specific actionable message.
@@ -624,7 +624,6 @@ mod tests {
     /// load-bearing bound (`SileroVad` can live on a capture thread; the
     /// bindings already assert `Send + 'static`). If a future trait change
     /// drops one of these bounds, this assertion fails at compile time.
-    #[allow(dead_code)]
     fn assert_send_sync<T: Send + Sync>() {}
 
     #[test]

--- a/crates/decibri/src/sample.rs
+++ b/crates/decibri/src/sample.rs
@@ -38,7 +38,15 @@ pub fn i16_to_f32(samples: &[i16]) -> Vec<f32> {
 ///
 /// Each pair of bytes is interpreted as an i16 LE value, then divided by 32768.0.
 /// Used by the output path: JS sends i16 LE bytes, Rust needs f32 for cpal.
+///
+/// A trailing odd byte (when `bytes.len()` is odd) is ignored. The public
+/// bindings only ever pass even-length PCM buffers, so this is a defensive
+/// note rather than a reachable case.
 pub fn i16_le_bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
+    debug_assert!(
+        bytes.len().is_multiple_of(2),
+        "i16_le_bytes_to_f32 expects an even-length buffer; a trailing odd byte is dropped"
+    );
     bytes
         .chunks_exact(2)
         .map(|c| {

--- a/crates/decibri/src/speaker.rs
+++ b/crates/decibri/src/speaker.rs
@@ -453,7 +453,9 @@ impl Speaker {
                 move |err| {
                     // Record a typed cause so a consumer that sees the stream
                     // close can distinguish a driver failure from stop().
-                    let typed = DecibriError::DeviceFailed(err.to_string());
+                    let typed = DecibriError::DeviceFailed {
+                        source: Box::new(err),
+                    };
                     eprintln!("{typed}");
                     if let Ok(mut slot) = err_last_error.lock() {
                         *slot = Some(typed);

--- a/crates/decibri/src/speaker.rs
+++ b/crates/decibri/src/speaker.rs
@@ -320,10 +320,12 @@ impl Drop for SpeakerStream {
     /// cpal callback that advances the sentinel count, so without this a
     /// `drain()` already mid-wait at drop time would block forever (and, in the
     /// Node binding, leak the libuv worker running it). Clearing `running` lets
-    /// that loop return on its next poll. The store runs before the `_stream`
-    /// field is dropped (a custom `drop` body runs before field drops), so the
-    /// flag is already false when the callback is torn down. `stop()` performs
-    /// the same flip on the explicit path; this covers drop-without-stop.
+    /// that loop return on its next poll. The fix does not depend on drop
+    /// ordering: a parked drain escapes via `running` regardless of when the
+    /// cpal callback is torn down (the `drop` body runs before the `_stream`
+    /// field drops, which is simply the natural place to clear the flag).
+    /// `stop()` performs the same flip on the explicit path; this covers
+    /// drop-without-stop.
     fn drop(&mut self) {
         self.running.store(false, Ordering::Relaxed);
     }

--- a/crates/decibri/src/speaker.rs
+++ b/crates/decibri/src/speaker.rs
@@ -201,6 +201,11 @@ pub struct SpeakerStream {
     // its ticket, so sequential drains each wait for their own audio.
     sentinel_seq: Arc<AtomicUsize>,
     sentinels_played: Arc<AtomicUsize>,
+    // Last device/driver error reported by the cpal output error callback
+    // while streaming, retrievable via [`take_last_error`](Self::take_last_error).
+    // Lets a consumer that sees a closed stream distinguish a driver failure
+    // from an explicit `stop()`. Written at most once, on failure.
+    last_error: Arc<Mutex<Option<DecibriError>>>,
 }
 
 #[cfg(feature = "playback")]
@@ -251,6 +256,17 @@ impl SpeakerStream {
     /// Check whether the stream is still actively playing.
     pub fn is_playing(&self) -> bool {
         self.running.load(Ordering::Relaxed)
+    }
+
+    /// Take the last device/driver error reported while streaming, if any.
+    ///
+    /// When the cpal output error callback fires (device unplug, driver
+    /// failure) it records a typed [`DecibriError::DeviceFailed`] and stops
+    /// playback. Reading it here drains it (returns `None` afterwards), letting
+    /// a consumer that observes a closed stream tell a driver failure apart
+    /// from an explicit [`stop`](Self::stop).
+    pub fn take_last_error(&self) -> Option<DecibriError> {
+        self.last_error.lock().ok().and_then(|mut slot| slot.take())
     }
 
     /// Immediate stop, releasing the device. The output goes silent at once and
@@ -384,6 +400,8 @@ impl Speaker {
         let running_cb = running.clone();
         let sentinels_played_cb = sentinels_played.clone();
         let running_clone = running.clone();
+        let last_error = Arc::new(Mutex::new(None));
+        let err_last_error = last_error.clone();
 
         let sample_rate = self.config.sample_rate;
         let channels = self.config.channels;
@@ -412,7 +430,13 @@ impl Speaker {
                     );
                 },
                 move |err| {
-                    eprintln!("decibri: audio output error: {err}");
+                    // Record a typed cause so a consumer that sees the stream
+                    // close can distinguish a driver failure from stop().
+                    let typed = DecibriError::DeviceFailed(err.to_string());
+                    eprintln!("{typed}");
+                    if let Ok(mut slot) = err_last_error.lock() {
+                        *slot = Some(typed);
+                    }
                     running_clone.store(false, Ordering::Relaxed);
                 },
                 None,
@@ -429,6 +453,7 @@ impl Speaker {
             running,
             sentinel_seq,
             sentinels_played,
+            last_error,
         })
     }
 }
@@ -451,6 +476,7 @@ mod tests {
             running: Arc::new(AtomicBool::new(true)),
             sentinel_seq: Arc::new(AtomicUsize::new(0)),
             sentinels_played: sentinels_played.clone(),
+            last_error: Arc::new(Mutex::new(None)),
         };
         (stream, receiver, sentinels_played)
     }

--- a/crates/decibri/src/speaker.rs
+++ b/crates/decibri/src/speaker.rs
@@ -310,6 +310,25 @@ impl SpeakerStream {
     }
 }
 
+#[cfg(feature = "playback")]
+impl Drop for SpeakerStream {
+    /// Release any drain parked on this stream, or on a [`SpeakerSink`] that
+    /// shares its `running` flag, when the stream is dropped without `stop()`.
+    ///
+    /// `drain()` waits in a poll loop ([`drain_impl`]) that exits only on its
+    /// sentinel count or `running == false`. Dropping the stream tears down the
+    /// cpal callback that advances the sentinel count, so without this a
+    /// `drain()` already mid-wait at drop time would block forever (and, in the
+    /// Node binding, leak the libuv worker running it). Clearing `running` lets
+    /// that loop return on its next poll. The store runs before the `_stream`
+    /// field is dropped (a custom `drop` body runs before field drops), so the
+    /// flag is already false when the callback is torn down. `stop()` performs
+    /// the same flip on the explicit path; this covers drop-without-stop.
+    fn drop(&mut self) {
+        self.running.store(false, Ordering::Relaxed);
+    }
+}
+
 /// A cloneable, `Send` handle to a running [`SpeakerStream`]'s sample channel
 /// and drain state.
 ///
@@ -525,6 +544,44 @@ mod tests {
             );
             thread::sleep(Duration::from_millis(1));
         }
+    }
+
+    #[test]
+    fn drain_returns_when_stream_dropped_without_stop() {
+        // Regression for the drop-while-draining hang: a drain() parked in its
+        // wait loop must return when the SpeakerStream is dropped without an
+        // explicit stop(). The synthetic stream has no output callback to
+        // advance `sentinels_played`, so the only way the drain can finish is
+        // the `running` flag going false. Pre-fix (no `impl Drop`) nothing
+        // cleared it on drop, so the drain polled forever (and a Node
+        // `drainAsync` leaked the libuv worker running it). The `impl Drop`
+        // clears `running`; this test fails (via the watchdog) without it.
+        let (stream, receiver, _played) = test_stream();
+        let sink = stream.sink();
+        let (done_tx, done_rx) = crossbeam_channel::bounded::<()>(1);
+        let drain_thread = thread::spawn(move || {
+            // Sends a sentinel (the channel is open: `receiver` is held below),
+            // then polls `sentinels_played`, which nothing advances here.
+            sink.drain();
+            let _ = done_tx.send(());
+        });
+
+        // Let the drain thread send its sentinel and enter the wait loop.
+        thread::sleep(Duration::from_millis(50));
+
+        // Drop the stream WITHOUT stop(). `impl Drop` must clear `running` so
+        // the parked drain returns on its next poll.
+        drop(stream);
+
+        // Watchdog: a regression fails the test here instead of hanging the
+        // whole suite.
+        assert!(
+            done_rx.recv_timeout(Duration::from_secs(2)).is_ok(),
+            "drain() did not return after the stream was dropped without stop() \
+             (regression: would hang forever without impl Drop for SpeakerStream)"
+        );
+        drain_thread.join().unwrap();
+        drop(receiver);
     }
 
     #[test]

--- a/crates/decibri/src/vad.rs
+++ b/crates/decibri/src/vad.rs
@@ -278,7 +278,12 @@ impl SileroVad {
                 source: "Silero output `output` missing from session run".into(),
             })?;
         let probability = match &prob.data {
-            OnnxTensorOwned::F32(v) => v[0],
+            OnnxTensorOwned::F32(v) => {
+                *v.first().ok_or_else(|| DecibriError::OnnxBackendFailed {
+                    backend: "ort",
+                    source: "Silero output `output` tensor is empty".into(),
+                })?
+            }
             OnnxTensorOwned::I64(_) => {
                 return Err(DecibriError::OnnxBackendFailed {
                     backend: "ort",
@@ -294,7 +299,20 @@ impl SileroVad {
                 source: "Silero output `stateN` missing from session run".into(),
             })?;
         match &state_n.data {
-            OnnxTensorOwned::F32(v) => self.state.copy_from_slice(v),
+            OnnxTensorOwned::F32(v) => {
+                if v.len() != self.state.len() {
+                    return Err(DecibriError::OnnxBackendFailed {
+                        backend: "ort",
+                        source: format!(
+                            "Silero output `stateN` has {} elements, expected {}",
+                            v.len(),
+                            self.state.len()
+                        )
+                        .into(),
+                    });
+                }
+                self.state.copy_from_slice(v);
+            }
             OnnxTensorOwned::I64(_) => {
                 return Err(DecibriError::OnnxBackendFailed {
                     backend: "ort",

--- a/crates/decibri/src/vad.rs
+++ b/crates/decibri/src/vad.rs
@@ -333,7 +333,88 @@ impl SileroVad {
 #[cfg(all(test, feature = "vad"))]
 mod tests {
     use super::*;
+    use crate::onnx::{OnnxOutputTensor, OnnxOutputs};
     use std::path::Path;
+
+    // ---- F7: malformed model output must surface a typed error, not panic ----
+
+    /// A mock session returning caller-specified `output`/`stateN` tensors, to
+    /// exercise `infer_window`'s malformed-output paths without ORT.
+    struct MalformedSession {
+        output: Vec<f32>,
+        state_n: Vec<f32>,
+    }
+
+    impl OnnxSession for MalformedSession {
+        fn run(&mut self, _inputs: OnnxInputs<'_>) -> Result<OnnxOutputs, DecibriError> {
+            Ok(OnnxOutputs {
+                tensors: vec![
+                    (
+                        "output".to_string(),
+                        OnnxOutputTensor {
+                            shape: vec![1, 1],
+                            data: OnnxTensorOwned::F32(self.output.clone()),
+                        },
+                    ),
+                    (
+                        "stateN".to_string(),
+                        OnnxOutputTensor {
+                            shape: vec![2, 1, 128],
+                            data: OnnxTensorOwned::F32(self.state_n.clone()),
+                        },
+                    ),
+                ],
+            })
+        }
+    }
+
+    /// Build a 16 kHz `SileroVad` around an arbitrary session, bypassing ORT.
+    /// This child module may construct `SileroVad`'s private fields directly, so
+    /// no production-side test seam is needed.
+    fn vad_with_session(session: Box<dyn OnnxSession>) -> SileroVad {
+        let window_size = 512;
+        let context_size = window_size / 8;
+        SileroVad {
+            session,
+            state: vec![0.0f32; STATE_SIZE],
+            sample_rate: 16000,
+            threshold: 0.5,
+            accumulator: Vec::new(),
+            window_size,
+            context: vec![0.0f32; context_size],
+            context_size,
+        }
+    }
+
+    #[test]
+    fn malformed_probability_output_returns_typed_error() {
+        // An empty `output` tensor must surface OnnxBackendFailed rather than
+        // panic at the probability read (the `v.first()` site).
+        let mut vad = vad_with_session(Box::new(MalformedSession {
+            output: vec![],
+            state_n: vec![0.0f32; STATE_SIZE],
+        }));
+        let err = vad.process(&[0.0f32; 512]).unwrap_err();
+        assert!(
+            matches!(err, DecibriError::OnnxBackendFailed { .. }),
+            "expected OnnxBackendFailed, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn malformed_state_output_returns_typed_error() {
+        // A wrong-length `stateN` tensor must surface OnnxBackendFailed rather
+        // than panic in `copy_from_slice` (the state length-check site).
+        let mut vad = vad_with_session(Box::new(MalformedSession {
+            output: vec![0.5f32],
+            state_n: vec![0.0f32; STATE_SIZE - 1],
+        }));
+        let err = vad.process(&[0.0f32; 512]).unwrap_err();
+        assert!(
+            matches!(err, DecibriError::OnnxBackendFailed { .. }),
+            "expected OnnxBackendFailed, got {err:?}"
+        );
+    }
 
     fn model_path() -> PathBuf {
         // Resolve relative to the workspace root

--- a/crates/decibri/src/vad.rs
+++ b/crates/decibri/src/vad.rs
@@ -368,9 +368,8 @@ mod tests {
         };
         assert!(!init_failed.is_ort_path_error());
 
-        // `SampleRateOutOfRange` is a unit variant (applies to capture/output
-        // configs, not VAD); Ross's draft had `(999999)` which wouldn't
-        // compile. Using the correct unit form.
+        // `SampleRateOutOfRange` is a unit variant (it applies to capture and
+        // output configs, not VAD), so it is constructed without a payload.
         let sample_rate = DecibriError::SampleRateOutOfRange;
         assert!(!sample_rate.is_ort_path_error());
 

--- a/crates/decibri/tests/vad_ort_load_failure.rs
+++ b/crates/decibri/tests/vad_ort_load_failure.rs
@@ -7,8 +7,8 @@
 //! each run is the first ORT init in its process and thus actually exercises
 //! the load-failure branch.
 //!
-//! The tests rely on the defensive pre-check added in
-//! `crates/decibri/src/vad.rs::init_ort_once`, which validates that the
+//! The tests rely on the defensive pre-check in
+//! `crates/decibri/src/onnx.rs::init_ort_once`, which validates that the
 //! provided `ort_library_path` points at a regular file before handing it
 //! to `ort::init_from`. Without that pre-check, Windows hangs indefinitely
 //! inside `ort::init_from` on a nonexistent path (reproduced 2026-04-22
@@ -29,7 +29,7 @@
 //! ```text
 //! cargo test -p decibri \
 //!   --no-default-features \
-//!   --features capture,output,vad,denoise,gain,ort-load-dynamic \
+//!   --features capture,playback,vad,denoise,gain,ort-load-dynamic \
 //!   --test vad_ort_load_failure
 //! ```
 

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -11,6 +11,14 @@ For other decibri packages, see:
 
 ## [Unreleased]
 
+## [4.4.1] - 2026-06-11
+
+### Fixed
+
+- Restarting a `DecibriBridge` (stop then start) no longer silently loses Silero VAD: the VAD is reclaimed across the cycle and `vadProbability` is reset on stop.
+- A device or driver error during capture now raises the `'error'` event instead of freezing silently with `isOpen` still true. The capture pump uses a timed receive, and `isOpen` reflects the real device state.
+- Picks up the Rust core `drain()` drop fix, so a pending `drainAsync()` whose speaker is dropped without `stop()` no longer leaks a libuv worker thread or leaves the promise unsettled.
+
 ## [4.4.0] - 2026-06-10
 
 ### Changed

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -17,7 +17,7 @@ For other decibri packages, see:
 
 - `end()` on the Node `Speaker` now flushes then stops: it plays out the queued audio (drain) and then stops the stream, so `isPlaying` is false after `finish`. This keeps `end()` terminal now that the Rust core makes `drain()` a non-terminal, repeatable flush. As a result, `drainAsync()` is repeatable too (a later `drainAsync()` waits for its own audio instead of returning immediately). `stop()` releases the audio device via the updated core (the binding already dropped the native stream on stop, so no behavior change there). The rest of the API is unchanged.
 
-## [4.3.0] - Unreleased
+## [4.3.0] - 2026-06-07
 
 ### Fixed
 

--- a/npm/decibri/package.json
+++ b/npm/decibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decibri",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "Cross-platform audio capture, playback, and processing for Node.js and browsers",
   "main": "src/decibri.js",
   "types": "src/decibri.d.ts",
@@ -72,10 +72,10 @@
     "MIGRATION.md"
   ],
   "optionalDependencies": {
-    "@decibri/decibri-win32-x64-msvc": "4.4.0",
-    "@decibri/decibri-darwin-arm64": "4.4.0",
-    "@decibri/decibri-linux-x64-gnu": "4.4.0",
-    "@decibri/decibri-linux-arm64-gnu": "4.4.0"
+    "@decibri/decibri-win32-x64-msvc": "4.4.1",
+    "@decibri/decibri-darwin-arm64": "4.4.1",
+    "@decibri/decibri-linux-x64-gnu": "4.4.1",
+    "@decibri/decibri-linux-arm64-gnu": "4.4.1"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.7.0"

--- a/npm/decibri/src/browser/decibri-browser.js
+++ b/npm/decibri/src/browser/decibri-browser.js
@@ -6,7 +6,7 @@ const { WORKLET_SOURCE } = require('./worklet-inline.js');
 // Browser build version. Keep in sync with package.json on each release; the
 // browser bundle cannot read package.json at runtime the way the Node wrapper
 // does, so this is a maintained constant.
-const VERSION = '4.4.0';
+const VERSION = '4.4.1';
 
 /**
  * Browser microphone capture.

--- a/npm/decibri/src/decibri.js
+++ b/npm/decibri/src/decibri.js
@@ -376,7 +376,7 @@ class Microphone extends Readable {
 
   /**
    * List all available input devices on the system.
-   * @returns {Array<{index: number, name: string, maxInputChannels: number, defaultSampleRate: number, isDefault: boolean}>}
+   * @returns {Array<{index: number, name: string, id: string, maxInputChannels: number, defaultSampleRate: number, isDefault: boolean}>}
    */
   static devices() {
     return DecibriBridge.devices();

--- a/npm/platform-darwin-arm64/package.json
+++ b/npm/platform-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-darwin-arm64",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "os": ["darwin"],
   "cpu": ["arm64"],
   "main": "decibri.darwin-arm64.node",

--- a/npm/platform-linux-arm64-gnu/package.json
+++ b/npm/platform-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-arm64-gnu",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "os": ["linux"],
   "cpu": ["arm64"],
   "main": "decibri.linux-arm64-gnu.node",

--- a/npm/platform-linux-x64-gnu/package.json
+++ b/npm/platform-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-x64-gnu",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "os": ["linux"],
   "cpu": ["x64"],
   "main": "decibri.linux-x64-gnu.node",

--- a/npm/platform-win32-x64-msvc/package.json
+++ b/npm/platform-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-win32-x64-msvc",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "os": ["win32"],
   "cpu": ["x64"],
   "main": "decibri.win32-x64-msvc.node",


### PR DESCRIPTION
Fixes the validated non-cpal findings, plus the pre-merge gold-standard additions. Patch release across all three packages; defect fixes plus additive non-breaking API.

## What changed
- fix(rust): drain() no longer hangs when the SpeakerStream is dropped without stop() (impl Drop clears running; regression test that hangs on the old code)
- fix(node): keep VAD across restart and surface device errors (timed recv, typed error to the 'error' event, isOpen reflects real state)
- feat(rust): typed DeviceFailed error carrying the underlying cpal stream error as a structured #[source]; take_last_error() on both stream types
- fix(rust): fork guard fires at session build; malformed model output returns OnnxBackendFailed instead of panicking; bounded capture channel with an overrun counter
- ci: golden VAD anchors run on macOS and Windows; ort-load-dynamic failure test wired in
- test(rust): drain-drop and malformed-model regression tests (crate tests 65 to 68)
- chore: docs/dependency/lint hygiene (#[allow] 9 to 6, two dead deps removed, SECURITY.md, comment corrections)
- chore: version bump crate 4.3.1, python 0.4.1, npm 4.4.1 across all source-constant sites

## Deferred (not in this release)
- cpal 0.18.x upgrade and native resampling (separate cycles)

## Verification
- Acoustic and lifecycle behavior verified by hardware checks