### PR TITLE
chore: tidy source comments and fix the bundler doc

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -194,11 +194,11 @@ fn exception_class<'py>(py: Python<'py>, name: &'static str) -> PyResult<Bound<'
 // Error mapping: DecibriError -> PyErr.
 //
 // Covers all 34 variants explicitly. Catch-all `_ =>` arm at end is required
-// because DecibriError is #[non_exhaustive] (per F10).
+// because DecibriError is #[non_exhaustive].
 //
 // For variants with a `path` field (OrtLoadFailed, OrtPathInvalid,
 // VadModelLoadFailed, ModelLoadFailed), the mapper passes a tuple as the args
-// so the Python __init__ override can store named attributes per F11.
+// so the Python __init__ override can store named attributes.
 // ---------------------------------------------------------------------------
 
 type ExceptionRaiser = Box<dyn FnOnce(Bound<'_, PyType>) -> PyErr>;
@@ -399,7 +399,7 @@ fn to_py_err(py: Python<'_>, err: CoreDecibriError) -> PyErr {
             Box::new(move |cls| PyErr::from_type(cls, (msg,))),
         ),
 
-        // #[non_exhaustive] catch-all per F10. Fall through to the base class.
+        // #[non_exhaustive] catch-all. Fall through to the base class.
         _ => (
             "DecibriError",
             Box::new(move |cls| PyErr::from_type(cls, (msg,))),
@@ -424,7 +424,7 @@ fn path_to_string(path: &std::path::Path) -> String {
 // Format parsing helper.
 //
 // Accepts only "int16" and "float32". Returns DecibriError::InvalidFormat
-// (unit variant per F9) for any other string. The to_py_err mapper translates
+// (a unit variant) for any other string. The to_py_err mapper translates
 // that to the InvalidFormat Python exception with the canonical Display
 // message ("format must be 'int16' or 'float32'").
 // ---------------------------------------------------------------------------
@@ -1207,7 +1207,7 @@ impl MicrophoneBridge {
 // removing the module-level assertion.
 //
 // Owns:
-//   - output_config: SpeakerConfig (no frames_per_buffer per F2)
+//   - output_config: SpeakerConfig (no frames_per_buffer)
 //   - format: BindingSampleFormat
 //   - output: Option<Speaker>
 //   - stream: Option<SpeakerStream>
@@ -1712,8 +1712,8 @@ impl AsyncMicrophoneBridge {
 // drain on Python cancellation, so the audio finishes playing even after
 // the Python coroutine is cancelled. The Python coroutine sees
 // CancelledError immediately; the audio finishes asynchronously to the
-// caller's logic. Document this in the AsyncSpeaker.drain docstring
-// in the Python wrapper (next relay).
+// caller's logic. This is documented in the AsyncSpeaker.drain docstring
+// in the Python wrapper.
 // ---------------------------------------------------------------------------
 
 /// Owned bundle of (data, format, channels, numpy_flag) extracted from

--- a/bindings/python/tests/test_fork_safety.py
+++ b/bindings/python/tests/test_fork_safety.py
@@ -134,7 +134,7 @@ def test_fork_before_silero_init_works() -> None:
 
     The child does its own ORT init from scratch in its own address
     space; no inherited state to corrupt; no fork detection trips.
-    Sanity check that the C7 detection isn't over-eager.
+    Sanity check that the fork detection isn't over-eager.
     """
     ctx = mp.get_context("fork")
     queue: "mp.Queue[tuple[str, str]]" = ctx.Queue()

--- a/bindings/python/tests/test_lifecycle_leak.py
+++ b/bindings/python/tests/test_lifecycle_leak.py
@@ -1,12 +1,11 @@
-"""Soak / leak detection tests for the Microphone lifecycle (0.1.3 Tier 1).
+"""Soak / leak detection tests for the Microphone lifecycle.
 
 Bounded soak loops with tracemalloc + psutil RSS sampling. Catches leaks
 in the binding's wrapper layer (Python-allocated; tracemalloc) and in
 native allocations underneath cpal / pyo3 / ort (RSS via psutil).
 
-Tier classification: Tier 1 ("ship pre-0.2.0"; cheap; high-leverage) per
-prerelease-decibri-additional-testing-reqs.md Test 4. Bounded suite ships
-in 0.1.3; multi-hour soaks (Tier 3) defer past 0.2.0.
+Scope: this is the bounded, low-cost soak suite suitable for routine CI.
+Longer multi-hour soaks are out of scope here and run separately.
 
 Test design:
 
@@ -31,7 +30,7 @@ Runtime budget:
 - test_silero_vad_construct_destroy: ~10 seconds (ORT init dominates)
 
 Combined target: under 30 seconds. Combined with test_microphone_properties.py
-the 0.1.3 Tier 1 testing addition stays under the relay's 90-second budget.
+the two files stay comfortably within the suite's CI time budget.
 
 Threshold rationale:
 

--- a/bindings/python/tests/test_microphone_properties.py
+++ b/bindings/python/tests/test_microphone_properties.py
@@ -1,4 +1,4 @@
-"""Property-based tests for the Microphone constructor (0.1.3 Tier 1 testing).
+"""Property-based tests for the Microphone constructor.
 
 Hypothesis-driven coverage for Microphone constructor argument validation.
 The existing test_config.py uses pytest.parametrize for hand-curated cases
@@ -7,10 +7,9 @@ by generating random inputs against typed strategies and asserting that
 validation always lands on a typed decibri exception, never a panic / abort
 / untyped exception.
 
-Tier classification: Tier 1 ("ship pre-0.2.0"; cheap; high-leverage) per
-prerelease-decibri-additional-testing-reqs.md Test 3. The bounded variant
-ships in 0.1.3; broader VAD / format-conversion property tests defer to
-0.2.0 where synthetic-waveform fixtures land.
+Scope: this is the bounded, hardware-free property suite. Broader VAD and
+format-conversion property tests that need synthetic-waveform fixtures are
+out of scope here and covered separately.
 
 Validation layers (mirrors test_config.py docstring):
 
@@ -24,8 +23,8 @@ Validation layers (mirrors test_config.py docstring):
 
 Hypothesis settings: max_examples=20, deadline=None per test. Total file
 runtime is bounded under 30 seconds on a typical CI runner; combined with
-test_lifecycle_leak.py the 0.1.3 Tier 1 testing addition stays under the
-relay's 90-second total CI budget.
+test_lifecycle_leak.py the two files stay comfortably within the suite's CI
+time budget.
 
 PyO3 boundary note (carried from test_config.py): sample_rate /
 frames_per_buffer are u32; channels is u16. Negative Python ints would

--- a/bindings/python/tests/test_ort_bundling.py
+++ b/bindings/python/tests/test_ort_bundling.py
@@ -62,7 +62,7 @@ def clean_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 
 # ---------------------------------------------------------------------------
-# Tier 1: Resolver unit tests
+# Resolver unit tests
 # ---------------------------------------------------------------------------
 
 
@@ -192,7 +192,7 @@ def test_resolver_bundled_handles_hash_suffix(
 
 
 # ---------------------------------------------------------------------------
-# Tier 2: Wheel-content integration tests
+# Wheel-content integration tests
 # ---------------------------------------------------------------------------
 
 
@@ -249,7 +249,7 @@ def test_resolver_bundled_default(
 
 
 # ---------------------------------------------------------------------------
-# Tier 3: End-to-end construction smoke
+# End-to-end construction smoke
 # ---------------------------------------------------------------------------
 
 

--- a/crates/decibri/src/microphone.rs
+++ b/crates/decibri/src/microphone.rs
@@ -314,7 +314,7 @@ pub struct MicrophoneStream {
     reblock_buffer: Mutex<VecDeque<f32>>,
     // The capture stage chain, applied to each native block before it lands in
     // `reblock_buffer`. `None` when no conditioning is needed (an already-mono
-    // device), keeping the drain on the direct, zero-cost A0b path. When `Some`,
+    // device), keeping the drain on the direct, zero-cost no-chain path. When `Some`,
     // the chain runs behind its own `Mutex` so the stage buffers mutate under a
     // shared `&self` while the type stays `Send + Sync` (a `CaptureStage` is
     // `Send`, so `Mutex<CaptureStage>` is `Send + Sync`).
@@ -597,7 +597,7 @@ impl MicrophoneStream {
     /// capture stage chain first when one is present.
     ///
     /// `None` chain: the block's samples are appended directly, byte-identical to
-    /// the A0b path, with no lock, allocation, or copy beyond the existing
+    /// the direct no-chain path, with no lock, allocation, or copy beyond the existing
     /// reblock. `Some` chain: the chain runs behind its `Mutex` and its
     /// conditioned output is appended instead.
     ///
@@ -989,7 +989,7 @@ mod tests {
         (stream, sender, running)
     }
 
-    /// Mono stream with no stage chain (the `None`, A0b-identical path).
+    /// Mono stream with no stage chain (the `None`, no-chain path).
     fn test_stream() -> (MicrophoneStream, Sender<AudioChunk>, Arc<AtomicBool>) {
         test_stream_with(None, 1)
     }
@@ -1300,7 +1300,7 @@ mod tests {
 
     /// Empty-chain no-op (the `None` path): with no stage chain (a mono device),
     /// `next_chunk` delivers the raw reblocked samples byte-identically to the
-    /// A0b path, exact size and final-tail behaviour included.
+    /// direct no-chain path, exact size and final-tail behaviour included.
     #[test]
     fn test_empty_chain_is_byte_identical_noop() {
         let (stream, sender, running) = test_stream(); // mono, capture_stage = None
@@ -1324,7 +1324,7 @@ mod tests {
                 Err(e) => panic!("unexpected error: {e}"),
             }
         }
-        // None path == A0b reblock: 9 samples -> two blocks of 4 then a 1-sample
+        // None path (direct reblock): 9 samples -> two blocks of 4 then a 1-sample
         // tail, every value passed through untransformed and in order.
         assert_eq!(collected, (0..9).map(|n| n as f32).collect::<Vec<f32>>());
     }
@@ -1332,7 +1332,7 @@ mod tests {
     /// Cost no-op (the `None` path): a mono device builds no chain, so the drain
     /// stays on the direct reblock. The `None` arm of `ingest` is a plain
     /// `buf.extend(chunk.data)` with no chain lock, allocation, or copy,
-    /// structurally identical to A0b.
+    /// structurally identical to the direct no-chain path.
     #[test]
     fn test_mono_device_builds_no_chain() {
         assert!(

--- a/crates/decibri/src/vad.rs
+++ b/crates/decibri/src/vad.rs
@@ -347,7 +347,7 @@ mod tests {
     use crate::onnx::{OnnxOutputTensor, OnnxOutputs};
     use std::path::Path;
 
-    // ---- F7: malformed model output must surface a typed error, not panic ----
+    // ---- malformed model output must surface a typed error, not panic ----
 
     /// A mock session returning caller-specified `output`/`stateN` tensors, to
     /// exercise `infer_window`'s malformed-output paths without ORT.

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -159,7 +159,7 @@ Error message wording on shipped `DecibriError` variants has historically been s
 
 ## [3.3.0] - 2026-04-23
 
-Groundwork release for upcoming P3 Python bindings. Adds a stable-ID form for audio device selection (`DeviceSelector::Id`), fixes a long-standing direction bug in `DecibriError::DeviceNotFound` when resolving output devices, exposes both in the Node binding, and extends the reference documentation with a Cargo feature flag guide plus additional crate-level rustdoc. No Node.js or browser API break. Direct Rust crate consumers pattern-matching on `DeviceSelector` or struct-literal-constructing `DeviceInfo` / `OutputDeviceInfo` need to update for the new `#[non_exhaustive]` attributes (see Migration notes below).
+Groundwork release for upcoming Python bindings. Adds a stable-ID form for audio device selection (`DeviceSelector::Id`), fixes a long-standing direction bug in `DecibriError::DeviceNotFound` when resolving output devices, exposes both in the Node binding, and extends the reference documentation with a Cargo feature flag guide plus additional crate-level rustdoc. No Node.js or browser API break. Direct Rust crate consumers pattern-matching on `DeviceSelector` or struct-literal-constructing `DeviceInfo` / `OutputDeviceInfo` need to update for the new `#[non_exhaustive]` attributes (see Migration notes below).
 
 ### Changed
 
@@ -182,7 +182,7 @@ Groundwork release for upcoming P3 Python bindings. Adds a stable-ID form for au
 ### Internal
 
 - `DeviceDirection` trait gains a `not_found_error(String) -> DecibriError` method so `resolve_device_generic`'s `Name` and `Id` arms produce direction-correct errors via the `Input` / `Output` impls.
-- Unit tests for `Arc<Mutex<CaptureStream>>` confirming the wrapping is `Send + Sync` (compile-time assertion) and serializes concurrent access across two threads (runtime test with `Barrier`). Documents the wrapping strategy the P3 Python binding will apply to share `!Sync` capture streams across Python threads.
+- Unit tests for `Arc<Mutex<CaptureStream>>` confirming the wrapping is `Send + Sync` (compile-time assertion) and serializes concurrent access across two threads (runtime test with `Barrier`). Documents the wrapping strategy the Python binding will apply to share `!Sync` capture streams across Python threads.
 - Crate-level rustdoc additions in `lib.rs`: a section on ORT error construction FFI side effects (the `ortsys![CreateStatus]` dylib-load trigger that motivates the `OrtPathInvalid` split from `OrtLoadFailed`) and a section on fork safety (guidance for Python `multiprocessing` consumers to use `spawn` start method).
 - `lib.rs` rustdoc "Feature flags" section cross-references `docs/features.md` for consumers wanting the deep-dive reference.
 - Em-dash cleanup across 19 code locations in `lib.rs`, `capture.rs`, `output.rs`, `vad.rs`, `error.rs`, `vad_integration.rs`, and `vad_ort_load_failure.rs`. Per CLAUDE.md, the codebase forbids em dashes; these were pre-existing violations.

--- a/npm/decibri/examples/README.md
+++ b/npm/decibri/examples/README.md
@@ -71,9 +71,10 @@ npx localtunnel --port 8080
 ### Regenerating the browser bundle
 
 `decibri.browser.js` is generated from the package's browser entry
-(`../src/browser/index.js`). Regenerate it after changing the browser source
-with any bundler that resolves the package's `browser` entry, for example:
+(`../src/browser/index.js`) with rolldown, the bundler used to produce the
+checked-in build. Regenerate it after changing the browser source so the
+bundle stays in sync:
 
 ```bash
-npx esbuild ../src/browser/index.js --bundle --format=iife --global-name=decibri --outfile=decibri.browser.js
+npx rolldown ../src/browser/index.js --format iife --name decibri --file decibri.browser.js
 ```


### PR DESCRIPTION
Reword internal comments, test docstrings, and a changelog note to plain public-facing wording. Fix examples/README.md to document the real browser-bundle regeneration command (rolldown, the bundler that built the checked-in decibri.browser.js).

Comment and doc only; no behavior change.