### PR TITLE
refactor: contain cpal behind an internal AudioBackend seam

### DIFF
--- a/crates/decibri/Cargo.toml
+++ b/crates/decibri/Cargo.toml
@@ -56,3 +56,10 @@ cpal = { workspace = true, optional = true }
 thiserror = { workspace = true }
 crossbeam-channel = { workspace = true, optional = true }
 ort = { workspace = true, optional = true }
+
+# Auto-discovered example targets that use a feature-gated module must declare
+# the feature they need, so cargo skips them when that feature is off instead of
+# failing to compile. `bench_vad` uses `decibri::vad`.
+[[example]]
+name = "bench_vad"
+required-features = ["vad"]

--- a/crates/decibri/src/backend.rs
+++ b/crates/decibri/src/backend.rs
@@ -1,0 +1,535 @@
+//! Internal audio-backend seam.
+//!
+//! [`AudioBackend`] is the single place the crate reaches the platform audio
+//! library. Device enumeration, selector resolution, and stream opening all go
+//! through this trait, and [`CpalBackend`] is its sole implementation: the only
+//! code in the crate that names a platform-audio (cpal) type. Containing the
+//! platform library behind one trait keeps a backend version change a
+//! single-file, single-implementation swap, and keeps the rest of the crate in
+//! decibri-owned types ([`DecibriError`], [`DeviceSelector`], [`MicrophoneInfo`],
+//! [`SpeakerInfo`], and the small support types defined below).
+
+use std::sync::Mutex;
+
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+
+use crate::device::{compute_is_default, ComputedRow, DeviceSelector, MicrophoneInfo, SpeakerInfo};
+use crate::error::DecibriError;
+
+// ── Decibri-owned support types ────────────────────────────────────────────
+
+/// A resolved platform audio device: an opaque, decibri-owned handle around the
+/// backend's native device so the platform type does not cross the seam.
+pub(crate) struct BackendDevice {
+    inner: cpal::Device,
+}
+
+/// A live platform audio stream, owned so that dropping it (on
+/// [`stop`](Self::stop) or on drop) releases the OS device.
+///
+/// The native stream is held behind a `Mutex<Option<...>>` so
+/// [`stop`](Self::stop) can take and drop it under a shared `&self` while the
+/// type stays `Send + Sync` (the bindings require `Sync`: a `#[pyclass]` and
+/// `py.detach` both need it). The lock is uncontended: only `stop()` and drop
+/// ever touch it. The `Option` also lets the test seam build a handle with no
+/// real stream.
+pub(crate) struct BackendStream {
+    inner: Mutex<Option<cpal::Stream>>,
+}
+
+impl BackendStream {
+    /// Drop the held stream now, releasing the OS device, rather than only on
+    /// drop. Idempotent and poison-tolerant: a poisoned lock still clears the
+    /// slot rather than panicking.
+    pub(crate) fn stop(&self) {
+        if let Ok(mut guard) = self.inner.lock() {
+            *guard = None;
+        }
+    }
+
+    /// Whether the stream is still held (not yet dropped by [`stop`](Self::stop)).
+    #[cfg(test)]
+    pub(crate) fn is_active(&self) -> bool {
+        self.inner.lock().map(|g| g.is_some()).unwrap_or(false)
+    }
+
+    /// A handle holding no native stream, for unit tests that exercise the
+    /// stream-reading paths without opening a real device.
+    #[cfg(test)]
+    pub(crate) fn empty() -> Self {
+        Self {
+            inner: Mutex::new(None),
+        }
+    }
+}
+
+/// Parameters for opening a stream: the decibri-owned mirror of the fields the
+/// open path sets on the platform stream config.
+pub(crate) struct StreamParams {
+    pub channels: u16,
+    pub sample_rate: u32,
+    /// Fixed buffer size in frames, or `None` for the backend default. Capture
+    /// pins a fixed size; playback uses the backend default.
+    pub frames_per_buffer: Option<u32>,
+}
+
+/// Realtime capture callback: invoked with one interleaved `f32` input buffer.
+#[cfg(feature = "capture")]
+pub(crate) type InputDataCallback = Box<dyn FnMut(&[f32]) + Send + 'static>;
+
+/// Realtime render callback: invoked to fill one interleaved `f32` output buffer.
+#[cfg(feature = "playback")]
+pub(crate) type OutputDataCallback = Box<dyn FnMut(&mut [f32]) + Send + 'static>;
+
+/// Stream error callback: invoked with a typed [`DecibriError::DeviceFailed`]
+/// when the device or driver fails while streaming.
+pub(crate) type StreamErrorCallback = Box<dyn FnMut(DecibriError) + Send + 'static>;
+
+// ── The seam ───────────────────────────────────────────────────────────────
+
+/// The crate's audio-backend seam. The implementor owns every interaction with
+/// the platform audio library; callers see only decibri-owned types.
+pub(crate) trait AudioBackend: Send + Sync {
+    /// List the available input devices.
+    fn input_devices(&self) -> Result<Vec<MicrophoneInfo>, DecibriError>;
+
+    /// List the available output devices.
+    fn output_devices(&self) -> Result<Vec<SpeakerInfo>, DecibriError>;
+
+    /// Resolve a selector to an input device handle.
+    #[cfg(feature = "capture")]
+    fn resolve_input_device(
+        &self,
+        selector: &DeviceSelector,
+    ) -> Result<BackendDevice, DecibriError>;
+
+    /// Resolve a selector to an output device handle.
+    #[cfg(feature = "playback")]
+    fn resolve_output_device(
+        &self,
+        selector: &DeviceSelector,
+    ) -> Result<BackendDevice, DecibriError>;
+
+    /// Open and start an input stream on `device`, driving `on_data` with each
+    /// captured buffer and `on_error` with a typed device failure.
+    #[cfg(feature = "capture")]
+    fn open_input_stream(
+        &self,
+        device: &BackendDevice,
+        params: &StreamParams,
+        on_data: InputDataCallback,
+        on_error: StreamErrorCallback,
+    ) -> Result<BackendStream, DecibriError>;
+
+    /// Open and start an output stream on `device`, driving `on_data` to fill
+    /// each playback buffer and `on_error` with a typed device failure.
+    #[cfg(feature = "playback")]
+    fn open_output_stream(
+        &self,
+        device: &BackendDevice,
+        params: &StreamParams,
+        on_data: OutputDataCallback,
+        on_error: StreamErrorCallback,
+    ) -> Result<BackendStream, DecibriError>;
+}
+
+/// The cpal-backed [`AudioBackend`]: the crate's sole backend implementation and
+/// the only place a cpal type is named.
+pub(crate) struct CpalBackend;
+
+impl AudioBackend for CpalBackend {
+    fn input_devices(&self) -> Result<Vec<MicrophoneInfo>, DecibriError> {
+        enumerate_devices::<Input>()
+    }
+
+    fn output_devices(&self) -> Result<Vec<SpeakerInfo>, DecibriError> {
+        enumerate_devices::<Output>()
+    }
+
+    #[cfg(feature = "capture")]
+    fn resolve_input_device(
+        &self,
+        selector: &DeviceSelector,
+    ) -> Result<BackendDevice, DecibriError> {
+        Ok(BackendDevice {
+            inner: resolve_device_generic::<Input>(selector)?,
+        })
+    }
+
+    #[cfg(feature = "playback")]
+    fn resolve_output_device(
+        &self,
+        selector: &DeviceSelector,
+    ) -> Result<BackendDevice, DecibriError> {
+        Ok(BackendDevice {
+            inner: resolve_device_generic::<Output>(selector)?,
+        })
+    }
+
+    #[cfg(feature = "capture")]
+    fn open_input_stream(
+        &self,
+        device: &BackendDevice,
+        params: &StreamParams,
+        mut on_data: InputDataCallback,
+        mut on_error: StreamErrorCallback,
+    ) -> Result<BackendStream, DecibriError> {
+        let stream = device
+            .inner
+            .build_input_stream(
+                &stream_config(params),
+                move |data: &[f32], _: &cpal::InputCallbackInfo| {
+                    on_data(data);
+                },
+                move |err| {
+                    // Convert the platform error to the typed cause at the
+                    // boundary, exactly as before; the decibri callback records
+                    // it and marks the stream closed.
+                    on_error(DecibriError::DeviceFailed {
+                        source: Box::new(err),
+                    });
+                },
+                None,
+            )
+            .map_err(|e| DecibriError::StreamOpenFailed(e.to_string()))?;
+
+        stream
+            .play()
+            .map_err(|e| DecibriError::StreamStartFailed(e.to_string()))?;
+
+        Ok(BackendStream {
+            inner: Mutex::new(Some(stream)),
+        })
+    }
+
+    #[cfg(feature = "playback")]
+    fn open_output_stream(
+        &self,
+        device: &BackendDevice,
+        params: &StreamParams,
+        mut on_data: OutputDataCallback,
+        mut on_error: StreamErrorCallback,
+    ) -> Result<BackendStream, DecibriError> {
+        let stream = device
+            .inner
+            .build_output_stream(
+                &stream_config(params),
+                move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
+                    on_data(data);
+                },
+                move |err| {
+                    on_error(DecibriError::DeviceFailed {
+                        source: Box::new(err),
+                    });
+                },
+                None,
+            )
+            .map_err(|e| DecibriError::StreamOpenFailed(e.to_string()))?;
+
+        stream
+            .play()
+            .map_err(|e| DecibriError::StreamStartFailed(e.to_string()))?;
+
+        Ok(BackendStream {
+            inner: Mutex::new(Some(stream)),
+        })
+    }
+}
+
+/// Build a cpal stream config from decibri-owned [`StreamParams`].
+fn stream_config(params: &StreamParams) -> cpal::StreamConfig {
+    cpal::StreamConfig {
+        channels: params.channels,
+        sample_rate: params.sample_rate,
+        buffer_size: match params.frames_per_buffer {
+            Some(frames) => cpal::BufferSize::Fixed(frames),
+            None => cpal::BufferSize::Default,
+        },
+    }
+}
+
+// ── cpal device enumeration and resolution ─────────────────────────────────
+//
+// Direction-generic over the input vs output differences in cpal's enumeration
+// and resolution APIs, so one implementation of `enumerate_devices` and
+// `resolve_device_generic` covers both. The pure `is_default` matching and the
+// `ComputedRow` row type are cpal-free and live in `crate::device`.
+
+/// Internal trait abstracting the input vs output differences in cpal's device
+/// enumeration and resolution APIs. Each `impl` is a small table of function
+/// pointers into cpal.
+trait DeviceDirection {
+    type Info;
+
+    fn default_device(host: &cpal::Host) -> Option<cpal::Device>;
+    fn list_devices(host: &cpal::Host) -> Result<Vec<cpal::Device>, DecibriError>;
+    /// Returns `(channels, sample_rate)`; `(0, 0)` on config failure (matches
+    /// the historical behaviour of surfacing an "unknown" device rather than
+    /// propagating the error).
+    fn default_config(device: &cpal::Device) -> (u16, u32);
+    fn build_info(row: ComputedRow) -> Self::Info;
+    fn no_device_error() -> DecibriError;
+    /// Direction-specific "not found" error for a `Name` / `Id` lookup miss.
+    /// Input returns [`DecibriError::MicrophoneNotFound`]; Output returns
+    /// [`DecibriError::SpeakerNotFound`].
+    fn not_found_error(query: String) -> DecibriError;
+}
+
+struct Input;
+
+struct Output;
+
+impl DeviceDirection for Input {
+    type Info = MicrophoneInfo;
+
+    fn default_device(host: &cpal::Host) -> Option<cpal::Device> {
+        host.default_input_device()
+    }
+
+    fn list_devices(host: &cpal::Host) -> Result<Vec<cpal::Device>, DecibriError> {
+        host.input_devices()
+            .map(|it| it.collect())
+            .map_err(|e| DecibriError::DeviceEnumerationFailed(e.to_string()))
+    }
+
+    fn default_config(device: &cpal::Device) -> (u16, u32) {
+        match device.default_input_config() {
+            Ok(config) => (config.channels(), config.sample_rate()),
+            Err(_) => (0, 0),
+        }
+    }
+
+    fn build_info(row: ComputedRow) -> Self::Info {
+        MicrophoneInfo {
+            index: row.index,
+            name: row.name,
+            id: row.id,
+            max_input_channels: row.channels,
+            default_sample_rate: row.sample_rate,
+            is_default: row.is_default,
+        }
+    }
+
+    fn no_device_error() -> DecibriError {
+        DecibriError::NoMicrophoneFound
+    }
+
+    fn not_found_error(query: String) -> DecibriError {
+        DecibriError::MicrophoneNotFound(query)
+    }
+}
+
+impl DeviceDirection for Output {
+    type Info = SpeakerInfo;
+
+    fn default_device(host: &cpal::Host) -> Option<cpal::Device> {
+        host.default_output_device()
+    }
+
+    fn list_devices(host: &cpal::Host) -> Result<Vec<cpal::Device>, DecibriError> {
+        host.output_devices()
+            .map(|it| it.collect())
+            .map_err(|e| DecibriError::DeviceEnumerationFailed(e.to_string()))
+    }
+
+    fn default_config(device: &cpal::Device) -> (u16, u32) {
+        match device.default_output_config() {
+            Ok(config) => (config.channels(), config.sample_rate()),
+            Err(_) => (0, 0),
+        }
+    }
+
+    fn build_info(row: ComputedRow) -> Self::Info {
+        SpeakerInfo {
+            index: row.index,
+            name: row.name,
+            id: row.id,
+            max_output_channels: row.channels,
+            default_sample_rate: row.sample_rate,
+            is_default: row.is_default,
+        }
+    }
+
+    fn no_device_error() -> DecibriError {
+        DecibriError::NoSpeakerFound
+    }
+
+    fn not_found_error(query: String) -> DecibriError {
+        DecibriError::SpeakerNotFound(query)
+    }
+}
+
+/// Shared implementation behind [`AudioBackend::input_devices`] /
+/// [`AudioBackend::output_devices`]. Direction-generic via [`DeviceDirection`].
+fn enumerate_devices<D: DeviceDirection>() -> Result<Vec<D::Info>, DecibriError> {
+    let host = cpal::default_host();
+
+    // Stable per-host id (WASAPI endpoint ID / CoreAudio UID / ALSA pcm_id)
+    // for the OS default device. `.id()` is fallible on rare host backends;
+    // treat a failure as "no default" rather than propagating.
+    let default_id = D::default_device(&host).and_then(|d| d.id().ok());
+
+    let devices = D::list_devices(&host)?;
+
+    let rows: Vec<(Option<cpal::DeviceId>, String, u16, u32)> = devices
+        .into_iter()
+        .enumerate()
+        .map(|(index, device)| {
+            let id = device.id().ok();
+            let name = device
+                .description()
+                .map(|d| d.name().to_string())
+                .unwrap_or_else(|_| format!("Unknown Device {index}"));
+            let (channels, sample_rate) = D::default_config(&device);
+            (id, name, channels, sample_rate)
+        })
+        .collect();
+
+    Ok(compute_is_default(rows, default_id)
+        .into_iter()
+        .map(D::build_info)
+        .collect())
+}
+
+/// Shared implementation behind [`AudioBackend::resolve_input_device`] /
+/// [`AudioBackend::resolve_output_device`]. Direction-generic via
+/// [`DeviceDirection`].
+fn resolve_device_generic<D: DeviceDirection>(
+    selector: &DeviceSelector,
+) -> Result<cpal::Device, DecibriError> {
+    let host = cpal::default_host();
+
+    match selector {
+        DeviceSelector::Default => D::default_device(&host).ok_or_else(D::no_device_error),
+
+        DeviceSelector::Index(idx) => D::list_devices(&host)?
+            .into_iter()
+            .nth(*idx)
+            .ok_or(DecibriError::DeviceIndexOutOfRange),
+
+        DeviceSelector::Name(query) => {
+            let query_lower = query.to_lowercase();
+            let devices = D::list_devices(&host)?;
+
+            let mut matches: Vec<(usize, String, cpal::Device)> = Vec::new();
+            for (index, device) in devices.into_iter().enumerate() {
+                let name = device
+                    .description()
+                    .map(|d| d.name().to_string())
+                    .unwrap_or_default();
+                if name.to_lowercase().contains(&query_lower) {
+                    matches.push((index, name, device));
+                }
+            }
+
+            match matches.len() {
+                0 => Err(D::not_found_error(query.clone())),
+                1 => Ok(matches.into_iter().next().unwrap().2),
+                _ => {
+                    let match_list = matches
+                        .iter()
+                        .map(|(idx, name, _)| format!("  [{idx}] {name}"))
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    Err(DecibriError::MultipleDevicesMatch {
+                        name: query.clone(),
+                        matches: format!(
+                            "{match_list}\nUse a more specific name or pass the device index directly."
+                        ),
+                    })
+                }
+            }
+        }
+
+        DeviceSelector::Id(query) => {
+            // Exact match on cpal::DeviceId's `Display` representation. Device
+            // IDs are unique per host, so at most one device matches. A device
+            // whose `id()` call fails (rare) is silently skipped; the scenario
+            // is treated as "not found", matching `enumerate_devices`, which
+            // assigns such a device an empty `id` string that no query matches.
+            let devices = D::list_devices(&host)?;
+            for device in devices {
+                if let Ok(id) = device.id() {
+                    if id.to_string() == *query {
+                        return Ok(device);
+                    }
+                }
+            }
+            Err(D::not_found_error(query.clone()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The cpal backend satisfies the [`AudioBackend`] seam contract, including
+    /// its `Send + Sync` supertrait bound (the bindings depend on it).
+    #[test]
+    fn cpal_backend_satisfies_the_seam() {
+        fn assert_backend<T: AudioBackend>() {}
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_backend::<CpalBackend>();
+        assert_send_sync::<CpalBackend>();
+    }
+
+    /// The stream handle is `Send + Sync` so the stream types that hold it stay
+    /// `Send + Sync` (the bindings require `Sync`).
+    #[test]
+    fn backend_stream_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<BackendStream>();
+    }
+
+    /// `stop()` drops the held stream and is idempotent. The test seam holds no
+    /// real device, so this asserts the slot is empty after stop and that a
+    /// second stop does not panic; the real `Some -> None` drop (device release)
+    /// is exercised by the binding suites and integration capture/playback.
+    #[test]
+    fn backend_stream_stop_empties_and_is_idempotent() {
+        let stream = BackendStream::empty();
+        assert!(!stream.is_active(), "an empty handle holds no stream");
+        stream.stop();
+        assert!(!stream.is_active(), "stop() leaves the slot empty");
+        stream.stop(); // idempotent: an already-empty slot must not panic
+    }
+
+    /// Enumeration through the seam reaches cpal and returns without panicking
+    /// on any host, including headless CI runners with no audio devices (the
+    /// result may be an empty list or an enumeration error, both acceptable).
+    #[test]
+    fn backend_enumeration_runs() {
+        let _ = CpalBackend.input_devices();
+        let _ = CpalBackend.output_devices();
+    }
+
+    /// The direction-specific `not_found_error` produces the correct
+    /// `DecibriError` variant and display string for each direction: input
+    /// lookups return `MicrophoneNotFound`, output lookups `SpeakerNotFound`.
+    #[test]
+    fn not_found_error_produces_direction_correct_variant() {
+        let input_err = Input::not_found_error("nonexistent-input".to_string());
+        let output_err = Output::not_found_error("nonexistent-output".to_string());
+
+        assert!(
+            matches!(input_err, DecibriError::MicrophoneNotFound(ref s) if s == "nonexistent-input"),
+            "Input direction must return DecibriError::MicrophoneNotFound"
+        );
+        assert!(
+            matches!(output_err, DecibriError::SpeakerNotFound(ref s) if s == "nonexistent-output"),
+            "Output direction must return DecibriError::SpeakerNotFound"
+        );
+
+        assert_eq!(
+            input_err.to_string(),
+            "No microphone found matching \"nonexistent-input\"",
+            "Input variant's Display must name the microphone"
+        );
+        assert_eq!(
+            output_err.to_string(),
+            "No speaker found matching \"nonexistent-output\"",
+            "Output variant's Display must name the speaker"
+        );
+    }
+}

--- a/crates/decibri/src/device.rs
+++ b/crates/decibri/src/device.rs
@@ -5,9 +5,10 @@
 //! one by system default, index, case-insensitive name substring, or stable
 //! per-host id, and is the value [`crate::MicrophoneConfig`] and
 //! [`crate::SpeakerConfig`] carry in their `device` field.
-
-#[cfg(any(feature = "capture", feature = "playback"))]
-use cpal::traits::{DeviceTrait, HostTrait};
+//!
+//! The platform enumeration and resolution themselves run behind
+//! [`crate::backend::AudioBackend`]; this module owns the public device types
+//! and the pure `is_default` matching, and routes listing through the seam.
 
 use crate::error::DecibriError;
 
@@ -89,19 +90,19 @@ pub enum DeviceSelector {
 }
 
 /// Internal: enumerated device row with `is_default` already resolved.
-/// Used as the output of the pure `compute_is_default` helper so both input
+/// Used as the output of the pure [`compute_is_default`] helper so both input
 /// and output enumeration can share the same device-identity matching logic
-/// (and so the logic is testable without mocking `cpal::Host`).
+/// (and so the logic is testable without mocking the host).
 #[cfg(any(feature = "capture", feature = "playback"))]
-struct ComputedRow {
-    index: usize,
-    name: String,
+pub(crate) struct ComputedRow {
+    pub(crate) index: usize,
+    pub(crate) name: String,
     /// Stable per-host device ID as a string, or empty if the device has no
-    /// cpal-assignable ID. Forwarded to `MicrophoneInfo.id` / `SpeakerInfo.id`.
-    id: String,
-    channels: u16,
-    sample_rate: u32,
-    is_default: bool,
+    /// host-assignable ID. Forwarded to `MicrophoneInfo.id` / `SpeakerInfo.id`.
+    pub(crate) id: String,
+    pub(crate) channels: u16,
+    pub(crate) sample_rate: u32,
+    pub(crate) is_default: bool,
 }
 
 /// Pure helper for Issue #14 fix.
@@ -112,7 +113,7 @@ struct ComputedRow {
 /// (NOT by name-equality. See [#14](https://github.com/decibri/decibri/issues/14) for context.)
 ///
 /// Semantics:
-/// - A row's `id` of `None` (caller couldn't fetch a cpal `DeviceId` for that
+/// - A row's `id` of `None` (caller couldn't fetch a host `DeviceId` for that
 ///   device) is treated as "not default".
 /// - A `default_id` of `None` (no default device reported by the host) means
 ///   no row is flagged default.
@@ -121,9 +122,9 @@ struct ComputedRow {
 ///   row matches even when multiple devices share a display name.
 ///
 /// Generic over `Id: PartialEq` so unit tests can use `String` ids and verify
-/// the matching logic without depending on a live cpal host.
+/// the matching logic without depending on a live host.
 #[cfg(any(feature = "capture", feature = "playback"))]
-fn compute_is_default<Id: PartialEq + ToString>(
+pub(crate) fn compute_is_default<Id: PartialEq + ToString>(
     rows: Vec<(Option<Id>, String, u16, u32)>,
     default_id: Option<Id>,
 ) -> Vec<ComputedRow> {
@@ -151,230 +152,13 @@ fn compute_is_default<Id: PartialEq + ToString>(
         .collect()
 }
 
-/// Internal trait abstracting the input vs output differences in cpal's
-/// device enumeration and resolution APIs. Allows one generic implementation
-/// of `enumerate_devices` and `resolve_device` to cover both directions.
-///
-/// Not part of the public API; lives here only to deduplicate the per-direction
-/// code paths. Each `impl` is a small table of function pointers into cpal.
-#[cfg(any(feature = "capture", feature = "playback"))]
-trait DeviceDirection {
-    type Info;
-
-    fn default_device(host: &cpal::Host) -> Option<cpal::Device>;
-    fn list_devices(host: &cpal::Host) -> Result<Vec<cpal::Device>, DecibriError>;
-    /// Returns `(channels, sample_rate)`; `(0, 0)` on config failure (matches
-    /// the pre-consolidation behaviour of surfacing an "unknown" device
-    /// rather than propagating the error).
-    fn default_config(device: &cpal::Device) -> (u16, u32);
-    fn build_info(row: ComputedRow) -> Self::Info;
-    fn no_device_error() -> DecibriError;
-    /// Direction-specific "not found" error for a `Name` / `Id` lookup miss.
-    /// Input returns [`DecibriError::MicrophoneNotFound`]; Output returns
-    /// [`DecibriError::SpeakerNotFound`]. Keeping this on the trait
-    /// avoids hardcoding the input-oriented variant in the shared
-    /// `resolve_device_generic` body.
-    fn not_found_error(query: String) -> DecibriError;
-}
-
-#[cfg(any(feature = "capture", feature = "playback"))]
-struct Input;
-
-#[cfg(any(feature = "capture", feature = "playback"))]
-struct Output;
-
-#[cfg(any(feature = "capture", feature = "playback"))]
-impl DeviceDirection for Input {
-    type Info = MicrophoneInfo;
-
-    fn default_device(host: &cpal::Host) -> Option<cpal::Device> {
-        host.default_input_device()
-    }
-
-    fn list_devices(host: &cpal::Host) -> Result<Vec<cpal::Device>, DecibriError> {
-        host.input_devices()
-            .map(|it| it.collect())
-            .map_err(|e| DecibriError::DeviceEnumerationFailed(e.to_string()))
-    }
-
-    fn default_config(device: &cpal::Device) -> (u16, u32) {
-        match device.default_input_config() {
-            Ok(config) => (config.channels(), config.sample_rate()),
-            Err(_) => (0, 0),
-        }
-    }
-
-    fn build_info(row: ComputedRow) -> Self::Info {
-        MicrophoneInfo {
-            index: row.index,
-            name: row.name,
-            id: row.id,
-            max_input_channels: row.channels,
-            default_sample_rate: row.sample_rate,
-            is_default: row.is_default,
-        }
-    }
-
-    fn no_device_error() -> DecibriError {
-        DecibriError::NoMicrophoneFound
-    }
-
-    fn not_found_error(query: String) -> DecibriError {
-        DecibriError::MicrophoneNotFound(query)
-    }
-}
-
-#[cfg(any(feature = "capture", feature = "playback"))]
-impl DeviceDirection for Output {
-    type Info = SpeakerInfo;
-
-    fn default_device(host: &cpal::Host) -> Option<cpal::Device> {
-        host.default_output_device()
-    }
-
-    fn list_devices(host: &cpal::Host) -> Result<Vec<cpal::Device>, DecibriError> {
-        host.output_devices()
-            .map(|it| it.collect())
-            .map_err(|e| DecibriError::DeviceEnumerationFailed(e.to_string()))
-    }
-
-    fn default_config(device: &cpal::Device) -> (u16, u32) {
-        match device.default_output_config() {
-            Ok(config) => (config.channels(), config.sample_rate()),
-            Err(_) => (0, 0),
-        }
-    }
-
-    fn build_info(row: ComputedRow) -> Self::Info {
-        SpeakerInfo {
-            index: row.index,
-            name: row.name,
-            id: row.id,
-            max_output_channels: row.channels,
-            default_sample_rate: row.sample_rate,
-            is_default: row.is_default,
-        }
-    }
-
-    fn no_device_error() -> DecibriError {
-        DecibriError::NoSpeakerFound
-    }
-
-    fn not_found_error(query: String) -> DecibriError {
-        DecibriError::SpeakerNotFound(query)
-    }
-}
-
-/// Shared implementation for `input_devices` / `output_devices`.
-/// Direction-generic via the `DeviceDirection` trait.
-#[cfg(any(feature = "capture", feature = "playback"))]
-fn enumerate_devices<D: DeviceDirection>() -> Result<Vec<D::Info>, DecibriError> {
-    let host = cpal::default_host();
-
-    // Stable per-host id (WASAPI endpoint ID / CoreAudio UID / ALSA pcm_id)
-    // for the OS default device. `.id()` is fallible on rare host backends;
-    // treat a failure as "no default" rather than propagating.
-    let default_id = D::default_device(&host).and_then(|d| d.id().ok());
-
-    let devices = D::list_devices(&host)?;
-
-    let rows: Vec<(Option<cpal::DeviceId>, String, u16, u32)> = devices
-        .into_iter()
-        .enumerate()
-        .map(|(index, device)| {
-            let id = device.id().ok();
-            let name = device
-                .description()
-                .map(|d| d.name().to_string())
-                .unwrap_or_else(|_| format!("Unknown Device {index}"));
-            let (channels, sample_rate) = D::default_config(&device);
-            (id, name, channels, sample_rate)
-        })
-        .collect();
-
-    Ok(compute_is_default(rows, default_id)
-        .into_iter()
-        .map(D::build_info)
-        .collect())
-}
-
-/// Shared implementation for `resolve_device` / `resolve_output_device`.
-#[cfg(any(feature = "capture", feature = "playback"))]
-fn resolve_device_generic<D: DeviceDirection>(
-    selector: &DeviceSelector,
-) -> Result<cpal::Device, DecibriError> {
-    let host = cpal::default_host();
-
-    match selector {
-        DeviceSelector::Default => D::default_device(&host).ok_or_else(D::no_device_error),
-
-        DeviceSelector::Index(idx) => D::list_devices(&host)?
-            .into_iter()
-            .nth(*idx)
-            .ok_or(DecibriError::DeviceIndexOutOfRange),
-
-        DeviceSelector::Name(query) => {
-            let query_lower = query.to_lowercase();
-            let devices = D::list_devices(&host)?;
-
-            let mut matches: Vec<(usize, String, cpal::Device)> = Vec::new();
-            for (index, device) in devices.into_iter().enumerate() {
-                let name = device
-                    .description()
-                    .map(|d| d.name().to_string())
-                    .unwrap_or_default();
-                if name.to_lowercase().contains(&query_lower) {
-                    matches.push((index, name, device));
-                }
-            }
-
-            match matches.len() {
-                0 => Err(D::not_found_error(query.clone())),
-                1 => Ok(matches.into_iter().next().unwrap().2),
-                _ => {
-                    let match_list = matches
-                        .iter()
-                        .map(|(idx, name, _)| format!("  [{idx}] {name}"))
-                        .collect::<Vec<_>>()
-                        .join("\n");
-                    Err(DecibriError::MultipleDevicesMatch {
-                        name: query.clone(),
-                        matches: format!(
-                            "{match_list}\nUse a more specific name or pass the device index directly."
-                        ),
-                    })
-                }
-            }
-        }
-
-        DeviceSelector::Id(query) => {
-            // Exact match on cpal::DeviceId's `Display` representation.
-            // Device IDs are unique per host, so at most one device matches.
-            // A device whose `id()` call fails (rare; some hosts cannot
-            // produce a stable id for every enumerated device) is silently
-            // skipped; the scenario is treated as "not found" rather than
-            // surfacing a cpal-level error. This matches `enumerate_devices`,
-            // which assigns such a device an empty `id` string that no query
-            // can match.
-            let devices = D::list_devices(&host)?;
-            for device in devices {
-                if let Ok(id) = device.id() {
-                    if id.to_string() == *query {
-                        return Ok(device);
-                    }
-                }
-            }
-            Err(D::not_found_error(query.clone()))
-        }
-    }
-}
-
 /// List the available microphone (input) devices.
 ///
 /// Also available as [`Microphone::devices`](crate::Microphone::devices).
 #[cfg(any(feature = "capture", feature = "playback"))]
 pub fn input_devices() -> Result<Vec<MicrophoneInfo>, DecibriError> {
-    enumerate_devices::<Input>()
+    use crate::backend::AudioBackend;
+    crate::backend::CpalBackend.input_devices()
 }
 
 /// List the available speaker (output) devices.
@@ -382,25 +166,8 @@ pub fn input_devices() -> Result<Vec<MicrophoneInfo>, DecibriError> {
 /// Also available as [`Speaker::devices`](crate::Speaker::devices).
 #[cfg(any(feature = "capture", feature = "playback"))]
 pub fn output_devices() -> Result<Vec<SpeakerInfo>, DecibriError> {
-    enumerate_devices::<Output>()
-}
-
-/// Resolve a device selector to a cpal input device.
-///
-/// Crate-internal device resolution for [`crate::Microphone`].
-#[cfg(feature = "capture")]
-pub(crate) fn resolve_device(selector: &DeviceSelector) -> Result<cpal::Device, DecibriError> {
-    resolve_device_generic::<Input>(selector)
-}
-
-/// Resolve a device selector to a cpal output device.
-///
-/// Crate-internal device resolution for [`crate::Speaker`].
-#[cfg(feature = "playback")]
-pub(crate) fn resolve_output_device(
-    selector: &DeviceSelector,
-) -> Result<cpal::Device, DecibriError> {
-    resolve_device_generic::<Output>(selector)
+    use crate::backend::AudioBackend;
+    crate::backend::CpalBackend.output_devices()
 }
 
 #[cfg(all(test, any(feature = "capture", feature = "playback")))]
@@ -409,7 +176,7 @@ mod tests {
 
     // Synthetic id type for testing. Any `PartialEq` works because
     // `compute_is_default` is generic over the id type. Using String keeps the
-    // tests readable and avoids any dependency on a live cpal host.
+    // tests readable and avoids any dependency on a live host.
     fn row(id: Option<&str>, name: &str) -> (Option<String>, String, u16, u32) {
         (id.map(String::from), name.to_string(), 2, 48_000)
     }
@@ -506,37 +273,6 @@ mod tests {
         assert_eq!(
             result[1].id, "",
             "None id must map to an empty string so the device is unreachable via DeviceSelector::Id"
-        );
-    }
-
-    /// Verifies that the direction-specific `not_found_error` trait method
-    /// produces the correct `DecibriError` variant and display string for
-    /// each direction. Input lookups return `MicrophoneNotFound` and name the
-    /// microphone in the message; output lookups return `SpeakerNotFound` and
-    /// name the speaker.
-    #[test]
-    fn test_not_found_error_produces_direction_correct_variant() {
-        let input_err = Input::not_found_error("nonexistent-input".to_string());
-        let output_err = Output::not_found_error("nonexistent-output".to_string());
-
-        assert!(
-            matches!(input_err, DecibriError::MicrophoneNotFound(ref s) if s == "nonexistent-input"),
-            "Input direction must return DecibriError::MicrophoneNotFound"
-        );
-        assert!(
-            matches!(output_err, DecibriError::SpeakerNotFound(ref s) if s == "nonexistent-output"),
-            "Output direction must return DecibriError::SpeakerNotFound"
-        );
-
-        assert_eq!(
-            input_err.to_string(),
-            "No microphone found matching \"nonexistent-input\"",
-            "Input variant's Display must name the microphone"
-        );
-        assert_eq!(
-            output_err.to_string(),
-            "No speaker found matching \"nonexistent-output\"",
-            "Output variant's Display must name the speaker"
         );
     }
 }

--- a/crates/decibri/src/lib.rs
+++ b/crates/decibri/src/lib.rs
@@ -200,6 +200,11 @@ pub const CPAL_VERSION: &str = env!("DECIBRI_CPAL_VERSION");
 #[cfg(any(feature = "capture", feature = "playback"))]
 pub mod device;
 
+// Internal audio-backend seam: the one place the crate reaches the platform
+// audio library. Not part of the public API.
+#[cfg(any(feature = "capture", feature = "playback"))]
+mod backend;
+
 #[cfg(feature = "capture")]
 pub mod microphone;
 

--- a/crates/decibri/src/microphone.rs
+++ b/crates/decibri/src/microphone.rs
@@ -14,10 +14,13 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 #[cfg(feature = "capture")]
-use cpal::traits::{DeviceTrait, StreamTrait};
-#[cfg(feature = "capture")]
 use crossbeam_channel::{Receiver, RecvTimeoutError, Sender, TryRecvError, TrySendError};
 
+#[cfg(feature = "capture")]
+use crate::backend::{
+    AudioBackend, BackendDevice, BackendStream, CpalBackend, InputDataCallback,
+    StreamErrorCallback, StreamParams,
+};
 use crate::device::DeviceSelector;
 use crate::error::DecibriError;
 
@@ -106,20 +109,16 @@ const CAPTURE_CHANNEL_CAPACITY: usize = 64;
 /// handle also releases it. The type is `Send + Sync`.
 #[cfg(feature = "capture")]
 pub struct MicrophoneStream {
-    /// Holds the cpal stream alive for the lifetime of this handle.
+    /// Owns the platform audio stream for the lifetime of this handle.
     ///
-    /// `Mutex<Option<...>>` (not `Cell`/`RefCell`) so [`stop`](Self::stop) can
-    /// `take()` and drop the stream under `&self`, releasing the device, while
-    /// keeping this type `Send + Sync`. The Python binding requires `Sync`: its
-    /// `#[pyclass]` (`assert_pyclass_send_sync`) and `py.detach` both need the
-    /// stream type to be `Sync`, and `cpal::Stream` is itself `Send + Sync` on
-    /// every backend. `Cell`/`RefCell` are `!Sync` and would break
-    /// `decibri-python`. The lock is uncontended: only `stop()` and `drop` ever
-    /// touch this field; the cpal callback owns the channel sender, not this.
-    /// The `Option` also lets the test-only `tests::test_stream()` helper build
-    /// a handle with no real device (`Mutex::new(None)`); production stores
-    /// `Mutex::new(Some(stream))`.
-    _stream: Mutex<Option<cpal::Stream>>,
+    /// Held behind [`BackendStream`](crate::backend::BackendStream), which keeps
+    /// the stream behind a `Mutex<Option<...>>` so [`stop`](Self::stop) can drop
+    /// it under `&self` to release the device while this type stays
+    /// `Send + Sync` (the bindings require `Sync` for their `#[pyclass]` and
+    /// `py.detach`). Dropping this field also releases the device. The test-only
+    /// `tests::test_stream()` helper builds it with `BackendStream::empty()`
+    /// (no real device); production stores the opened stream.
+    _stream: BackendStream,
     receiver: Receiver<AudioChunk>,
     running: Arc<AtomicBool>,
     sample_rate: u32,
@@ -306,9 +305,9 @@ impl MicrophoneStream {
 
     /// Stop capturing audio and release the device.
     ///
-    /// Flips the running flag, then drops the held `cpal::Stream`, so the OS
-    /// releases the input device (and the mic-in-use indicator clears) at once
-    /// rather than only when this handle is dropped. Dropping the stream also
+    /// Flips the running flag, then drops the held stream, so the OS releases
+    /// the input device (and the mic-in-use indicator clears) at once rather
+    /// than only when this handle is dropped. Dropping the stream also
     /// disconnects the capture channel; chunks already buffered remain readable
     /// via [`try_next_chunk`](Self::try_next_chunk) or
     /// [`next_chunk`](Self::next_chunk) until the buffer is drained, after which
@@ -320,12 +319,9 @@ impl MicrophoneStream {
     /// tears down.
     pub fn stop(&self) {
         self.running.store(false, Ordering::Relaxed);
-        // Drop the cpal stream to release the OS device now, not only on drop.
-        // Poison-tolerant: if a teardown elsewhere panicked while holding the
-        // lock, still clear the slot rather than panicking in stop().
-        if let Ok(mut guard) = self._stream.lock() {
-            *guard = None;
-        }
+        // Drop the held stream to release the OS device now, not only on drop.
+        // Poison-tolerant and idempotent (see `BackendStream::stop`).
+        self._stream.stop();
     }
 }
 
@@ -345,7 +341,7 @@ impl MicrophoneStream {
 #[cfg(feature = "capture")]
 pub struct Microphone {
     config: MicrophoneConfig,
-    device: cpal::Device,
+    device: BackendDevice,
 }
 
 #[cfg(feature = "capture")]
@@ -355,7 +351,7 @@ impl Microphone {
     /// for that.
     pub fn new(config: MicrophoneConfig) -> Result<Self, DecibriError> {
         config.validate()?;
-        let device = crate::device::resolve_device(&config.device)?;
+        let device = CpalBackend.resolve_input_device(&config.device)?;
         Ok(Self { config, device })
     }
 
@@ -376,66 +372,56 @@ impl Microphone {
         let channels = self.config.channels;
         let frames_per_buffer = self.config.frames_per_buffer;
 
-        let stream_config = cpal::StreamConfig {
-            channels,
-            sample_rate,
-            buffer_size: cpal::BufferSize::Fixed(frames_per_buffer),
-        };
-
         let err_running = running.clone();
         let last_error = Arc::new(Mutex::new(None));
         let err_last_error = last_error.clone();
         let overruns = Arc::new(AtomicU64::new(0));
         let overruns_cb = overruns.clone();
 
-        let stream = self
-            .device
-            .build_input_stream(
-                &stream_config,
-                move |data: &[f32], _: &cpal::InputCallbackInfo| {
-                    if !running_clone.load(Ordering::Relaxed) {
-                        return;
-                    }
-                    let chunk = AudioChunk {
-                        data: data.to_vec(),
-                        sample_rate,
-                        channels,
-                    };
-                    // Non-blocking send: the cpal callback must never block the
-                    // realtime audio thread. On a full channel (a stalled
-                    // consumer) drop this chunk and count it rather than growing
-                    // memory without bound; a disconnected receiver also just
-                    // discards.
-                    match sender.try_send(chunk) {
-                        Ok(()) => {}
-                        Err(TrySendError::Full(_)) => {
-                            overruns_cb.fetch_add(1, Ordering::Relaxed);
-                        }
-                        Err(TrySendError::Disconnected(_)) => {}
-                    }
-                },
-                move |err| {
-                    // Record a typed cause so a consumer that sees the stream
-                    // close can distinguish a driver failure from stop().
-                    let typed = DecibriError::DeviceFailed {
-                        source: Box::new(err),
-                    };
-                    eprintln!("{typed}");
-                    if let Ok(mut slot) = err_last_error.lock() {
-                        *slot = Some(typed);
-                    }
-                    err_running.store(false, Ordering::Relaxed);
-                },
-                None, // No timeout
-            )
-            .map_err(|e| DecibriError::StreamOpenFailed(e.to_string()))?;
+        // Realtime data callback: capture, copy, non-blocking send. Identical
+        // work as before; the seam wraps only stream construction.
+        let on_data: InputDataCallback = Box::new(move |data: &[f32]| {
+            if !running_clone.load(Ordering::Relaxed) {
+                return;
+            }
+            let chunk = AudioChunk {
+                data: data.to_vec(),
+                sample_rate,
+                channels,
+            };
+            // Non-blocking send: the realtime audio thread must never block. On
+            // a full channel (a stalled consumer) drop this chunk and count it
+            // rather than growing memory without bound; a disconnected receiver
+            // also just discards.
+            match sender.try_send(chunk) {
+                Ok(()) => {}
+                Err(TrySendError::Full(_)) => {
+                    overruns_cb.fetch_add(1, Ordering::Relaxed);
+                }
+                Err(TrySendError::Disconnected(_)) => {}
+            }
+        });
 
-        stream
-            .play()
-            .map_err(|e| DecibriError::StreamStartFailed(e.to_string()))?;
+        // Error callback: record the typed cause and mark the stream closed so a
+        // consumer that sees the stream close can distinguish a driver failure
+        // from stop(). The backend builds the typed `DeviceFailed`.
+        let on_error: StreamErrorCallback = Box::new(move |err: DecibriError| {
+            eprintln!("{err}");
+            if let Ok(mut slot) = err_last_error.lock() {
+                *slot = Some(err);
+            }
+            err_running.store(false, Ordering::Relaxed);
+        });
+
+        let params = StreamParams {
+            channels,
+            sample_rate,
+            frames_per_buffer: Some(frames_per_buffer),
+        };
+        let _stream = CpalBackend.open_input_stream(&self.device, &params, on_data, on_error)?;
 
         Ok(MicrophoneStream {
-            _stream: Mutex::new(Some(stream)),
+            _stream,
             receiver,
             running,
             sample_rate,
@@ -458,7 +444,7 @@ mod tests {
         let (sender, receiver) = crossbeam_channel::unbounded::<AudioChunk>();
         let running = Arc::new(AtomicBool::new(true));
         let stream = MicrophoneStream {
-            _stream: Mutex::new(None),
+            _stream: BackendStream::empty(),
             receiver,
             running: running.clone(),
             sample_rate: 16000,
@@ -671,7 +657,7 @@ mod tests {
         stream.stop();
         assert!(!stream.is_open(), "stop() clears the running flag");
         assert!(
-            stream._stream.lock().unwrap().is_none(),
+            !stream._stream.is_active(),
             "stop() leaves the stream slot empty (device released)"
         );
         stream.stop(); // idempotent: an already-empty slot must not panic

--- a/crates/decibri/src/speaker.rs
+++ b/crates/decibri/src/speaker.rs
@@ -13,10 +13,13 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 #[cfg(feature = "playback")]
-use cpal::traits::{DeviceTrait, StreamTrait};
-#[cfg(feature = "playback")]
 use crossbeam_channel::{Receiver, Sender};
 
+#[cfg(feature = "playback")]
+use crate::backend::{
+    AudioBackend, BackendDevice, BackendStream, CpalBackend, OutputDataCallback,
+    StreamErrorCallback, StreamParams,
+};
 use crate::device::DeviceSelector;
 use crate::error::DecibriError;
 
@@ -188,17 +191,14 @@ fn drain_impl(
 /// `Send + Sync`.
 #[cfg(feature = "playback")]
 pub struct SpeakerStream {
-    // `Mutex<Option<...>>` (not `Cell`/`RefCell`) so `stop(&self)` can `take()`
-    // and drop the stream under `&self`, releasing the device, while keeping
-    // this type `Send + Sync`. The Python binding requires `Sync`: its
-    // `#[pyclass]` (`assert_pyclass_send_sync`) and `py.detach` both need the
-    // stream type to be `Sync`, and `cpal::Stream` is itself `Send + Sync` on
-    // every backend. `Cell`/`RefCell` are `!Sync` and would break
-    // `decibri-python`. The lock is uncontended: only `stop()` and `drop` ever
-    // touch this field; the cpal callback owns the channel receiver, not this.
-    // The `Option` also lets the test seam build a stream with no real device
-    // (`Mutex::new(None)`); production stores `Mutex::new(Some(stream))`.
-    _stream: Mutex<Option<cpal::Stream>>,
+    // Owns the platform audio stream, held behind
+    // [`BackendStream`](crate::backend::BackendStream), which keeps it behind a
+    // `Mutex<Option<...>>` so `stop(&self)` can drop it under `&self` to release
+    // the device while this type stays `Send + Sync` (the bindings require
+    // `Sync` for their `#[pyclass]` and `py.detach`). Dropping this field also
+    // releases the device. The test seam builds it with `BackendStream::empty()`
+    // (no real device); production stores the opened stream.
+    _stream: BackendStream,
     sender: Sender<Vec<f32>>,
     running: Arc<AtomicBool>,
     // Drain handshake. `drain()` reserves the next `sentinel_seq` ticket and
@@ -279,18 +279,15 @@ impl SpeakerStream {
     /// all queued audio is discarded; [`is_playing`](Self::is_playing) is false
     /// immediately and later non-empty [`send`](Self::send) calls (including via
     /// a surviving [`SpeakerSink`]) return [`DecibriError::SpeakerStreamClosed`].
-    /// The held `cpal::Stream` is dropped here, so the OS releases the output
-    /// device on stop rather than only when the handle is dropped; this blocks
-    /// briefly while the audio thread tears down.
+    /// The held stream is dropped here, so the OS releases the output device on
+    /// stop rather than only when the handle is dropped; this blocks briefly
+    /// while the audio thread tears down.
     pub fn stop(&self) {
         // Flag first: a surviving sink's send/drain key off this and short-circuit.
         self.running.store(false, Ordering::Relaxed);
-        // Then drop the cpal stream to release the OS device now, not only on
-        // drop. Poison-tolerant: if a teardown elsewhere panicked while holding
-        // the lock, still clear the slot rather than panicking in stop().
-        if let Ok(mut guard) = self._stream.lock() {
-            *guard = None;
-        }
+        // Then drop the held stream to release the OS device now, not only on
+        // drop. Poison-tolerant and idempotent (see `BackendStream::stop`).
+        self._stream.stop();
     }
 
     /// A cloneable, `Send` handle to this stream's sample channel and drain
@@ -397,7 +394,7 @@ impl SpeakerSink {
 #[cfg(feature = "playback")]
 pub struct Speaker {
     config: SpeakerConfig,
-    device: cpal::Device,
+    device: BackendDevice,
 }
 
 #[cfg(feature = "playback")]
@@ -407,7 +404,7 @@ impl Speaker {
     /// [`start`](Self::start) for that.
     pub fn new(config: SpeakerConfig) -> Result<Self, DecibriError> {
         config.validate()?;
-        let device = crate::device::resolve_output_device(&config.device)?;
+        let device = CpalBackend.resolve_output_device(&config.device)?;
         Ok(Self { config, device })
     }
 
@@ -433,51 +430,42 @@ impl Speaker {
         let sample_rate = self.config.sample_rate;
         let channels = self.config.channels;
 
-        let stream_config = cpal::StreamConfig {
-            channels,
-            sample_rate,
-            buffer_size: cpal::BufferSize::Default,
-        };
-
-        // Internal accumulator for the cpal callback.
-        // cpal requests variable-sized buffers; we feed from the channel.
+        // Internal accumulator for the render callback. The backend requests
+        // variable-sized buffers; we feed from the channel.
         let mut accum: Vec<f32> = Vec::new();
 
-        let stream = self
-            .device
-            .build_output_stream(
-                &stream_config,
-                move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
-                    render_output(
-                        data,
-                        &mut accum,
-                        &receiver,
-                        &running_cb,
-                        &sentinels_played_cb,
-                    );
-                },
-                move |err| {
-                    // Record a typed cause so a consumer that sees the stream
-                    // close can distinguish a driver failure from stop().
-                    let typed = DecibriError::DeviceFailed {
-                        source: Box::new(err),
-                    };
-                    eprintln!("{typed}");
-                    if let Ok(mut slot) = err_last_error.lock() {
-                        *slot = Some(typed);
-                    }
-                    running_clone.store(false, Ordering::Relaxed);
-                },
-                None,
-            )
-            .map_err(|e| DecibriError::StreamOpenFailed(e.to_string()))?;
+        // Realtime render callback: fill the buffer from the playback queue.
+        // Identical work as before; the seam wraps only stream construction.
+        let on_data: OutputDataCallback = Box::new(move |data: &mut [f32]| {
+            render_output(
+                data,
+                &mut accum,
+                &receiver,
+                &running_cb,
+                &sentinels_played_cb,
+            );
+        });
 
-        stream
-            .play()
-            .map_err(|e| DecibriError::StreamStartFailed(e.to_string()))?;
+        // Error callback: record the typed cause and mark the stream stopped so
+        // a consumer that sees the stream close can distinguish a driver failure
+        // from stop(). The backend builds the typed `DeviceFailed`.
+        let on_error: StreamErrorCallback = Box::new(move |err: DecibriError| {
+            eprintln!("{err}");
+            if let Ok(mut slot) = err_last_error.lock() {
+                *slot = Some(err);
+            }
+            running_clone.store(false, Ordering::Relaxed);
+        });
+
+        let params = StreamParams {
+            channels,
+            sample_rate,
+            frames_per_buffer: None,
+        };
+        let _stream = CpalBackend.open_output_stream(&self.device, &params, on_data, on_error)?;
 
         Ok(SpeakerStream {
-            _stream: Mutex::new(Some(stream)),
+            _stream,
             sender,
             running,
             sentinel_seq,
@@ -500,7 +488,7 @@ mod tests {
         let (sender, receiver) = crossbeam_channel::bounded::<Vec<f32>>(32);
         let sentinels_played = Arc::new(AtomicUsize::new(0));
         let stream = SpeakerStream {
-            _stream: Mutex::new(None),
+            _stream: BackendStream::empty(),
             sender,
             running: Arc::new(AtomicBool::new(true)),
             sentinel_seq: Arc::new(AtomicUsize::new(0)),
@@ -797,7 +785,7 @@ mod tests {
         stream.stop();
         assert!(!stream.is_playing(), "stop() clears the running flag");
         assert!(
-            stream._stream.lock().unwrap().is_none(),
+            !stream._stream.is_active(),
             "stop() leaves the stream slot empty (device released)"
         );
         stream.stop(); // idempotent: an already-empty slot must not panic


### PR DESCRIPTION
Contain cpal behind a single internal AudioBackend seam. Internal, behaviour-preserving refactor: no public API or behaviour change. Also gate the bench_vad example behind the vad feature so single-feature builds compile.

## What ships
- `crates/decibri/src/backend.rs` (new): the `pub(crate) AudioBackend` trait and its sole `CpalBackend` impl; `BackendDevice` / `BackendStream` wrappers; cpal confined here.
- `crates/decibri/src/device.rs`: enumeration and selector resolution delegate through the seam; keeps the public device types and the pure is_default helper; no cpal types.
- `crates/decibri/src/microphone.rs`: holds a `BackendDevice` / `BackendStream`, opens through the backend, callbacks unchanged; no cpal types.
- `crates/decibri/src/speaker.rs`: same for output; no cpal types.
- `crates/decibri/src/lib.rs`: registers the internal `backend` module.
- `crates/decibri/Cargo.toml`: gate the `bench_vad` example with `required-features = ["vad"]`.
