### PR TITLE
feat: add an opt-in DC-removal step to the capture chain

### DIFF
--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -11,6 +11,10 @@ For other decibri packages, see:
 
 ## [Unreleased]
 
+### Added
+
+- An opt-in capture enhancement with a DC-removal step. `MicrophoneConfig` gains an `enhancement: EnhancementConfig` field (a `#[non_exhaustive]` struct whose every setting defaults to off), re-exported as `decibri::EnhancementConfig`. Setting `enhancement.dc_removal = true` adds a one-pole DC-blocking high-pass to the capture chain, applied after the channel and rate normalization, which removes a constant offset from the captured audio while leaving the voice band essentially flat. Default off, so the capture path stays byte-identical unless a consumer opts in.
+
 ### Changed
 
 - Capture now delivers audio at exactly the requested `sample_rate` on every device by resampling in the engine. The input device is opened at its native sample rate (its default supported format) and a resample stage in the capture chain converts the native rate to the requested rate (after the downmix, so the resampler receives mono), using the owned anti-aliased polyphase `decibri-resampler`. A device already at the requested rate keeps the direct path with no resample stage. Previously `start()` handed the requested rate to the platform audio backend, which delivered it only when the device or OS could and otherwise failed to open. `MicrophoneStream::sample_rate()` and `AudioChunk::sample_rate` still report the requested rate, now guaranteed regardless of the device's native rate. Breaking for Rust consumers: the captured audio is now produced by decibri's resampler when the device's native rate differs from the configured rate.

--- a/crates/decibri/src/lib.rs
+++ b/crates/decibri/src/lib.rs
@@ -230,7 +230,9 @@ pub mod gain;
 // Crate-root re-exports so consumers can write `use decibri::Microphone`
 // rather than reaching through the module path.
 #[cfg(feature = "capture")]
-pub use microphone::{AudioChunk, Microphone, MicrophoneConfig, MicrophoneStream};
+pub use microphone::{
+    AudioChunk, EnhancementConfig, Microphone, MicrophoneConfig, MicrophoneStream,
+};
 
 #[cfg(feature = "playback")]
 pub use speaker::{Speaker, SpeakerConfig, SpeakerSink, SpeakerStream};

--- a/crates/decibri/src/microphone.rs
+++ b/crates/decibri/src/microphone.rs
@@ -32,6 +32,21 @@ use crate::error::DecibriError;
 #[cfg(feature = "capture")]
 use crate::stage::{build_capture_stage, CaptureStage};
 
+/// Opt-in capture enhancement settings.
+///
+/// Carried on [`MicrophoneConfig::enhancement`]. Every field defaults to off, so
+/// the capture path is unchanged unless a consumer opts in. `#[non_exhaustive]`:
+/// construct it with [`EnhancementConfig::default`] and assign the fields you
+/// want, so adding an enhancement later stays backward compatible.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct EnhancementConfig {
+    /// Remove a constant (DC) offset from captured audio with a one-pole
+    /// DC-blocking high-pass, applied after the channel and rate normalization.
+    /// Default: false (off).
+    pub dc_removal: bool,
+}
+
 /// Configuration for a microphone capture session.
 ///
 /// `#[non_exhaustive]`: construct it with [`MicrophoneConfig::default`] and then
@@ -49,6 +64,9 @@ pub struct MicrophoneConfig {
     pub frames_per_buffer: u32,
     /// Device selection. Default: system default input.
     pub device: DeviceSelector,
+    /// Opt-in capture enhancement. Default: every enhancement off, so the
+    /// capture path is unchanged.
+    pub enhancement: EnhancementConfig,
 }
 
 impl Default for MicrophoneConfig {
@@ -58,6 +76,7 @@ impl Default for MicrophoneConfig {
             channels: 1,
             frames_per_buffer: 1600,
             device: DeviceSelector::Default,
+            enhancement: EnhancementConfig::default(),
         }
     }
 }
@@ -572,8 +591,13 @@ impl Microphone {
         // downmixes, which is what the exact-size `samples` math is counted in)
         // and the target rate.
         let target_channels: u16 = 1;
-        let capture_stage =
-            build_capture_stage(channels, target_channels, native_rate, target_rate)?;
+        let capture_stage = build_capture_stage(
+            channels,
+            target_channels,
+            native_rate,
+            target_rate,
+            &self.config.enhancement,
+        )?;
         let output_channels = if channels > target_channels {
             target_channels
         } else {
@@ -1025,7 +1049,9 @@ mod tests {
     #[test]
     fn test_mono_device_builds_no_chain() {
         assert!(
-            build_capture_stage(1, 1, 16000, 16000).unwrap().is_none(),
+            build_capture_stage(1, 1, 16000, 16000, &EnhancementConfig::default())
+                .unwrap()
+                .is_none(),
             "a mono device at the target rate needs no normalize chain"
         );
         let (stream, _sender, _running) = test_stream();
@@ -1041,7 +1067,7 @@ mod tests {
     /// tail is delivered.
     #[test]
     fn test_downmix_chain_yields_correct_mono() {
-        let stage = build_capture_stage(2, 1, 16000, 16000).unwrap();
+        let stage = build_capture_stage(2, 1, 16000, 16000, &EnhancementConfig::default()).unwrap();
         assert!(stage.is_some(), "a stereo device gets a downmix chain");
         let (stream, sender, running) = test_stream_with(stage, 1); // output is mono
 
@@ -1089,7 +1115,7 @@ mod tests {
     /// count tracks the 1:3 rate ratio (48 kHz -> 16 kHz).
     #[test]
     fn test_resample_chain_delivers_exact_blocks_at_target_rate() {
-        let stage = build_capture_stage(1, 1, 48_000, 16_000)
+        let stage = build_capture_stage(1, 1, 48_000, 16_000, &EnhancementConfig::default())
             .unwrap()
             .expect("48k mono -> resample chain");
         // test_stream_with stamps the stream at 16 kHz (the target), mono.
@@ -1168,7 +1194,7 @@ mod tests {
         let mut process_out = Vec::new();
         process_only.process(&input, &mut process_out);
 
-        let stage = build_capture_stage(1, 1, 48_000, 16_000)
+        let stage = build_capture_stage(1, 1, 48_000, 16_000, &EnhancementConfig::default())
             .unwrap()
             .expect("48k mono -> resample chain");
         let (stream, sender, running) = test_stream_with(Some(stage), 1);
@@ -1225,6 +1251,58 @@ mod tests {
                 .unwrap_err();
             assert!(matches!(err, DecibriError::MicrophoneStreamClosed));
         }
+    }
+
+    /// Enhancement-on, end to end through `ingest` (the `Some([transform])`
+    /// path): with `dc_removal` enabled on a mono device already at the target
+    /// rate, the chain is transform-only (no downmix, no resample), so a constant
+    /// DC offset fed through the stream is delivered with the same sample count
+    /// (the DC step preserves length and holds no tail) and a settled mean near
+    /// zero (the offset is removed). This proves the transform segment is applied
+    /// to delivered audio through the normal capture path.
+    #[test]
+    fn test_enhancement_on_removes_dc_end_to_end() {
+        let enhancement = EnhancementConfig { dc_removal: true };
+        let stage = build_capture_stage(1, 1, 16_000, 16_000, &enhancement)
+            .unwrap()
+            .expect("dc_removal builds a transform-only chain for a mono device");
+        let (stream, sender, running) = test_stream_with(Some(stage), 1);
+
+        // A constant 0.5 offset: pure DC, no audio content.
+        let n = 16_000;
+        let input = vec![0.5_f32; n];
+        sender.send(make_native_chunk(input)).unwrap();
+        drop(sender);
+        running.store(false, Ordering::Relaxed);
+
+        let samples = 320;
+        let mut collected: Vec<f32> = Vec::new();
+        loop {
+            match stream.next_chunk(samples, Some(Duration::from_millis(100))) {
+                Ok(Some(c)) => {
+                    assert_eq!(c.channels, 1, "the enhanced output stays mono");
+                    assert_eq!(c.sample_rate, 16_000, "no resample, the rate is unchanged");
+                    collected.extend_from_slice(&c.data);
+                }
+                Ok(None) => panic!("unexpected timeout while data was buffered"),
+                Err(DecibriError::MicrophoneStreamClosed) => break,
+                Err(e) => panic!("unexpected error: {e}"),
+            }
+        }
+
+        assert_eq!(
+            collected.len(),
+            n,
+            "the DC step preserves the sample count exactly (no resample, no tail)"
+        );
+        // After the filter settles, the constant offset is gone: the mean of the
+        // last quarter is essentially zero.
+        let settled = &collected[n - n / 4..];
+        let mean = settled.iter().sum::<f32>() / settled.len() as f32;
+        assert!(
+            mean.abs() < 1e-3,
+            "the DC offset is removed end to end (settled mean {mean})"
+        );
     }
 
     /// Compile-time assertion that `Arc<Mutex<MicrophoneStream>>` is `Send + Sync`,

--- a/crates/decibri/src/stage.rs
+++ b/crates/decibri/src/stage.rs
@@ -2,23 +2,26 @@
 //!
 //! A [`CaptureStage`] conditions raw device capture into the canonical format the
 //! consumer receives, running between the cpal callback's native buffers and the
-//! exact-size reblock in [`crate::microphone`]. The chain has one segment,
-//! `normalize`, holding up to two stages: [`Downmix`], which averages a
+//! exact-size reblock in [`crate::microphone`]. The chain has two segments. The
+//! `normalize` segment holds up to two stages: [`Downmix`], which averages a
 //! multichannel device down to mono, then [`ResampleStage`], which converts the
 //! device's native sample rate to the requested target rate. Downmix runs first
-//! so the resampler receives mono, the format it expects.
+//! so the resampler receives mono, the format it expects. The optional
+//! `transform` segment runs after `normalize`, holding the same-length
+//! conditioning step a consumer opts into (the [`DcBlocker`] DC-removal step).
 //!
 //! Each [`Stage`] reads one block of interleaved f32 samples and writes its
 //! output, so stages compose by ping-ponging two buffers. At stream close the
 //! chain drains each stage's held tail through the same walk, so the resampler's
 //! group-delay tail is delivered rather than dropped. The chain is built by
 //! [`build_capture_stage`], which returns `None` when no conditioning is needed
-//! (an already-mono device already at the target rate), keeping the capture path
-//! on its zero-cost direct path.
+//! (an already-mono device already at the target rate with no enhancement
+//! enabled), keeping the capture path on its zero-cost direct path.
 
 use decibri_resampler::{PolyphaseResampler, Resampler};
 
 use crate::error::DecibriError;
+use crate::microphone::EnhancementConfig;
 use crate::sample;
 
 /// A capture processing stage: reads one block of interleaved f32 samples and
@@ -91,14 +94,93 @@ impl Stage for ResampleStage {
     }
 }
 
-/// The capture stage chain: the `normalize` segment applied to each native
-/// capture block before exact-size delivery.
+/// A same-length DSP step: filters a buffer of samples in place, producing
+/// exactly as many output samples as it received. The adapter [`InPlace`] wraps
+/// any `InPlaceDsp` as a [`Stage`].
 ///
-/// Invariant: `normalize` is never empty. [`build_capture_stage`] is the only
-/// constructor and returns `None` rather than an empty chain, so the capture path
-/// can skip the chain entirely when no conditioning is needed.
+/// `Send` so the wrapped step can live behind the stream's `Mutex`, matching the
+/// [`Stage`] bound.
+trait InPlaceDsp: Send {
+    /// Filter `samples` in place: each element is replaced by its processed
+    /// value, the length unchanged.
+    fn process_in_place(&mut self, samples: &mut [f32]);
+}
+
+/// Adapts an [`InPlaceDsp`] to the [`Stage`] interface. `process` copies the
+/// input into `out` then filters it in place, so the output length equals the
+/// input length; `flush` keeps the [`Stage`] default no-op, since a same-length
+/// DSP holds no end-of-stream tail.
+struct InPlace<T: InPlaceDsp>(T);
+
+impl<T: InPlaceDsp> Stage for InPlace<T> {
+    fn process(&mut self, input: &[f32], out: &mut Vec<f32>) -> Result<(), DecibriError> {
+        // The caller clears `out` first, so this is an exact-length copy of the
+        // input that the DSP then rewrites in place: one input sample, one output
+        // sample.
+        out.extend_from_slice(input);
+        self.0.process_in_place(out);
+        Ok(())
+    }
+}
+
+/// One-pole DC-blocking high-pass: removes a constant (DC) offset from the signal
+/// while leaving the audio band essentially flat. Implements the standard
+/// difference equation `y[n] = x[n] - x[n-1] + R*y[n-1]`, with the pole `R` just
+/// below 1 so the corner sits close to DC.
+///
+/// Same-length and sample-by-sample (one input sample yields one output sample),
+/// so it is an [`InPlaceDsp`] driven through [`InPlace`]. The filter memory
+/// (`x_prev`, `y_prev`) carries across blocks, so the response is continuous at
+/// chunk boundaries; it holds no end-of-stream tail, so it keeps the default
+/// no-op flush.
+struct DcBlocker {
+    /// Previous input sample `x[n-1]`, carried across blocks.
+    x_prev: f32,
+    /// Previous output sample `y[n-1]`, carried across blocks.
+    y_prev: f32,
+}
+
+impl DcBlocker {
+    /// Feedback coefficient `R`. At 0.995 the high-pass corner sits near 13 Hz at
+    /// 16 kHz, well below the voice band, and a DC offset settles out within a
+    /// few hundred samples.
+    const R: f32 = 0.995;
+
+    fn new() -> Self {
+        Self {
+            x_prev: 0.0,
+            y_prev: 0.0,
+        }
+    }
+}
+
+impl InPlaceDsp for DcBlocker {
+    fn process_in_place(&mut self, samples: &mut [f32]) {
+        for s in samples.iter_mut() {
+            let x = *s;
+            let y = x - self.x_prev + Self::R * self.y_prev;
+            self.x_prev = x;
+            self.y_prev = y;
+            *s = y;
+        }
+    }
+}
+
+/// The capture stage chain: a `normalize` segment (downmix, resample) that
+/// conditions a device to the output format, then an optional `transform`
+/// segment (the DC-removal step) applied to the normalized signal.
+///
+/// Invariant: at least one segment is non-empty. [`build_capture_stage`] is the
+/// only constructor and returns `None` rather than an empty chain when both
+/// segments are empty, so the capture path can skip the chain entirely when no
+/// conditioning is needed.
 pub(crate) struct CaptureStage {
+    /// Channel and rate normalization stages (downmix, then resample), applied
+    /// first.
     normalize: Vec<Box<dyn Stage>>,
+    /// Optional same-length conditioning stages (the DC-removal step), applied
+    /// after `normalize`.
+    transform: Vec<Box<dyn Stage>>,
     /// Holds the current block as it passes through the chain; [`run`](Self::run)
     /// returns a borrow of this after the last stage.
     work: Vec<f32>,
@@ -109,58 +191,88 @@ pub(crate) struct CaptureStage {
 impl CaptureStage {
     /// Run the chain on one native block, returning the conditioned output.
     ///
-    /// Seeds `work` with `input`, then ping-pongs `work` <-> `scratch` across the
-    /// `normalize` stages, leaving the final output in `work`.
+    /// Seeds `work` with `input`, then ping-pongs `work` <-> `scratch` first
+    /// across the `normalize` stages and then across the `transform` stages,
+    /// leaving the final output in `work`.
     pub(crate) fn run(&mut self, input: &[f32]) -> Result<&[f32], DecibriError> {
         self.work.clear();
         self.work.extend_from_slice(input);
-        for stage in &mut self.normalize {
-            self.scratch.clear();
-            stage.process(&self.work, &mut self.scratch)?;
-            std::mem::swap(&mut self.work, &mut self.scratch);
-        }
+        Self::run_segment(&mut self.work, &mut self.scratch, &mut self.normalize)?;
+        Self::run_segment(&mut self.work, &mut self.scratch, &mut self.transform)?;
         Ok(&self.work)
+    }
+
+    /// Ping-pong one block through a single segment's stages, leaving the result
+    /// in `work`. Each stage reads `work` and writes `scratch`; the two are then
+    /// swapped, so after the loop `work` holds the segment's output. An empty
+    /// segment leaves `work` untouched.
+    fn run_segment(
+        work: &mut Vec<f32>,
+        scratch: &mut Vec<f32>,
+        stages: &mut [Box<dyn Stage>],
+    ) -> Result<(), DecibriError> {
+        for stage in stages.iter_mut() {
+            scratch.clear();
+            stage.process(work, scratch)?;
+            std::mem::swap(work, scratch);
+        }
+        Ok(())
     }
 
     /// Drain the chain's complete end-of-stream tail, appending it to `out`.
     ///
-    /// Walks the `normalize` stages in order carrying a buffer: at each stage it
-    /// processes the upstream-carried tail (when non-empty) through the stage,
-    /// then drains that stage's own held tail into the same buffer, and passes the
-    /// combined result to the next stage. So a tail produced by one stage flows
-    /// through every downstream stage exactly as a normal block would. For the
-    /// stateless [`Downmix`] this contributes nothing; for [`ResampleStage`] it
-    /// yields the resampler's group-delay tail. Call once at stream close, after
-    /// the last [`run`](Self::run).
+    /// Walks the `normalize` segment then the `transform` segment with a single
+    /// carried buffer, so a tail produced by one stage flows through every
+    /// downstream stage (including across the segment boundary) exactly as a
+    /// normal block would. For the stateless [`Downmix`] this contributes
+    /// nothing; for [`ResampleStage`] it yields the resampler's group-delay tail,
+    /// which then passes through the `transform` stages. Call once at stream
+    /// close, after the last [`run`](Self::run).
     pub(crate) fn flush(&mut self, out: &mut Vec<f32>) -> Result<(), DecibriError> {
         // `work` carries the inter-stage buffer. It starts empty because there is
-        // no new input at end of stream, only each stage's drained tail.
+        // no new input at end of stream, only each stage's drained tail; it is
+        // carried unbroken from the `normalize` walk into the `transform` walk.
         self.work.clear();
-        for stage in &mut self.normalize {
-            self.scratch.clear();
-            // Feed the upstream stage's tail through this stage first (skipped for
-            // the first stage, whose carry is always empty), then drain this
-            // stage's own tail into the same buffer.
-            if !self.work.is_empty() {
-                stage.process(&self.work, &mut self.scratch)?;
-            }
-            stage.flush(&mut self.scratch)?;
-            std::mem::swap(&mut self.work, &mut self.scratch);
-        }
+        Self::flush_segment(&mut self.work, &mut self.scratch, &mut self.normalize)?;
+        Self::flush_segment(&mut self.work, &mut self.scratch, &mut self.transform)?;
         out.extend_from_slice(&self.work);
+        Ok(())
+    }
+
+    /// Drain one segment's tail, carrying `work` across its stages. At each stage
+    /// it feeds the upstream-carried tail through (when non-empty), then drains
+    /// that stage's own held tail into the same buffer. `work` enters holding the
+    /// previous segment's carried tail (empty for the first non-empty stage) and
+    /// leaves holding this segment's output.
+    fn flush_segment(
+        work: &mut Vec<f32>,
+        scratch: &mut Vec<f32>,
+        stages: &mut [Box<dyn Stage>],
+    ) -> Result<(), DecibriError> {
+        for stage in stages.iter_mut() {
+            scratch.clear();
+            if !work.is_empty() {
+                stage.process(work, scratch)?;
+            }
+            stage.flush(scratch)?;
+            std::mem::swap(work, scratch);
+        }
         Ok(())
     }
 }
 
-/// Build the capture stage chain that normalizes a device to the output format.
+/// Build the capture stage chain that normalizes a device to the output format
+/// and applies any opt-in enhancement.
 ///
 /// Pushes [`Downmix`] when the device delivers more channels than the output
 /// target (averaging down to the target, which is mono here), then
 /// [`ResampleStage`] when the device's `native_rate` differs from `target_rate`
-/// (converting the captured audio to the requested rate). Returns `Some(chain)`
-/// when at least one stage is needed and `None` when neither is (a mono device
-/// already at the target rate), leaving the capture path on its direct,
-/// zero-cost reblock.
+/// (converting the captured audio to the requested rate). When `enhancement`
+/// enables the DC-removal step, pushes the [`DcBlocker`] into the `transform`
+/// segment, which runs after `normalize` on the mono signal at the target rate.
+/// Returns `Some(chain)` when at least one stage is needed and `None` when no
+/// segment has any (a mono device already at the target rate with no enhancement
+/// enabled), leaving the capture path on its direct, zero-cost reblock.
 ///
 /// Returns an error when the resampler rejects the rate pair at construction;
 /// every in-range configured rate over any device-native rate constructs, so
@@ -170,6 +282,7 @@ pub(crate) fn build_capture_stage(
     target_channels: u16,
     native_rate: u32,
     target_rate: u32,
+    enhancement: &EnhancementConfig,
 ) -> Result<Option<CaptureStage>, DecibriError> {
     let mut normalize: Vec<Box<dyn Stage>> = Vec::new();
 
@@ -185,11 +298,19 @@ pub(crate) fn build_capture_stage(
         normalize.push(Box::new(ResampleStage(resampler)));
     }
 
-    Ok(if normalize.is_empty() {
+    let mut transform: Vec<Box<dyn Stage>> = Vec::new();
+
+    if enhancement.dc_removal {
+        // Runs after `normalize`, on the mono signal at the target rate.
+        transform.push(Box::new(InPlace(DcBlocker::new())));
+    }
+
+    Ok(if normalize.is_empty() && transform.is_empty() {
         None
     } else {
         Some(CaptureStage {
             normalize,
+            transform,
             work: Vec::new(),
             scratch: Vec::new(),
         })
@@ -200,34 +321,76 @@ pub(crate) fn build_capture_stage(
 mod tests {
     use super::*;
 
-    /// `build_capture_stage` returns `None` only for a mono device already at
-    /// the target rate, and `Some` once a downmix and/or a resample is needed.
+    /// With enhancement off (the default), `build_capture_stage` returns `None`
+    /// only for a mono device already at the target rate, and `Some` once a
+    /// downmix and/or a resample is needed.
     #[test]
     fn build_returns_none_only_for_mono_at_target_rate() {
+        let off = EnhancementConfig::default();
         // Mono, native == target: nothing to normalize.
         assert!(
-            build_capture_stage(1, 1, 16_000, 16_000).unwrap().is_none(),
+            build_capture_stage(1, 1, 16_000, 16_000, &off)
+                .unwrap()
+                .is_none(),
             "mono device at the target rate needs no chain"
         );
         // Multichannel, native == target: downmix only.
         assert!(
-            build_capture_stage(2, 1, 16_000, 16_000).unwrap().is_some(),
+            build_capture_stage(2, 1, 16_000, 16_000, &off)
+                .unwrap()
+                .is_some(),
             "stereo device gets a chain (downmix)"
         );
         assert!(
-            build_capture_stage(6, 1, 16_000, 16_000).unwrap().is_some(),
+            build_capture_stage(6, 1, 16_000, 16_000, &off)
+                .unwrap()
+                .is_some(),
             "5.1 device gets a chain (downmix)"
         );
         // Mono, native != target: resample only.
         assert!(
-            build_capture_stage(1, 1, 48_000, 16_000).unwrap().is_some(),
+            build_capture_stage(1, 1, 48_000, 16_000, &off)
+                .unwrap()
+                .is_some(),
             "mono device above the target rate gets a chain (resample)"
         );
         // Multichannel, native != target: downmix then resample.
         assert!(
-            build_capture_stage(2, 1, 48_000, 16_000).unwrap().is_some(),
+            build_capture_stage(2, 1, 48_000, 16_000, &off)
+                .unwrap()
+                .is_some(),
             "stereo device above the target rate gets a chain (downmix + resample)"
         );
+    }
+
+    /// Enabling the DC-removal step adds a `transform` stage, so even a mono
+    /// device already at the target rate now gets a chain (transform-only, with
+    /// an empty `normalize`); `build_capture_stage` returns `None` only when BOTH
+    /// segments are empty.
+    #[test]
+    fn build_with_dc_removal_adds_transform_even_with_empty_normalize() {
+        let on = EnhancementConfig { dc_removal: true };
+
+        // Mono at target, enhancement on: a transform-only chain (no normalize).
+        let chain = build_capture_stage(1, 1, 16_000, 16_000, &on)
+            .unwrap()
+            .expect("dc_removal builds a chain even with nothing to normalize");
+        assert!(
+            chain.normalize.is_empty(),
+            "a mono device at the target rate needs no normalize stage"
+        );
+        assert_eq!(
+            chain.transform.len(),
+            1,
+            "dc_removal pushes exactly one transform stage"
+        );
+
+        // Stereo above target, enhancement on: downmix + resample + DC.
+        let full = build_capture_stage(2, 1, 48_000, 16_000, &on)
+            .unwrap()
+            .expect("downmix + resample + DC chain");
+        assert_eq!(full.normalize.len(), 2, "downmix then resample");
+        assert_eq!(full.transform.len(), 1, "the DC-removal step");
     }
 
     /// The downmix chain averages interleaved frames to mono, reproducing
@@ -236,7 +399,7 @@ mod tests {
     /// pure downmix.
     #[test]
     fn downmix_chain_averages_to_mono() {
-        let mut chain = build_capture_stage(2, 1, 16_000, 16_000)
+        let mut chain = build_capture_stage(2, 1, 16_000, 16_000, &EnhancementConfig::default())
             .unwrap()
             .expect("stereo -> downmix chain");
         // Two stereo frames: (0.5, 0.3) -> 0.4, (0.4, 0.6) -> 0.5.
@@ -253,7 +416,7 @@ mod tests {
     /// filter's startup ramp, since this `process`-only path does not flush).
     #[test]
     fn resample_chain_changes_rate_and_count() {
-        let mut chain = build_capture_stage(1, 1, 48_000, 16_000)
+        let mut chain = build_capture_stage(1, 1, 48_000, 16_000, &EnhancementConfig::default())
             .unwrap()
             .expect("48k mono -> resample chain");
         let input: Vec<f32> = (0..24_000).map(|n| (n as f32 * 0.01).sin()).collect();
@@ -301,7 +464,7 @@ mod tests {
     /// cap to exercise the `?` bridge end to end.
     #[test]
     fn build_capture_stage_surfaces_unsupported_rate_pair() {
-        let result = build_capture_stage(1, 1, 316_800_000, 16_000);
+        let result = build_capture_stage(1, 1, 316_800_000, 16_000, &EnhancementConfig::default());
         assert!(
             matches!(result, Err(DecibriError::ResampleConfigInvalid { .. })),
             "an enormous native rate exceeds the resampler's filter cap"
@@ -328,7 +491,7 @@ mod tests {
         reference.flush(&mut expected);
 
         // The chain: process the whole input via run(), then flush() the tail.
-        let mut chain = build_capture_stage(1, 1, 48_000, 16_000)
+        let mut chain = build_capture_stage(1, 1, 48_000, 16_000, &EnhancementConfig::default())
             .unwrap()
             .expect("48k mono -> resample chain");
         let mut got = chain.run(&input).expect("process runs").to_vec();
@@ -357,7 +520,7 @@ mod tests {
     /// samples (the unchanged downmix-only path).
     #[test]
     fn downmix_only_flush_is_empty() {
-        let mut chain = build_capture_stage(2, 1, 16_000, 16_000)
+        let mut chain = build_capture_stage(2, 1, 16_000, 16_000, &EnhancementConfig::default())
             .unwrap()
             .expect("stereo -> downmix chain");
         let _ = chain.run(&[0.5, 0.3, 0.4, 0.6]).expect("downmix runs");
@@ -371,6 +534,126 @@ mod tests {
         );
     }
 
+    /// Transform-off no-op: with enhancement off (the default) the `transform`
+    /// segment is empty, so a downmix-only chain matches the pre-transform state:
+    /// no DC step, and the output is exactly the downmix.
+    #[test]
+    fn transform_off_leaves_segment_empty_and_output_unchanged() {
+        let mut chain = build_capture_stage(2, 1, 16_000, 16_000, &EnhancementConfig::default())
+            .unwrap()
+            .expect("stereo -> downmix chain");
+        assert!(
+            chain.transform.is_empty(),
+            "enhancement off leaves the transform segment empty"
+        );
+        let out = chain.run(&[0.5, 0.3, 0.4, 0.6]).expect("downmix runs");
+        assert_eq!(
+            out,
+            sample::downmix_to_mono(&[0.5, 0.3, 0.4, 0.6], 2),
+            "with no transform the output is exactly the downmix"
+        );
+    }
+
+    /// DC-removal correctness: a constant offset settles to a near-zero mean, the
+    /// length is preserved exactly (one output sample per input), and the
+    /// response is continuous across chunk boundaries: the filter state carries,
+    /// so splitting the input into two chunks yields the same samples as one.
+    #[test]
+    fn dc_removal_removes_offset_preserves_length_and_is_continuous() {
+        let on = EnhancementConfig { dc_removal: true };
+
+        // Mono at the target rate: a transform-only chain (just the DC step).
+        let mut chain = build_capture_stage(1, 1, 16_000, 16_000, &on)
+            .unwrap()
+            .expect("dc-only chain");
+        let n = 16_000;
+        let input = vec![0.5_f32; n];
+        let out = chain.run(&input).expect("dc runs").to_vec();
+
+        assert_eq!(
+            out.len(),
+            n,
+            "the DC step preserves the sample count exactly"
+        );
+        // The constant offset settles out: the mean of the last quarter is ~0.
+        let settled = &out[n - n / 4..];
+        let mean = settled.iter().sum::<f32>() / settled.len() as f32;
+        assert!(
+            mean.abs() < 1e-3,
+            "a known DC offset yields a near-zero-mean output (mean {mean})"
+        );
+
+        // Continuity: the same input split across two chunks (state carried)
+        // yields identical output, so there is no per-chunk discontinuity.
+        let mut split = build_capture_stage(1, 1, 16_000, 16_000, &on)
+            .unwrap()
+            .expect("dc-only chain");
+        let mut combined = split.run(&input[..8_000]).expect("first half").to_vec();
+        combined.extend_from_slice(split.run(&input[8_000..]).expect("second half"));
+        assert_eq!(
+            combined, out,
+            "filter state carries across chunks: split processing matches one-shot"
+        );
+    }
+
+    /// Two-segment run/flush: a downmix + resample + DC chain runs its stages in
+    /// order (downmix, then resample, then DC) and, at close, delivers the
+    /// resampler's group-delay tail through the DC step. Concatenating the run
+    /// output with the flushed tail reproduces, bit for bit, a reference that
+    /// downmixes, resamples (process then flush), then DC-blocks the whole signal
+    /// with a single continuous filter. That equality holds only if the chain
+    /// applies the stages in that order and carries the DC filter state unbroken
+    /// across the run/flush boundary. The resampler's no-sample-dropped flush
+    /// guarantee still holds with a transform present.
+    #[test]
+    fn two_segment_run_and_flush_order_and_tail() {
+        let on = EnhancementConfig { dc_removal: true };
+
+        // Stereo 48k input: a sine plus a DC offset on both channels (so the
+        // downmix keeps the offset for the DC step to remove).
+        let frames = 12_000;
+        let mut input = Vec::with_capacity(frames * 2);
+        for k in 0..frames {
+            let s = (k as f32 * 0.01).sin() + 0.5;
+            input.push(s);
+            input.push(s);
+        }
+
+        // Reference: downmix -> resample(process + flush) -> DC over the whole.
+        let mono = sample::downmix_to_mono(&input, 2);
+        let mut resampler = PolyphaseResampler::new(48_000, 16_000).unwrap();
+        let mut resampled = Vec::new();
+        resampler.process(&mono, &mut resampled);
+        resampler.flush(&mut resampled);
+        let mut dc = DcBlocker::new();
+        let mut expected = resampled.clone();
+        dc.process_in_place(&mut expected);
+
+        // The chain: process the whole input via run(), then flush() the tail.
+        let mut chain = build_capture_stage(2, 1, 48_000, 16_000, &on)
+            .unwrap()
+            .expect("downmix + resample + DC chain");
+        let mut got = chain.run(&input).expect("run").to_vec();
+        let process_only = got.len();
+        let mut tail = Vec::new();
+        chain.flush(&mut tail).expect("flush");
+        assert!(
+            !tail.is_empty(),
+            "the resampler still holds a group-delay tail, now flushed through the DC step"
+        );
+        got.extend_from_slice(&tail);
+
+        assert_eq!(
+            got, expected,
+            "downmix -> resample -> DC order, DC state carried across run/flush, bit for bit"
+        );
+        assert_eq!(
+            got.len(),
+            process_only + tail.len(),
+            "the flushed tail is appended after the run output, nothing reordered"
+        );
+    }
+
     /// `CaptureStage` is `Send` so it can live behind the stream's `Mutex` and
     /// keep `MicrophoneStream: Send + Sync`. The resampler is `Send`, so a chain
     /// carrying a `ResampleStage` keeps the bound.
@@ -378,5 +661,13 @@ mod tests {
     fn capture_stage_is_send() {
         fn assert_send<T: Send>() {}
         assert_send::<CaptureStage>();
+    }
+
+    /// The DC step is `Send`, so a chain carrying it in the `transform` segment
+    /// stays `Send` and can live behind the stream's `Mutex`.
+    #[test]
+    fn dc_stage_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<InPlace<DcBlocker>>();
     }
 }


### PR DESCRIPTION
Add the transform tier to the capture stage chain with its first stage, a one-pole DC blocker, gated behind a default-off enhancement toggle. The default capture path is byte-identical; the new behavior only runs when a consumer opts in.

## What ships
- `crates/decibri/src/microphone.rs`: `EnhancementConfig` (a `#[non_exhaustive]` struct, `Default` all-off) on `MicrophoneConfig.enhancement`, passed into `build_capture_stage` as `&EnhancementConfig` so it extends additively.
- `crates/decibri/src/stage.rs`: the `InPlace` / `InPlaceDsp` same-length adapter; the `DcBlocker` stage (`y[n] = x[n] - x[n-1] + 0.995*y[n-1]`, stateful across chunks, no flush tail); a `transform` segment on `CaptureStage`; `run` and `flush` extended to walk normalize then transform via `run_segment`/`flush_segment`, so the resampler tail still flushes through the transform at close. `build_capture_stage` returns `None` only when both segments are empty.
- `crates/decibri/src/lib.rs`: `EnhancementConfig` re-exported under the capture feature.
- Crate CHANGELOG: `Added` entry.

VAD is untouched here.