### PR TITLE
fix: deliver the resampler group-delay tail at capture close

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Resampled capture (a device whose native rate differs from the configured `sample_rate`) no longer drops the resampler's group-delay tail at stream close: the final, possibly-shorter chunk now carries it, so `Microphone.read()` and `AsyncMicrophone.read()` deliver the complete resampled signal. A device already at the requested rate (no resample) is unchanged.
 - On macOS, the microphone-permission error message now reads "System Settings > Privacy & Security" (the modern macOS wording) instead of the pre-Ventura "System Preferences > Security & Privacy".
 
 ## [0.4.3] - 2026-06-12

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -21,6 +21,7 @@ For other decibri packages, see:
 
 ### Fixed
 
+- Resampled capture no longer drops the resampler's group-delay tail at stream close. The capture chain now drains the resampler's held tail once when the stream closes, appending it to the re-block buffer so it is delivered as part of the final chunk(s). The complete resampled signal is now delivered and no captured sample is dropped on the resample path. A device already at the requested rate (no resample stage) and a single-channel device (no chain) are unchanged.
 - The macOS microphone-permission hint now reads "System Settings > Privacy & Security" (the modern macOS wording) instead of the pre-Ventura "System Preferences > Security & Privacy". The `PermissionDenied` message prefix is unchanged.
 
 ## [4.3.2] - 2026-06-12

--- a/crates/decibri/src/microphone.rs
+++ b/crates/decibri/src/microphone.rs
@@ -158,6 +158,13 @@ pub struct MicrophoneStream {
     // shared `&self` while the type stays `Send + Sync` (a `CaptureStage` is
     // `Send`, so `Mutex<CaptureStage>` is `Send + Sync`).
     capture_stage: Option<Mutex<CaptureStage>>,
+    // One-time guard for the close-path chain flush. The chain's stages carry
+    // conditioning state between blocks (the resampler holds its anti-alias
+    // filter's group-delay tail); at close that held tail is drained once into
+    // `reblock_buffer` so it is delivered rather than dropped. Set the first time
+    // close is detected with a chain present, under the `reblock_buffer` lock, so
+    // the drain runs exactly once. `AtomicBool` keeps the type `Send + Sync`.
+    chain_flushed: AtomicBool,
 }
 
 #[cfg(feature = "capture")]
@@ -238,8 +245,10 @@ impl MicrophoneStream {
             // stream has since closed.
             Ok(Some(self.take_block(&mut buf, samples)))
         } else if disconnected || !self.is_open() {
-            // Closed with fewer than a full block left: deliver the final tail
-            // as one short chunk, then report closed once the buffer is empty.
+            // Closed with fewer than a full block left. Drain the chain's
+            // end-of-stream tail (once) into the buffer first, then deliver the
+            // remaining samples as full blocks plus one final short chunk.
+            self.flush_chain(&mut buf)?;
             self.take_block_or_closed(&mut buf, samples)
         } else {
             // Open, but not yet a full block. Try again shortly.
@@ -341,13 +350,16 @@ impl MicrophoneStream {
                     // disconnecting the channel).
                     if !self.is_open() {
                         self.drain_available(&mut buf)?;
+                        self.flush_chain(&mut buf)?;
                         return self.take_block_or_closed(&mut buf, samples);
                     }
                     // Stream still alive; loop with whatever deadline remains.
                 }
                 Err(RecvTimeoutError::Disconnected) => {
-                    // Channel closed and drained. Deliver any remaining full
+                    // Channel closed and drained. Drain the chain's end-of-stream
+                    // tail (once) into the buffer, then deliver any remaining full
                     // blocks and the final short tail before reporting closed.
+                    self.flush_chain(&mut buf)?;
                     return self.take_block_or_closed(&mut buf, samples);
                 }
             }
@@ -416,6 +428,33 @@ impl MicrophoneStream {
                 Ok(())
             }
         }
+    }
+
+    /// Drain the capture chain's end-of-stream tail into the re-block buffer,
+    /// exactly once, when the stream closes.
+    ///
+    /// The chain's stages carry conditioning state between blocks (the resampler
+    /// holds its anti-alias filter's group-delay tail). At close this drains that
+    /// held tail through the chain and appends it to `buf`, so the existing
+    /// reblock delivers it as part of the final chunk(s) rather than dropping it.
+    /// Runs at most once, guarded by `chain_flushed`; a stream with no chain
+    /// (`None`) drains nothing and the direct path is unchanged. The caller holds
+    /// the `reblock_buffer` lock, which orders this drain against every other
+    /// buffer access and makes the guard's check-and-set effectively atomic.
+    ///
+    /// Called after the last native block has been drained through
+    /// [`ingest`](Self::ingest) and before the close-time delivery, so the tail
+    /// is appended after all processed output and reblocked normally.
+    fn flush_chain(&self, buf: &mut VecDeque<f32>) -> Result<(), DecibriError> {
+        if let Some(stage) = &self.capture_stage {
+            if !self.chain_flushed.swap(true, Ordering::Relaxed) {
+                let mut stage = stage.lock().unwrap_or_else(PoisonError::into_inner);
+                let mut tail = Vec::new();
+                stage.flush(&mut tail)?;
+                buf.extend(tail);
+            }
+        }
+        Ok(())
     }
 
     /// Check whether the stream is still actively capturing.
@@ -605,6 +644,7 @@ impl Microphone {
             overruns,
             reblock_buffer: Mutex::new(VecDeque::new()),
             capture_stage: capture_stage.map(Mutex::new),
+            chain_flushed: AtomicBool::new(false),
         })
     }
 }
@@ -633,6 +673,7 @@ mod tests {
             overruns: Arc::new(AtomicU64::new(0)),
             reblock_buffer: Mutex::new(VecDeque::new()),
             capture_stage: capture_stage.map(Mutex::new),
+            chain_flushed: AtomicBool::new(false),
         };
         (stream, sender, running)
     }
@@ -1088,13 +1129,102 @@ mod tests {
         );
 
         let total: usize = blocks.iter().map(|b| b.len()).sum();
-        // 1:3 downsample of 24000 input is at most 8000 output, and after the
-        // brief filter warmup comfortably above a quarter of the input.
+        // A 1:3 downsample of the 24000-sample input yields roughly 8000 output
+        // samples, plus the resampler's group-delay tail now drained at close, so
+        // the total sits just above input/3 and well below half the input.
         assert!(
-            total <= input.len() / 3 && total > input.len() / 4,
+            total > input.len() / 4 && total < input.len() / 2,
             "resampled total {total} tracks the 1:3 ratio of {} input",
             input.len()
         );
+    }
+
+    /// Resample close path, the no-sample-dropped proof: a known signal fed
+    /// through the resampling capture chain and read to close delivers the
+    /// COMPLETE resampled signal, group-delay tail included. The concatenation of
+    /// every delivered chunk (steady full blocks plus the final short tail)
+    /// equals a bare resampler fed the whole input then flushed once, bit for
+    /// bit: no sample lost, reordered, requantized, or scaled. The flushed tail
+    /// arrives as part of the final chunk(s) through the normal reblock (full
+    /// blocks then one final partial), not a separate post-close emission.
+    /// Bit-equality also proves the flush ran exactly once: a missing flush would
+    /// drop the tail and a double flush would append extra samples, either of
+    /// which breaks the equality.
+    #[test]
+    fn test_resample_close_delivers_full_signal_with_flushed_tail() {
+        use decibri_resampler::{PolyphaseResampler, Resampler};
+
+        let input: Vec<f32> = (0..24_000).map(|n| (n as f32 * 0.01).sin()).collect();
+
+        // Ground truth: a bare resampler fed the whole input, then one flush.
+        let mut reference = PolyphaseResampler::new(48_000, 16_000).unwrap();
+        let mut expected = Vec::new();
+        reference.process(&input, &mut expected);
+        reference.flush(&mut expected);
+
+        // The process-only count (no flush) shows the tail is a real contribution
+        // that the resample path dropped before this drain existed.
+        let mut process_only = PolyphaseResampler::new(48_000, 16_000).unwrap();
+        let mut process_out = Vec::new();
+        process_only.process(&input, &mut process_out);
+
+        let stage = build_capture_stage(1, 1, 48_000, 16_000)
+            .unwrap()
+            .expect("48k mono -> resample chain");
+        let (stream, sender, running) = test_stream_with(Some(stage), 1);
+        sender.send(make_native_chunk(input)).unwrap();
+        drop(sender);
+        running.store(false, Ordering::Relaxed);
+
+        let samples = 320; // 20 ms at 16 kHz
+        let mut blocks: Vec<Vec<f32>> = Vec::new();
+        loop {
+            match stream.next_chunk(samples, Some(Duration::from_millis(100))) {
+                Ok(Some(c)) => {
+                    assert_eq!(c.sample_rate, 16_000, "chunks report the target rate");
+                    assert_eq!(c.channels, 1, "resampled output is mono");
+                    blocks.push(c.data);
+                }
+                Ok(None) => panic!("unexpected timeout while data was buffered"),
+                Err(DecibriError::MicrophoneStreamClosed) => break,
+                Err(e) => panic!("unexpected error: {e}"),
+            }
+        }
+
+        // Delivered as full blocks then one final partial: the tail rides the
+        // normal reblock, not a separate emission.
+        let (last, full) = blocks.split_last().expect("at least one block delivered");
+        for block in full {
+            assert_eq!(
+                block.len(),
+                samples,
+                "non-final blocks are exactly `samples` long, tail included"
+            );
+        }
+        assert!(
+            !last.is_empty() && last.len() <= samples,
+            "the final chunk carries 1..=`samples` resampled samples"
+        );
+
+        // No sample dropped, none added: the delivered stream equals the full
+        // resampled signal (steady output plus the flushed group-delay tail).
+        let delivered: Vec<f32> = blocks.into_iter().flatten().collect();
+        assert_eq!(
+            delivered, expected,
+            "the resample close path delivers the complete resampled signal, tail included"
+        );
+        assert!(
+            expected.len() > process_out.len(),
+            "the flushed tail adds the samples the process-only path dropped"
+        );
+
+        // Idempotent close: further reads stay closed with no resurrected audio.
+        for _ in 0..3 {
+            let err = stream
+                .next_chunk(samples, Some(Duration::from_millis(20)))
+                .unwrap_err();
+            assert!(matches!(err, DecibriError::MicrophoneStreamClosed));
+        }
     }
 
     /// Compile-time assertion that `Arc<Mutex<MicrophoneStream>>` is `Send + Sync`,

--- a/crates/decibri/src/stage.rs
+++ b/crates/decibri/src/stage.rs
@@ -9,7 +9,9 @@
 //! so the resampler receives mono, the format it expects.
 //!
 //! Each [`Stage`] reads one block of interleaved f32 samples and writes its
-//! output, so stages compose by ping-ponging two buffers. The chain is built by
+//! output, so stages compose by ping-ponging two buffers. At stream close the
+//! chain drains each stage's held tail through the same walk, so the resampler's
+//! group-delay tail is delivered rather than dropped. The chain is built by
 //! [`build_capture_stage`], which returns `None` when no conditioning is needed
 //! (an already-mono device already at the target rate), keeping the capture path
 //! on its zero-cost direct path.
@@ -27,6 +29,18 @@ use crate::sample;
 pub(crate) trait Stage: Send {
     /// Process `input`, appending the result to `out`.
     fn process(&mut self, input: &[f32], out: &mut Vec<f32>) -> Result<(), DecibriError>;
+
+    /// Drain any end-of-stream tail held in the stage's state into `out`.
+    ///
+    /// Called once at stream close, after the final [`process`](Stage::process).
+    /// A stateless stage holds no tail and keeps this default no-op; a stage that
+    /// carries state across blocks (the resampler's anti-alias filter holds a
+    /// group-delay tail) overrides it to append the held samples, so no captured
+    /// audio is dropped at close.
+    fn flush(&mut self, out: &mut Vec<f32>) -> Result<(), DecibriError> {
+        let _ = out;
+        Ok(())
+    }
 }
 
 /// Downmix interleaved multichannel audio to mono by averaging channels.
@@ -67,6 +81,14 @@ impl Stage for ResampleStage {
         self.0.process(input, out);
         Ok(())
     }
+
+    fn flush(&mut self, out: &mut Vec<f32>) -> Result<(), DecibriError> {
+        // Drain the resampler's group-delay tail (and any partial-frame carry)
+        // into `out`. Called once at close; the resampler appends and is
+        // infallible, so wrap it as `Ok(())`.
+        self.0.flush(out);
+        Ok(())
+    }
 }
 
 /// The capture stage chain: the `normalize` segment applied to each native
@@ -98,6 +120,35 @@ impl CaptureStage {
             std::mem::swap(&mut self.work, &mut self.scratch);
         }
         Ok(&self.work)
+    }
+
+    /// Drain the chain's complete end-of-stream tail, appending it to `out`.
+    ///
+    /// Walks the `normalize` stages in order carrying a buffer: at each stage it
+    /// processes the upstream-carried tail (when non-empty) through the stage,
+    /// then drains that stage's own held tail into the same buffer, and passes the
+    /// combined result to the next stage. So a tail produced by one stage flows
+    /// through every downstream stage exactly as a normal block would. For the
+    /// stateless [`Downmix`] this contributes nothing; for [`ResampleStage`] it
+    /// yields the resampler's group-delay tail. Call once at stream close, after
+    /// the last [`run`](Self::run).
+    pub(crate) fn flush(&mut self, out: &mut Vec<f32>) -> Result<(), DecibriError> {
+        // `work` carries the inter-stage buffer. It starts empty because there is
+        // no new input at end of stream, only each stage's drained tail.
+        self.work.clear();
+        for stage in &mut self.normalize {
+            self.scratch.clear();
+            // Feed the upstream stage's tail through this stage first (skipped for
+            // the first stage, whose carry is always empty), then drain this
+            // stage's own tail into the same buffer.
+            if !self.work.is_empty() {
+                stage.process(&self.work, &mut self.scratch)?;
+            }
+            stage.flush(&mut self.scratch)?;
+            std::mem::swap(&mut self.work, &mut self.scratch);
+        }
+        out.extend_from_slice(&self.work);
+        Ok(())
     }
 }
 
@@ -254,6 +305,69 @@ mod tests {
         assert!(
             matches!(result, Err(DecibriError::ResampleConfigInvalid { .. })),
             "an enormous native rate exceeds the resampler's filter cap"
+        );
+    }
+
+    /// `CaptureStage::flush` drains the resampling chain's complete end-of-stream
+    /// tail: processing the whole stream through the chain and then flushing once
+    /// reproduces, bit for bit, a bare resampler fed the whole stream then
+    /// flushed once. The flushed tail is nonzero (the resampler holds a
+    /// group-delay tail), it is appended after the process output, and no sample
+    /// is lost, reordered, or scaled. This is the no-sample-dropped guarantee for
+    /// the resample path at the chain level.
+    #[test]
+    fn flush_drains_resampler_tail_exactly() {
+        use decibri_resampler::{PolyphaseResampler, Resampler};
+
+        let input: Vec<f32> = (0..24_000).map(|n| (n as f32 * 0.01).sin()).collect();
+
+        // Ground truth: a bare resampler, whole input then a single flush.
+        let mut reference = PolyphaseResampler::new(48_000, 16_000).unwrap();
+        let mut expected = Vec::new();
+        reference.process(&input, &mut expected);
+        reference.flush(&mut expected);
+
+        // The chain: process the whole input via run(), then flush() the tail.
+        let mut chain = build_capture_stage(1, 1, 48_000, 16_000)
+            .unwrap()
+            .expect("48k mono -> resample chain");
+        let mut got = chain.run(&input).expect("process runs").to_vec();
+        let process_only = got.len();
+        let mut tail = Vec::new();
+        chain.flush(&mut tail).expect("flush drains the tail");
+
+        assert!(
+            !tail.is_empty(),
+            "the resampler holds a group-delay tail to drain"
+        );
+        got.extend_from_slice(&tail);
+        assert_eq!(
+            got, expected,
+            "chain process+flush reproduces the full resampled signal, tail included, bit for bit"
+        );
+        assert_eq!(
+            got.len(),
+            process_only + tail.len(),
+            "the flushed tail is appended after the process output, nothing reordered"
+        );
+    }
+
+    /// `Downmix` is stateless, so its trait-default `flush` appends nothing: a
+    /// downmix-only chain has no end-of-stream tail and `flush` yields no extra
+    /// samples (the unchanged downmix-only path).
+    #[test]
+    fn downmix_only_flush_is_empty() {
+        let mut chain = build_capture_stage(2, 1, 16_000, 16_000)
+            .unwrap()
+            .expect("stereo -> downmix chain");
+        let _ = chain.run(&[0.5, 0.3, 0.4, 0.6]).expect("downmix runs");
+        let mut tail = Vec::new();
+        chain
+            .flush(&mut tail)
+            .expect("flush on a downmix-only chain");
+        assert!(
+            tail.is_empty(),
+            "a stateless downmix chain has no flush tail"
         );
     }
 

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -23,6 +23,7 @@ For other decibri packages, see:
 
 ### Fixed
 
+- Resampled capture (a device whose native rate differs from the configured `sampleRate`) no longer drops the resampler's group-delay tail at stream close: the final, possibly-shorter `'data'` chunk(s) before `'end'` now carry it, so the complete resampled signal is delivered. A device already at the requested rate (no resample) is unchanged.
 - On macOS, the microphone-permission error message now reads "System Settings > Privacy & Security" (the modern macOS wording) instead of the pre-Ventura "System Preferences > Security & Privacy".
 
 ## [4.4.2] - 2026-06-12


### PR DESCRIPTION
The capture chain's `ResampleStage` held the resampler's group-delay tail in its filter state and never drained it, so a resampled capture stream dropped a few ms of audio at close, violating the no-captured-sample-dropped guarantee on the resample path. This adds the flush path that closes that gap.

## What ships
- `crates/decibri/src/stage.rs`: a defaulted `flush` on the `Stage` trait; `ResampleStage::flush` delegating to the resampler's `flush`; `CaptureStage::flush` as a sequential walk that, at each stage, processes the upstream-carried tail then drains that stage's own tail, so the result flows correctly through every downstream stage. `Downmix` keeps the default no-op (it is stateless).
- `crates/decibri/src/microphone.rs`: a `chain_flushed` one-time guard and a `flush_chain` driven from the three close-time delivery sites, after the native drain and before the final-tail delivery, so the tail reblocks into the final chunk(s) rather than a separate emission. Clean-stop guarantees the flush; the driver-error path stays best-effort. Realtime callback untouched.
- Crate, npm, and Python CHANGELOGs: `Fixed` entry.

Only `flush` is added to the trait; `latency_samples` and `reset` (chains are built fresh per start) are deferred to their first callers.