### PR TITLE
docs: document decibri ACE across the READMEs and ignore python tool caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,12 @@ __pycache__/
 *.pyc
 *.pyo
 
+# Python test/lint tool caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.hypothesis/
+
 # Python virtual environments (uv defaults to .venv/)
 .venv/
 venv/

--- a/README.md
+++ b/README.md
@@ -32,6 +32,34 @@ Key features:
 
 To learn more, visit [decibri.com/docs/](https://decibri.com/docs/).
 
+## decibri ACE
+
+Audio Capture Engine for Speech.
+
+decibri ACE (Audio Capture Engine) is decibri's opt-in audio front-end for speech: it conditions microphone audio before it reaches your recognizer. Every stage is off by default, so a plain `Microphone(...)` is byte-identical to capture without ACE, and you turn on only the stages you want.
+
+What makes it useful is not the individual filters, it is the package they come in:
+
+- **Keyless and local.** No API key, no account, no network call. The chain runs on-device. The denoise model and the Silero VAD model ship inside the package.
+- **Opt-in and zero-cost when off.** Nothing in the chain runs until you ask for it. With every stage left at its default, the capture path is unchanged.
+- **One surface across the bindings.** The same conditioning options, with the same names and ranges, are available from Python, Node.js, and Rust.
+
+ACE is a practical capture pipeline, not a claim to state-of-the-art signal processing. The stages are conventional and described plainly:
+
+| Stage | Option | What it does |
+| :--- | :--- | :--- |
+| DC removal | `dc_removal` (bool) | Removes a constant (DC) offset with a one-pole DC-blocking high-pass. |
+| Denoise | `denoise="fastenhancer-t"` | Optional bundled single-channel speech-enhancement model. |
+| High-pass | `highpass=80` or `100` | A second-order Butterworth high-pass (80 or 100 Hz) that removes low-frequency rumble below the voice band. |
+| AGC | `agc=-18` (dBFS, -40 to -3) | Drives the running level toward a target with a smoothed, rate-limited gain. |
+| Limiter | `limiter=-1.0` (dBFS, -3.0 to 0.0) | A sample-peak ceiling that catches a transient the AGC would let exceed full scale. |
+
+The stages run in that order: DC removal, denoise, high-pass, AGC, then limiter.
+
+Voice activity detection reads the signal before the chain, so turning on enhancement does not change what counts as speech.
+
+See the [Quick Start](#quick-start) below for a runnable example. The same options are available in Node.js (`dcRemoval`, `denoise`, `highpass`, `agc`, `limiter`) and Rust (`MicrophoneConfig` fields); per-language detail lives in each binding's README.
+
 ## Installation
 
 **Python** (recommended with [uv](https://docs.astral.sh/uv/)):
@@ -75,6 +103,23 @@ with decibri.Microphone(sample_rate=16000) as mic:
     for chunk in mic:
         print(f"Got {len(chunk)} bytes")
         break
+```
+
+With decibri ACE conditioning and Silero VAD in front (every stage is opt-in):
+
+```python
+import decibri
+
+# Denoise and a high-pass in front of Silero VAD. Both are opt-in.
+with decibri.Microphone(
+    sample_rate=16000,
+    denoise="fastenhancer-t",
+    highpass=80,
+    vad=decibri.Vad(model="silero", threshold=0.5),
+) as mic:
+    for chunk in mic:
+        if mic.is_speaking:
+            handle(chunk)  # conditioned audio, ready for your recognizer
 ```
 
 Full Python guide: [here](bindings/python/README.md).

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -125,6 +125,38 @@ mic = decibri.Microphone(vad=decibri.Vad(model="silero", threshold=0.5))
 
 Use `mic.vad_score` (a value in `[0, 1]`) to gate downstream processing. `mic.is_speaking` returns the boolean above-threshold view.
 
+## decibri ACE (audio conditioning)
+
+decibri ACE (Audio Capture Engine) is decibri's opt-in audio front-end for speech: a conditioning chain applied to the captured audio before it is delivered. Every stage is off by default, runs on-device, and needs no API key. Leave the options unset and the capture path is unchanged.
+
+The stages run in this order. Pass any subset on the `Microphone` constructor:
+
+| Stage | Keyword | Value |
+| --- | --- | --- |
+| DC removal | `dc_removal=True` | bool, default `False` |
+| Denoise | `denoise="fastenhancer-t"` | the one bundled model |
+| High-pass | `highpass=80` or `100` | Hz, second-order Butterworth |
+| AGC | `agc=-18` | int dBFS, -40 to -3 |
+| Limiter | `limiter=-1.0` | float dBFS, -3.0 to 0.0 |
+
+```python
+import decibri
+
+with decibri.Microphone(
+    sample_rate=16000,
+    denoise="fastenhancer-t",  # bundled speech-enhancement model
+    highpass=80,               # remove low-frequency rumble
+    agc=-18,                   # target level in dBFS
+    limiter=-1.0,              # peak ceiling in dBFS
+    vad=decibri.Vad(model="silero", threshold=0.5),
+) as mic:
+    for chunk in mic:
+        if mic.is_speaking:
+            handle(chunk)      # conditioned int16 PCM bytes
+```
+
+The denoise model is bundled in the wheel (the same way the Silero VAD model is), so `denoise="fastenhancer-t"` needs no download. VAD reads the signal before the chain, so `mic.vad_score` and `mic.is_speaking` are unaffected by which conditioning stages you enable. The same options are available on `AsyncMicrophone`.
+
 ## Compatibility
 
 | Python                       | Platforms                                                |

--- a/crates/decibri/README.md
+++ b/crates/decibri/README.md
@@ -21,7 +21,7 @@ Or directly:
 decibri = "4"
 ```
 
-The default feature set (`capture`, `playback`, `vad`, `ort-load-dynamic`) covers most use cases. See [Feature flags](#feature-flags) below for opt-in or trimmed configurations.
+The default feature set (`capture`, `playback`, `vad`, `denoise`, `gain`, `ort-load-dynamic`) covers most use cases. See [Feature flags](#feature-flags) below for opt-in or trimmed configurations.
 
 ## Quick start
 
@@ -88,6 +88,27 @@ for device in Microphone::devices()? {
 
 `Speaker::devices()` is the playback equivalent. The free functions `decibri::input_devices()` and `decibri::output_devices()` return the same lists.
 
+### decibri ACE: capture conditioning
+
+decibri ACE (Audio Capture Engine) is the opt-in conditioning chain on the capture path. `MicrophoneConfig` carries one field per stage; each defaults to off, so `MicrophoneConfig::default()` captures with no conditioning. The stages run in a fixed order after the device is normalized to the target mono rate: DC removal, denoise, high-pass, AGC, then limiter.
+
+```rust
+use decibri::{Microphone, MicrophoneConfig, DenoiseModel, HighpassFilter};
+
+let mut config = MicrophoneConfig::default();
+config.dc_removal = true;                            // 1. DC-blocking high-pass
+config.denoise = Some(DenoiseModel::FastEnhancerT);  // 2. speech-enhancement model
+config.denoise_model_path = Some("/path/to/fastenhancer_t.onnx".into()); // required for denoise to run
+config.highpass = Some(HighpassFilter::Hz80);        // 3. 80 Hz high-pass
+config.agc = Some(-18);                              // 4. AGC target, dBFS (-40..=-3)
+config.limiter = Some(-1.0);                         // 5. limiter ceiling, dBFS (-3.0..=0.0)
+
+let microphone = Microphone::new(config)?;
+let stream = microphone.start()?;
+```
+
+The denoise stage needs the `denoise` feature and an explicit `denoise_model_path`: the crate ships no model bytes, and with the model named but no path the denoise stage stays off. This is the one place the crate asks for more than the bindings do. The Python and Node.js packages bundle the denoise model and resolve its path for you, so there you pass only the model selector. `agc` and `limiter` need the `gain` feature (pure DSP, no model); `dc_removal` and `highpass` need no extra feature. The AGC target and limiter ceiling are validated in `MicrophoneConfig::validate`, so an out-of-range value is a typed error, not a silent clamp. The high-pass cutoff and the denoise model are named enums (`HighpassFilter`, `DenoiseModel`) so adding further cutoffs or models stays a non-breaking widening.
+
 ### Without ONNX Runtime
 
 If you do not need Silero VAD, disable the `vad` feature to drop the ONNX Runtime dependency entirely.
@@ -99,6 +120,8 @@ If you do not need Silero VAD, disable the `vad` feature to drop the ONNX Runtim
 | `capture` | on | Microphone input stream support |
 | `playback` | on | Speaker output stream support |
 | `vad` | on | Silero voice-activity detection (pulls in ONNX Runtime) |
+| `denoise` | on | Capture-path single-channel speech enhancement (pulls in ONNX Runtime; runs only alongside `capture`) |
+| `gain` | on | Capture-path AGC and peak limiter (pure DSP, no extra dependency) |
 | `ort-load-dynamic` | on | ONNX Runtime loaded at runtime from a path you control |
 | `ort-download-binaries` | off | ONNX Runtime downloaded at build time and embedded |
 

--- a/npm/decibri/README.md
+++ b/npm/decibri/README.md
@@ -82,12 +82,17 @@ Creates a Readable stream that captures from the microphone.
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `sampleRate` | number | 16000 | Samples per second (1000 to 384000) |
-| `channels` | number | 1 | Input channels (1 to 32) |
+| `channels` | number | 1 | Mono only: the only accepted value is `1`; a value greater than `1` throws a `RangeError` |
 | `framesPerBuffer` | number | 1600 | Frames per chunk (64 to 65536). At 16kHz mono, 1600 = 100ms = 3200 bytes |
 | `device` | number, string, or `{ id: string }` | system default | Device index, case-insensitive name substring, or stable per-host ID |
 | `dtype` | `'int16'` \| `'float32'` | `'int16'` | Sample encoding |
 | `vad` | `false` \| `'silero'` \| `'energy'` \| `VadOptions` | `false` | Voice activity detection: disabled, the Silero ML model, an RMS energy threshold, or a config object `{ model, threshold, holdoffMs }` to tune the policy |
 | `modelPath` | string | bundled model | Path to the Silero model. Only used when `vad` is `'silero'` |
+| `dcRemoval` | boolean | off | Remove a constant (DC) offset with a one-pole DC-blocking high-pass. Runs first in the chain; same-length, no added latency |
+| `denoise` | `'fastenhancer-t'` | off | Single-channel speech-enhancement (denoise) model. The model ships in the package; no path or download needed |
+| `highpass` | `80` \| `100` | off | High-pass cutoff in Hz (second-order Butterworth) that removes low-frequency rumble. Runs after denoise. Out-of-set values throw a `RangeError` |
+| `agc` | number | off | AGC target level in dBFS, an integer in -40 to -3 (typical -18). Runs after the high-pass. Out-of-range throws a `RangeError` |
+| `limiter` | number | off | Peak limiter ceiling in dBFS, a number in -3.0 to 0.0 (typical -1.0). Runs last. Out-of-range throws a `RangeError` |
 
 Standard `ReadableOptions` (e.g. `highWaterMark`) are also accepted.
 
@@ -281,6 +286,40 @@ mic.on('silence', () => console.log('silent'));
 ```
 
 The Silero model (~2MB) ships inside the npm package. No downloads or API keys required. Silero mode is Node.js only.
+
+## decibri ACE (audio conditioning)
+
+decibri ACE (Audio Capture Engine) is decibri's opt-in audio front-end for speech. It is a conditioning chain that runs on the captured audio before it reaches your `'data'` handler. Every stage is off by default, runs on-device, and needs no API key. With nothing enabled the capture path is byte-identical to plain capture.
+
+The stages run in a fixed order. Enable any subset:
+
+| Stage | Option | Range |
+| --- | --- | --- |
+| DC removal | `dcRemoval: true` | boolean |
+| Denoise | `denoise: 'fastenhancer-t'` | the one bundled model |
+| High-pass | `highpass: 80` or `100` | Hz |
+| AGC | `agc: -18` | dBFS, -40 to -3 |
+| Limiter | `limiter: -1.0` | dBFS, -3.0 to 0.0 |
+
+```javascript
+const { Microphone } = require('decibri');
+
+const mic = new Microphone({
+  sampleRate: 16000,
+  denoise: 'fastenhancer-t',   // bundled speech-enhancement model
+  highpass: 80,                // remove low-frequency rumble
+  agc: -18,                    // target level in dBFS
+  limiter: -1.0,               // peak ceiling in dBFS
+  vad: { model: 'silero', threshold: 0.5 },
+});
+
+mic.on('data', (chunk) => { /* Buffer of conditioned Int16 PCM */ });
+mic.on('speech', () => console.log('speech'));
+mic.on('silence', () => console.log('silence'));
+setTimeout(() => mic.stop(), 5000);
+```
+
+VAD reads the signal before the chain, so `vadScore` and the `'speech'` / `'silence'` events are unaffected by which conditioning stages you enable. The conditioning chain runs in the native Node.js capture path; the browser build does not include it.
 
 ## Device Selection
 


### PR DESCRIPTION
Add the opt-in capture-conditioning chain (dc_removal, denoise, highpass, agc, limiter) and the Vad config object to the root, npm, Python, and crate READMEs. Fix the stale npm channels row (mono only) and add the denoise and gain default features to the crate feature table.

Also ignore the python test and lint tool caches (.pytest_cache, .mypy_cache, .ruff_cache, .hypothesis) in the root .gitignore so they are deliberately ignored rather than only by tool-generated inner files.