### PR TITLE
Python 0.4.2: stop() safely interrupts an in-flight read; audit config

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,15 @@
+# Security advisory ignores for `cargo audit`.
+# Each entry records WHY it is ignored and that the real fix is tracked,
+# so this never becomes a silent forgotten suppression.
+
+[advisories]
+ignore = [
+    # pyo3 0.28.3: OOB read in nth/nth_back for PyList/PyTuple iterators (RUSTSEC-2026-0176).
+    # decibri's binding does not call nth/nth_back (confirmed by grep 2026-06-12).
+    # Real fix: upgrade pyo3 to >=0.29 (tracked in the backlog). Remove this entry then.
+    "RUSTSEC-2026-0176",
+    # pyo3 0.28.3: missing Sync bound on PyCFunction::new_closure closures (RUSTSEC-2026-0177).
+    # decibri's binding does not use new_closure (confirmed by grep 2026-06-12).
+    # Real fix: upgrade pyo3 to >=0.29 (tracked in the backlog). Remove this entry then.
+    "RUSTSEC-2026-0177",
+]

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -8,6 +8,13 @@ For Rust core (`crates/decibri`) and npm binding (`bindings/node`) changes, see 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2026-06-12
+
+### Fixed
+
+- `Microphone.stop()` called from a different thread than the one blocked inside `read()` no longer raises `RuntimeError` ("already borrowed"). The sync bridge now exposes `read()` / `stop()` without an exclusive borrow and shares the core stream behind a handle, so a cross-thread `stop()` interrupts the parked read (which then raises `MicrophoneStreamClosed`) and releases the device.
+- `AsyncMicrophone.stop()` no longer deadlocks against a `read()` parked on a silent (non-delivering) device. The async wrapper no longer holds a bridge-wide lock across the blocking read, so a concurrent `await stop()` reaches the core stop (which wakes the parked read within roughly 20ms) instead of waiting behind it. The two are the sync and async halves of the same "stop() cannot safely interrupt an in-flight read" issue.
+
 ## [0.4.1] - 2026-06-11
 
 ### Fixed

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "decibri"
-version = "0.4.1"
+version = "0.4.2"
 description = "Cross-platform audio capture, playback, and voice activity detection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/python/python/decibri/__init__.py
+++ b/bindings/python/python/decibri/__init__.py
@@ -51,7 +51,7 @@ from decibri.exceptions import (
     VadThresholdOutOfRange,
 )
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 
 def input_devices() -> list[MicrophoneInfo]:

--- a/bindings/python/python/decibri/_classes.py
+++ b/bindings/python/python/decibri/_classes.py
@@ -274,16 +274,15 @@ class Microphone:
         underlying stream within roughly 20ms; the wrapper then sees the
         closed state on its next read attempt and raises.
 
-        Threaded shutdown limitation in 0.1.0: calling ``stop()`` from a
-        thread other than the one currently blocked inside ``read()`` can
-        raise ``AlreadyBorrowed`` (a pyo3 ``RuntimeError`` from the
-        bridge's ``RefCell`` borrow). This is a known 0.1.0 limitation
-        pinned by ``test_sync_stop_from_other_thread_raises_already_borrowed``;
-        a thread-safe shutdown path is planned for a future release.
-        Workarounds:
-        use ``AsyncMicrophone`` (sibling-task cancellation works
-        correctly), or call ``stop()`` from the same thread that owns
-        the iteration loop.
+        Threaded shutdown: calling ``stop()`` from a thread other than
+        the one currently blocked inside ``read()`` is safe. It
+        interrupts the parked read, which then raises
+        ``MicrophoneStreamClosed``, and releases the device. The bridge
+        holds the core stream behind a shared handle and exposes
+        ``read()`` / ``stop()`` without an exclusive borrow, so the
+        cross-thread ``stop()`` reaches the core stop (which wakes the
+        parked read within roughly 20ms) instead of raising
+        ``AlreadyBorrowed``.
     """
 
     def __init__(

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -24,8 +24,8 @@
 //! the bridge exposes via `vad_probability`.
 
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use std::collections::HashMap;
@@ -68,11 +68,11 @@ use decibri::CPAL_VERSION;
 // Coverage:
 //   - MicrophoneBridge / SpeakerBridge: the sync pyclasses; their
 //     Send + 'static property comes from not being `unsendable`.
-//   - AsyncMicrophoneBridge / AsyncSpeakerBridge: the async wrappers;
-//     each holds an Arc<tokio::sync::Mutex<T>> where T is the matching
-//     sync bridge. Arc + tokio::sync::Mutex are Send + Sync when T is
-//     Send (which the sync bridges are), so the async wrappers inherit
-//     the property automatically.
+//   - AsyncMicrophoneBridge: holds an Arc<MicrophoneBridge> directly (the
+//     sync mic bridge is internally thread-safe, so no outer Mutex is
+//     needed); AsyncSpeakerBridge holds an Arc<tokio::sync::Mutex<SpeakerBridge>>.
+//     Arc<T> is Send + Sync when T is Send + Sync, so both async wrappers
+//     inherit the Send + 'static property automatically.
 //
 // If this assertion fails to compile, look for a recently added field
 // on any of the four pyclasses whose type is not `Send + 'static`: raw
@@ -422,7 +422,7 @@ fn build_version_info() -> VersionInfo {
     VersionInfo {
         decibri: env!("CARGO_PKG_VERSION").to_string(),
         audio_backend: format!("cpal {}", CPAL_VERSION),
-        binding: "0.4.1".to_string(),
+        binding: "0.4.2".to_string(),
     }
 }
 
@@ -686,23 +686,50 @@ fn numpy_smoke(py: Python<'_>) -> Bound<'_, PyArray1<i16>> {
 //     for diagnostic introspection)
 //   - format: BindingSampleFormat (parsed from constructor 'format' arg)
 //   - vad_holdoff_ms: u32 (inert; wrapper layer reads this if it wants to)
-//   - capture: Option<Microphone> (None until start())
-//   - stream: Option<MicrophoneStream> (None until start())
-//   - vad: Option<SileroVad> (None unless constructor's vad=True AND
+//   - active: Mutex<Option<ActiveCapture>> (the open Microphone plus an
+//     Arc<MicrophoneStream>; None until start(), cleared by stop())
+//   - vad: Mutex<Option<SileroVad>> (None unless constructor's vad=True AND
 //     vad_mode=="silero"; per VAD Option (b)+(h) decision)
-//   - last_vad_probability: f32 (most recent Silero raw probability; updated
-//     on each read() that runs Silero inference)
+//   - last_vad_probability: AtomicU32 (most recent Silero raw probability as
+//     f32 bits; updated on each read() that runs Silero inference)
+//
+// The mutable state lives behind interior-mutability primitives so read() and
+// stop() are both `&self`. read() takes only a transient lock to clone the
+// Arc<MicrophoneStream>, never holding it across the blocking next_chunk, so a
+// concurrent stop() can take the same lock, call the core stream's stop()
+// (which wakes a parked next_chunk in ~20ms), and clear the state. This is the
+// shape the Node binding already uses, and it is what lets stop() safely
+// interrupt a read() that is in flight on another thread (sync) or task
+// (async) instead of panicking on a borrow or deadlocking on a lock.
 // ---------------------------------------------------------------------------
+
+/// Lock a `std::sync::Mutex`, recovering the guard if a previous holder
+/// panicked while holding it. The critical sections here are short and
+/// panic-free, so poisoning is not expected; recovering rather than
+/// propagating keeps a stray panic from turning every later read()/stop()
+/// into a poison panic. Mirrors the poison tolerance in the core's stop().
+fn lock_recover<T>(m: &StdMutex<T>) -> std::sync::MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// The live capture state: the open `Microphone` (kept alive so the device
+/// stays open for the stream's lifetime) and a shared handle to its
+/// `MicrophoneStream`. The stream is an `Arc` so stop() can hold a handle and
+/// call the core stop() out of band of a read() parked in next_chunk on
+/// another thread.
+struct ActiveCapture {
+    _capture: Microphone,
+    stream: Arc<MicrophoneStream>,
+}
 
 #[pyclass(module = "decibri._decibri")]
 struct MicrophoneBridge {
     capture_config: MicrophoneConfig,
     format: BindingSampleFormat,
     vad_holdoff_ms: u32,
-    capture: Option<Microphone>,
-    stream: Option<MicrophoneStream>,
-    vad: Option<SileroVad>,
-    last_vad_probability: f32,
+    active: StdMutex<Option<ActiveCapture>>,
+    vad: StdMutex<Option<SileroVad>>,
+    last_vad_probability: AtomicU32,
     /// When true, `read()` returns a numpy.ndarray instead of
     /// a bytes object. Constructor flag; per-instance commitment for
     /// the iterator's lifetime (the user picks one return type at
@@ -713,8 +740,8 @@ struct MicrophoneBridge {
 
 // Internal helpers on MicrophoneBridge; not exposed to Python.
 // Used by the public `read` pymethod (same module) and by
-// `AsyncMicrophoneBridge::read` (which locks the inner sync bridge inside
-// spawn_blocking, calls these to extract owned Vec data + metadata,
+// `AsyncMicrophoneBridge::read` (which calls these on the shared inner
+// bridge inside spawn_blocking to extract owned Vec data + metadata,
 // then constructs the Python object outside the spawn_blocking
 // boundary because `Bound<'py, ...>` is GIL-bound).
 impl MicrophoneBridge {
@@ -722,30 +749,47 @@ impl MicrophoneBridge {
     /// return the raw `Vec<f32>` data. No Python object construction;
     /// returning `Vec<f32>` lets the caller decide between PyBytes and
     /// PyArray encoding without re-running the cpal read or VAD pass.
-    fn read_raw(&mut self, py: Python<'_>, timeout_ms: Option<u64>) -> PyResult<Option<Vec<f32>>> {
+    fn read_raw(&self, py: Python<'_>, timeout_ms: Option<u64>) -> PyResult<Option<Vec<f32>>> {
         let timeout = timeout_ms.map(Duration::from_millis);
-        let stream = self
-            .stream
-            .as_mut()
-            .ok_or_else(|| raise_named(py, "MicrophoneStreamClosed", "capture is not running"))?;
 
-        // Release GIL for the blocking next_chunk call. Run VAD inference
-        // inside the same allow_threads region to avoid GIL ping-pong.
-        let result: Result<Option<AudioChunk>, CoreDecibriError> = py.detach(|| {
-            let chunk = stream.next_chunk(timeout)?;
-            Ok(chunk)
-        });
+        // Clone a handle to the core stream under a tiny lock, then release the
+        // lock BEFORE the blocking read. Holding only an Arc clone (not the
+        // `active` lock) across next_chunk is what lets a concurrent stop()
+        // take the lock and interrupt a parked read.
+        let stream = {
+            let guard = lock_recover(&self.active);
+            match guard.as_ref() {
+                Some(active) => Arc::clone(&active.stream),
+                None => {
+                    return Err(raise_named(
+                        py,
+                        "MicrophoneStreamClosed",
+                        "capture is not running",
+                    ))
+                }
+            }
+        };
+
+        // Release GIL for the blocking next_chunk call. The `active` lock is
+        // not held here, so stop() can proceed concurrently and wake us.
+        let result: Result<Option<AudioChunk>, CoreDecibriError> =
+            py.detach(|| stream.next_chunk(timeout));
 
         let Some(chunk) = result.map_err(|e| to_py_err(py, e))? else {
             return Ok(None);
         };
 
-        // Run Silero VAD inference if configured.
-        if let Some(vad) = self.vad.as_mut() {
-            let result = py
-                .detach(|| vad.process(&chunk.data))
-                .map_err(|e| to_py_err(py, e))?;
-            self.last_vad_probability = result.probability;
+        // Run Silero VAD inference if configured. Only read() touches `vad`, so
+        // this lock never contends with stop().
+        {
+            let mut vad_guard = lock_recover(&self.vad);
+            if let Some(vad) = vad_guard.as_mut() {
+                let result = py
+                    .detach(|| vad.process(&chunk.data))
+                    .map_err(|e| to_py_err(py, e))?;
+                self.last_vad_probability
+                    .store(result.probability.to_bits(), Ordering::Relaxed);
+            }
         }
 
         Ok(Some(chunk.data))
@@ -833,16 +877,16 @@ impl MicrophoneBridge {
             capture_config,
             format: parsed_format,
             vad_holdoff_ms: vad_holdoff,
-            capture: None,
-            stream: None,
-            vad: vad_instance,
-            last_vad_probability: 0.0,
+            active: StdMutex::new(None),
+            vad: StdMutex::new(vad_instance),
+            last_vad_probability: AtomicU32::new(0),
             numpy,
         })
     }
 
-    fn start(&mut self, py: Python<'_>) -> PyResult<()> {
-        if self.stream.is_some() {
+    fn start(&self, py: Python<'_>) -> PyResult<()> {
+        let mut active = lock_recover(&self.active);
+        if active.is_some() {
             return Err(raise_named(
                 py,
                 "AlreadyRunning",
@@ -851,20 +895,29 @@ impl MicrophoneBridge {
         }
         let capture = Microphone::new(self.capture_config.clone()).map_err(|e| to_py_err(py, e))?;
         let stream = capture.start().map_err(|e| to_py_err(py, e))?;
-        self.capture = Some(capture);
-        self.stream = Some(stream);
+        *active = Some(ActiveCapture {
+            _capture: capture,
+            stream: Arc::new(stream),
+        });
         Ok(())
     }
 
-    fn stop(&mut self) -> PyResult<()> {
-        // Drop the stream first, then the capture handle. Both are infallible
-        // on drop; the explicit Option swap clarifies intent.
-        self.stream = None;
-        self.capture = None;
+    fn stop(&self) -> PyResult<()> {
+        // Take the live capture out under a tiny lock, then signal the core
+        // stop OUTSIDE the lock. The core MicrophoneStream::stop() flips the
+        // running flag and drops the cpal stream, disconnecting the capture
+        // channel and waking any next_chunk parked in a concurrent read()
+        // within ~20ms. A parked read holds only an Arc clone of the stream
+        // (not the `active` lock), so taking the Option here never blocks on
+        // it. Dropping `active` then releases the device.
+        let active = lock_recover(&self.active).take();
+        if let Some(active) = active {
+            active.stream.stop();
+        }
         Ok(())
     }
 
-    fn close(&mut self) -> PyResult<()> {
+    fn close(&self) -> PyResult<()> {
         // Literal alias for stop, mirroring SpeakerBridge::close.
         // Bridge-level symmetry for users constructing MicrophoneBridge
         // directly (advanced use; surface in __all__).
@@ -873,7 +926,7 @@ impl MicrophoneBridge {
 
     #[pyo3(signature = (timeout_ms = None))]
     fn read<'py>(
-        &mut self,
+        &self,
         py: Python<'py>,
         timeout_ms: Option<u64>,
     ) -> PyResult<Option<Bound<'py, PyAny>>> {
@@ -901,7 +954,7 @@ impl MicrophoneBridge {
         slf
     }
 
-    fn __next__<'py>(mut slf: PyRefMut<'_, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+    fn __next__<'py>(slf: PyRef<'_, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         // Block indefinitely on next_chunk by passing None timeout. If the
         // stream returns None (closed), raise StopIteration via PyO3's
         // None-as-StopIteration convention by returning the appropriate err.
@@ -914,14 +967,14 @@ impl MicrophoneBridge {
         }
     }
 
-    fn __enter__(mut slf: PyRefMut<'_, Self>) -> PyResult<PyRefMut<'_, Self>> {
+    fn __enter__(slf: PyRef<'_, Self>) -> PyResult<PyRef<'_, Self>> {
         let py = slf.py();
         slf.start(py)?;
         Ok(slf)
     }
 
     fn __exit__(
-        &mut self,
+        &self,
         _exc_type: Option<&Bound<'_, PyAny>>,
         _exc_value: Option<&Bound<'_, PyAny>>,
         _traceback: Option<&Bound<'_, PyAny>>,
@@ -932,12 +985,12 @@ impl MicrophoneBridge {
 
     #[getter]
     fn is_open(&self) -> bool {
-        self.stream.is_some()
+        lock_recover(&self.active).is_some()
     }
 
     #[getter]
     fn vad_probability(&self) -> f32 {
-        self.last_vad_probability
+        f32::from_bits(self.last_vad_probability.load(Ordering::Relaxed))
     }
 
     /// Returns inert vad_holdoff_ms set at construction; wrapper reads this
@@ -1213,11 +1266,11 @@ impl SpeakerBridge {
 // ---------------------------------------------------------------------------
 // AsyncMicrophoneBridge: async wrapper around MicrophoneBridge.
 //
-// Holds an `Arc<tokio::sync::Mutex<MicrophoneBridge>>` and
-// exposes the same blocking methods as the sync bridge, but async. Each
-// blocking method dispatches the underlying sync work to a Tokio worker
-// thread via `tokio::task::spawn_blocking`, keeping the runtime thread
-// responsive.
+// Holds an `Arc<MicrophoneBridge>` (the sync mic bridge is internally
+// thread-safe, so no outer Mutex is needed) and exposes the same blocking
+// methods as the sync bridge, but async. Each blocking method dispatches the
+// underlying sync work to a Tokio worker thread via
+// `tokio::task::spawn_blocking`, keeping the runtime thread responsive.
 //
 // The compile-time `Send + 'static` assertion at the top of this module is
 // extended to cover this pyclass; PyO3 + pyo3-async-runtimes capture into
@@ -1230,12 +1283,14 @@ impl SpeakerBridge {
 // async surface (`start`, `stop`, `read`, etc.) is what the
 // `AsyncMicrophone` Python wrapper proxies through.
 //
-// Concurrent calls on the same instance serialize via the inner Mutex.
-// This is a behavioural characteristic, not advertised concurrency.
-// spawn_blocking does not cooperatively cancel
-// OS threads; cancellation surfaces immediately to Python while the spawned
-// thread runs to completion. For `read`, the thread finishes its current
-// chunk (~100 ms); for `drain`, the thread waits for the cpal output to
+// stop() no longer serializes behind an in-flight read(): the sync bridge's
+// read() and stop() are both `&self` and share the core stream by `Arc`, so a
+// concurrent stop() calls the core MicrophoneStream::stop() (waking a parked
+// next_chunk in ~20ms) without contending on any bridge-wide lock.
+// spawn_blocking does not cooperatively cancel OS threads; cancellation
+// surfaces immediately to Python while the spawned thread runs to completion.
+// For `read`, the thread returns once the current chunk arrives or stop()
+// closes the stream; for `drain`, the thread waits for the cpal output to
 // flush (potentially seconds). The Python coroutine's `CancelledError`
 // arrives immediately regardless.
 //
@@ -1248,14 +1303,13 @@ impl SpeakerBridge {
 
 #[pyclass(module = "decibri._decibri")]
 pub(crate) struct AsyncMicrophoneBridge {
-    inner: Arc<Mutex<MicrophoneBridge>>,
-    // Lock-free mirror of inner.stream.is_some(). The
-    // public is_open getter is awaitable (acquires the tokio Mutex), which
-    // makes it unusable from a synchronous Python property. The wrapper
-    // class needs a sync property to keep API symmetry with sync
-    // Microphone.is_open; this AtomicBool is its source of truth.
-    // Updated by start() and stop() after the inner mutation succeeds;
-    // read by the is_open_sync getter without locking.
+    inner: Arc<MicrophoneBridge>,
+    // Lock-free mirror of the bridge's open state. The public is_open getter
+    // is awaitable (returns a future), which makes it unusable from a
+    // synchronous Python property. The wrapper class needs a sync property to
+    // keep API symmetry with sync Microphone.is_open; this AtomicBool is its
+    // source of truth. Updated by start() and stop() after the inner mutation
+    // succeeds; read by the is_open_sync getter without locking.
     is_open_atomic: Arc<AtomicBool>,
 }
 
@@ -1308,7 +1362,7 @@ impl AsyncMicrophoneBridge {
             ort_library_path,
         )?;
         Ok(AsyncMicrophoneBridge {
-            inner: Arc::new(Mutex::new(inner)),
+            inner: Arc::new(inner),
             is_open_atomic: Arc::new(AtomicBool::new(false)),
         })
     }
@@ -1318,8 +1372,7 @@ impl AsyncMicrophoneBridge {
         let is_open_atomic = Arc::clone(&self.is_open_atomic);
         future_into_py(py, async move {
             tokio::task::spawn_blocking(move || -> PyResult<()> {
-                let mut bridge = inner.blocking_lock();
-                Python::attach(|py| bridge.start(py))?;
+                Python::attach(|py| inner.start(py))?;
                 // Only set the atomic AFTER the inner
                 // start() succeeds. If start() returns Err, the ? operator
                 // returns early and the atomic stays false.
@@ -1335,13 +1388,12 @@ impl AsyncMicrophoneBridge {
         let inner = Arc::clone(&self.inner);
         let is_open_atomic = Arc::clone(&self.is_open_atomic);
         future_into_py(py, async move {
-            // stop() is non-blocking (just drops Options) but we still go
-            // through spawn_blocking so the Mutex acquisition is uniform
-            // with start/read; this avoids the awkward .blocking_lock()
-            // call inside an async context that tokio warns against.
+            // Run on a blocking worker: stop() calls the core stream stop(),
+            // which blocks briefly while the audio thread tears down. It needs
+            // no bridge-wide lock, so it proceeds even while a read() is parked
+            // in next_chunk, waking that read within ~20ms.
             tokio::task::spawn_blocking(move || -> PyResult<()> {
-                let mut bridge = inner.blocking_lock();
-                bridge.stop()?;
+                inner.stop()?;
                 // Clear the atomic after the inner
                 // stop() succeeds. inner.stop() itself is infallible, but
                 // mirroring the pattern from start() keeps the symmetry.
@@ -1369,17 +1421,19 @@ impl AsyncMicrophoneBridge {
             // Bound<'py, ...> is GIL-bound and not Send + 'static, so
             // it cannot cross the spawn_blocking boundary. Vec<f32>,
             // u16, bool, and BindingSampleFormat are all Send + 'static.
+            //
+            // read_raw is `&self` and holds no bridge-wide lock across the
+            // blocking next_chunk, so a concurrent stop() interrupts it.
             let extracted: Option<AsyncReadOutput> =
                 tokio::task::spawn_blocking(move || -> PyResult<Option<AsyncReadOutput>> {
-                    let mut bridge = inner.blocking_lock();
                     Python::attach(|py| {
-                        let opt = bridge.read_raw(py, timeout_ms)?;
+                        let opt = inner.read_raw(py, timeout_ms)?;
                         Ok(opt.map(|data| {
                             (
                                 data,
-                                bridge.binding_format(),
-                                bridge.channels(),
-                                bridge.numpy_mode(),
+                                inner.binding_format(),
+                                inner.channels(),
+                                inner.numpy_mode(),
                             )
                         }))
                     })
@@ -1404,10 +1458,9 @@ impl AsyncMicrophoneBridge {
     fn is_open<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let inner = Arc::clone(&self.inner);
         future_into_py(py, async move {
-            // Non-blocking getter: acquire the Mutex via async lock and
-            // read cached state inline. No spawn_blocking needed.
-            let bridge = inner.lock().await;
-            Ok(bridge.is_open())
+            // Non-blocking getter: the bridge's is_open() takes only a tiny
+            // lock on the capture state. No spawn_blocking needed.
+            Ok(inner.is_open())
         })
     }
 
@@ -1423,19 +1476,13 @@ impl AsyncMicrophoneBridge {
     #[getter]
     fn vad_probability<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let inner = Arc::clone(&self.inner);
-        future_into_py(py, async move {
-            let bridge = inner.lock().await;
-            Ok(bridge.vad_probability())
-        })
+        future_into_py(py, async move { Ok(inner.vad_probability()) })
     }
 
     #[getter]
     fn vad_holdoff_ms<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let inner = Arc::clone(&self.inner);
-        future_into_py(py, async move {
-            let bridge = inner.lock().await;
-            Ok(bridge.vad_holdoff_ms())
-        })
+        future_into_py(py, async move { Ok(inner.vad_holdoff_ms()) })
     }
 
     #[staticmethod]

--- a/bindings/python/tests/test_lifecycle.py
+++ b/bindings/python/tests/test_lifecycle.py
@@ -255,14 +255,16 @@ def _supports_kwarg(_obj: Any, _name: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Section 5: mid-stream device-disconnect surfacing.
+# Section 5: mid-stream device-disconnect and concurrent-stop surfacing.
 #
-# Pins the documented 0.1.0 behavior:
+# Pins the behavior:
 #   - read() after stop() raises MicrophoneStreamClosed (sync + async).
 #   - The wrapper's iterator propagates MicrophoneStreamClosed from the bridge.
-#   - Calling stop() from a thread other than the one inside read() raises
-#     AlreadyBorrowed (a pyo3 RuntimeError from the bridge's RefCell borrow).
-#     This is a known limitation pinned by the test below.
+#   - Calling stop() from a thread other than the one inside read() is safe:
+#     it interrupts the parked read and releases the device (sync), and a
+#     concurrent await stop() interrupts a parked await read() (async),
+#     instead of raising AlreadyBorrowed or deadlocking. Pinned by the tests
+#     below.
 # ---------------------------------------------------------------------------
 
 
@@ -323,18 +325,27 @@ def test_async_read_after_stop_raises_capture_closed() -> None:
 
 
 @pytest.mark.requires_audio_input
-def test_sync_stop_from_other_thread_raises_already_borrowed() -> None:
-    """Pins the 0.1.0 sync threaded-shutdown limitation.
+def test_sync_stop_from_other_thread_interrupts_read() -> None:
+    """stop() from another thread safely interrupts an in-flight read().
 
-    Calling Microphone.stop() from a thread other than the one currently
-    blocked inside read() raises a RuntimeError from pyo3's RefCell borrow
-    machinery (the bridge holds the borrow during read()). This is a
-    KNOWN 0.1.0 limitation. The documented workaround is AsyncMicrophone, which
-    serializes stop() against in-flight read() via the Rust-side tokio
-    mutex and supports sibling-task cancellation cleanly. This test pins
-    the current behaviour so that 0.2.0's fix is detectable as a behaviour
-    change rather than a silent regression.
+    Regression for the sync threaded-shutdown bug. Previously calling
+    Microphone.stop() from a thread other than the one blocked inside read()
+    raised a RuntimeError from pyo3's pyclass borrow check, because read() held
+    an exclusive (&mut self) borrow across the blocking call. The bridge now
+    shares the core stream behind an Arc and exposes read()/stop() as &self, so
+    the cross-thread stop() succeeds and the parked read() observes the stream
+    closing. This replaces the former pin
+    (test_sync_stop_from_other_thread_raises_already_borrowed) that asserted the
+    RuntimeError.
+
+    On a backend that honours a large frames_per_buffer (Linux ALSA) the read
+    parks for the buffer period, so the stopper deterministically races an
+    in-flight read. On WASAPI (which delivers ~10ms buffers regardless of
+    frames_per_buffer) the read may return before the stopper runs; the
+    assertions below hold in both cases.
     """
+    from decibri import MicrophoneStreamClosed
+
     d = Microphone(sample_rate=16000, channels=1, frames_per_buffer=8192)
     d.start()
     try:
@@ -343,34 +354,87 @@ def test_sync_stop_from_other_thread_raises_already_borrowed() -> None:
         def _stop_from_other_thread() -> None:
             try:
                 d.stop()
-            except BaseException as exc:  # noqa: BLE001 (pinning behaviour)
+            except BaseException as exc:  # noqa: BLE001
                 observed.append(exc)
 
-        # Start a thread that will call stop() while the main thread is
-        # blocked inside a long-timeout read().
         stopper = threading.Thread(target=_stop_from_other_thread, daemon=True)
         stopper.start()
         try:
-            # Block long enough that the stopper thread reaches stop()
-            # while the main thread is inside the bridge's read().
+            # Block inside read() so the stopper races an in-flight read.
             d.read(timeout_ms=300)
-        except BaseException:  # noqa: BLE001
+        except MicrophoneStreamClosed:
+            # Expected when stop() closed the stream while this read was
+            # parked. A clean chunk (no exception) is also fine if the device
+            # delivered a buffer before the stopper ran.
             pass
         stopper.join(timeout=2.0)
 
-        # Either the stopper observed the RefCell borrow conflict (the
-        # 0.1.0 limitation we are pinning) or the read completed cleanly
-        # before the stopper ran. The deterministic pin is that, when the
-        # race fires, we get a RuntimeError mentioning borrow.
-        if observed:
-            assert isinstance(observed[0], RuntimeError)
-            assert "borrow" in str(observed[0]).lower() or "already" in str(observed[0]).lower()
+        # The fix: stop() from another thread must NOT raise (it previously
+        # raised RuntimeError "already borrowed") and must return.
+        assert not observed, f"stop() from another thread raised: {observed!r}"
+        assert not stopper.is_alive(), "stop() from another thread did not return"
+
+        # After stop(), the stream is closed: a subsequent read() reports it.
+        assert d.is_open is False
+        with pytest.raises(MicrophoneStreamClosed):
+            d.read(timeout_ms=100)
     finally:
-        # Best-effort final cleanup; tolerate the limitation here too.
-        try:
-            d.stop()
-        except BaseException:  # noqa: BLE001
-            pass
+        # Idempotent; safe to call again from this (the owning) thread.
+        d.stop()
+
+
+@pytest.mark.requires_audio_input
+def test_async_stop_interrupts_parked_read() -> None:
+    """await stop() interrupts a concurrent parked read() instead of deadlocking.
+
+    Regression for the async half of the stop()-during-read() bug. The async
+    read() previously held the inner tokio Mutex across the blocking next_chunk,
+    so a concurrent await stop() (which needed the same lock) could not run
+    until the read returned; on a non-delivering device that deadlocked stop()
+    forever. The bridge now shares the core stream by Arc and read()/stop() hold
+    no bridge-wide lock across the blocking call, so stop() reaches the core
+    stop() (waking next_chunk in ~20ms) immediately.
+
+    A true non-delivering device cannot be simulated for a live cpal stream, so
+    this uses the largest frames_per_buffer (65536) as the narrowest seam that
+    exhibits the lock-hold: on a backend that honours it (Linux ALSA) next_chunk
+    parks for the buffer period (seconds), so pre-fix the stop() watchdog below
+    would time out and post-fix it passes. On WASAPI (~10ms buffers regardless)
+    it is a regression guard confirming stop() stays prompt and the parked read
+    is woken rather than left hanging.
+    """
+    import asyncio
+
+    from decibri import AsyncMicrophone, MicrophoneStreamClosed
+
+    async def _run() -> None:
+        d = AsyncMicrophone(sample_rate=16000, channels=1, frames_per_buffer=65536)
+        await d.start()
+
+        read_outcome: dict[str, object] = {}
+
+        async def _parked_read() -> None:
+            try:
+                read_outcome["chunk"] = await d.read(timeout_ms=None)
+            except MicrophoneStreamClosed:
+                read_outcome["closed"] = True
+            except BaseException as exc:  # noqa: BLE001
+                read_outcome["error"] = exc
+
+        reader = asyncio.create_task(_parked_read())
+        # Let the reader enter the blocking next_chunk before stopping.
+        await asyncio.sleep(0.05)
+
+        # The fix: stop() returns promptly even while a read is parked.
+        # wait_for raises TimeoutError if stop() deadlocks (the pre-fix bug).
+        await asyncio.wait_for(d.stop(), timeout=1.0)
+
+        # The parked read is woken by the close rather than hanging.
+        await asyncio.wait_for(reader, timeout=1.0)
+        assert "error" not in read_outcome, f"parked read errored: {read_outcome!r}"
+        assert d.is_open is False
+
+    asyncio.run(_run())
 
 
 # ---------------------------------------------------------------------------

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -16,7 +16,7 @@ import decibri
 
 
 def test_package_imports() -> None:
-    assert decibri.__version__ == "0.4.1"
+    assert decibri.__version__ == "0.4.2"
     # The bridges are hidden behind the private _decibri module. They are
     # NOT accessible at decibri.<X> top level (sync or async). The async
     # pair was never accessible at the top level; the sync pair
@@ -72,7 +72,7 @@ def test_version_info_fields() -> None:
     info = _decibri.MicrophoneBridge.version()
     assert info.decibri == "4.3.1"
     assert info.audio_backend == "cpal 0.17"
-    assert info.binding == "0.4.1"
+    assert info.binding == "0.4.2"
 
 
 def test_version_info_is_frozen() -> None:

--- a/bindings/python/tests/test_wheel_smoke.py
+++ b/bindings/python/tests/test_wheel_smoke.py
@@ -29,7 +29,7 @@ def test_import_decibri() -> None:
     """The package imports successfully from the installed wheel."""
     assert decibri is not None
     assert hasattr(decibri, "__version__")
-    assert decibri.__version__ == "0.4.1"
+    assert decibri.__version__ == "0.4.2"
 
 
 def test_construct_decibri_default() -> None:

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -27,7 +27,7 @@ wheels = [
 
 [[package]]
 name = "decibri"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions" },


### PR DESCRIPTION
Python-only patch release. Fixes the two Python stop()/read() concurrency bugs (fix-list items 1 and 10) and adds a cargo-audit ignore for two non-exercised pyo3 advisories.

## Fixes
- fix(python): stop() safely interrupts an in-flight read (items 1 + 10)
- sync stop() from another thread no longer panics on the pyclass borrow
- async stop() no longer deadlocks against a read parked on a silent device
- the bridge now shares the core MicrophoneStream so stop() reaches the core stop() (which wakes next_chunk in ~20ms), mirroring the Node binding
- regression tests cover both paths
- ci: ignore non-exercised pyo3 advisories (RUSTSEC-2026-0176/0177) in .cargo/audit.toml pending the pyo3 0.29 upgrade (tracked in backlog item 17; decibri's binding calls neither vulnerable path, grep-confirmed)

## Scope
- Python only: python 0.4.1 -> 0.4.2. Crate and npm untouched.
- No public API change; internal concurrency only.