### PR TITLE
chore(release): 5.0.0 (npm, crate) and 0.5.0 (python)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "decibri"
-version = "4.3.2"
+version = "5.0.0"
 dependencies = [
  "cpal",
  "crossbeam-channel",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "decibri-node"
-version = "4.3.2"
+version = "5.0.0"
 dependencies = [
  "decibri",
  "napi",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "decibri-python"
-version = "4.3.2"
+version = "5.0.0"
 dependencies = [
  "decibri",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.3.2"
+version = "5.0.0"
 edition = "2021"
 # MSRV empirically verified 2026-04-22: rustc 1.88 is the minimum version
 # that compiles the workspace. Floors: ort 2.0.0-rc.12 declares

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -8,7 +8,7 @@ For Rust core (`crates/decibri`) and npm binding (`bindings/node`) changes, see 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2026-06-24
 
 ### Added
 

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -28,7 +28,7 @@ crate-type = ["cdylib"]
 # features across both bindings silently; diverging overrides produce a build
 # that neither binding tests in isolation. Both bindings inherit decibri's
 # default features (capture, playback, vad, denoise, gain, ort-load-dynamic).
-decibri = { version = "4.3", path = "../../crates/decibri" }
+decibri = { version = "5.0", path = "../../crates/decibri" }
 
 # PyO3 0.29 line (MSRV 1.83, below the workspace 1.88 floor, so headroom is
 # preserved). Bumped from 0.28 to take the RUSTSEC-2026-0176 and -0177 fixes,

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "decibri"
-version = "0.4.3"
+version = "0.5.0"
 description = "Cross-platform audio capture, playback, and voice activity detection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/python/python/decibri/__init__.py
+++ b/bindings/python/python/decibri/__init__.py
@@ -57,7 +57,7 @@ from decibri.exceptions import (
     VadThresholdOutOfRange,
 )
 
-__version__ = "0.4.3"
+__version__ = "0.5.0"
 
 
 def input_devices() -> list[MicrophoneInfo]:

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -472,7 +472,7 @@ fn build_version_info() -> VersionInfo {
     VersionInfo {
         decibri: env!("CARGO_PKG_VERSION").to_string(),
         audio_backend: format!("cpal {}", CPAL_VERSION),
-        binding: "0.4.3".to_string(),
+        binding: "0.5.0".to_string(),
     }
 }
 

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -16,7 +16,7 @@ import decibri
 
 
 def test_package_imports() -> None:
-    assert decibri.__version__ == "0.4.3"
+    assert decibri.__version__ == "0.5.0"
     # The bridges are hidden behind the private _decibri module. They are
     # NOT accessible at decibri.<X> top level (sync or async). The async
     # pair was never accessible at the top level; the sync pair
@@ -54,7 +54,7 @@ def test_version_decibri_matches_rust_core() -> None:
     # Literal equality is intentional. When the Rust workspace bumps past
     # 4.0.0 this assertion breaks deliberately, to force a conscious update of
     # the Python expectation alongside the Rust version bump.
-    assert _decibri.MicrophoneBridge.version().decibri == "4.3.2"
+    assert _decibri.MicrophoneBridge.version().decibri == "5.0.0"
 
 
 def test_version_audio_backend_matches_cpal() -> None:
@@ -70,9 +70,9 @@ def test_version_info_fields() -> None:
     from decibri import _decibri
 
     info = _decibri.MicrophoneBridge.version()
-    assert info.decibri == "4.3.2"
+    assert info.decibri == "5.0.0"
     assert info.audio_backend == "cpal 0.17"
-    assert info.binding == "0.4.3"
+    assert info.binding == "0.5.0"
 
 
 def test_version_info_is_frozen() -> None:

--- a/bindings/python/tests/test_wheel_smoke.py
+++ b/bindings/python/tests/test_wheel_smoke.py
@@ -29,7 +29,7 @@ def test_import_decibri() -> None:
     """The package imports successfully from the installed wheel."""
     assert decibri is not None
     assert hasattr(decibri, "__version__")
-    assert decibri.__version__ == "0.4.3"
+    assert decibri.__version__ == "0.5.0"
 
 
 def test_construct_decibri_default() -> None:

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -27,7 +27,7 @@ wheels = [
 
 [[package]]
 name = "decibri"
-version = "0.4.3"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions" },

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -9,7 +9,7 @@ For other decibri packages, see:
 - npm package: [npm/decibri/CHANGELOG.md](../../npm/decibri/CHANGELOG.md)
 - Python package: [bindings/python/CHANGELOG.md](../../bindings/python/CHANGELOG.md)
 
-## [Unreleased]
+## [5.0.0] - 2026-06-24
 
 ### Added
 

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -9,7 +9,7 @@ For other decibri packages, see:
 - Rust crate: [crates/decibri/CHANGELOG.md](../../crates/decibri/CHANGELOG.md)
 - Python wheel: [bindings/python/CHANGELOG.md](../../bindings/python/CHANGELOG.md)
 
-## [Unreleased]
+## [5.0.0] - 2026-06-24
 
 ### Added
 

--- a/npm/decibri/examples/decibri.browser.js
+++ b/npm/decibri/examples/decibri.browser.js
@@ -70,7 +70,7 @@ var decibri = (function() {
 	var require_decibri_browser = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		const { Emitter } = require_emitter();
 		const { WORKLET_SOURCE } = require_worklet_inline();
-		const VERSION = "4.4.2";
+		const VERSION = "5.0.0";
 		/**
 		* Browser microphone capture.
 		*

--- a/npm/decibri/package.json
+++ b/npm/decibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decibri",
-  "version": "4.4.2",
+  "version": "5.0.0",
   "description": "Cross-platform audio capture, playback, and processing for Node.js and browsers",
   "main": "src/decibri.js",
   "types": "src/decibri.d.ts",
@@ -72,10 +72,10 @@
     "MIGRATION.md"
   ],
   "optionalDependencies": {
-    "@decibri/decibri-win32-x64-msvc": "4.4.2",
-    "@decibri/decibri-darwin-arm64": "4.4.2",
-    "@decibri/decibri-linux-x64-gnu": "4.4.2",
-    "@decibri/decibri-linux-arm64-gnu": "4.4.2"
+    "@decibri/decibri-win32-x64-msvc": "5.0.0",
+    "@decibri/decibri-darwin-arm64": "5.0.0",
+    "@decibri/decibri-linux-x64-gnu": "5.0.0",
+    "@decibri/decibri-linux-arm64-gnu": "5.0.0"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.7.0"

--- a/npm/decibri/src/browser/decibri-browser.js
+++ b/npm/decibri/src/browser/decibri-browser.js
@@ -6,7 +6,7 @@ const { WORKLET_SOURCE } = require('./worklet-inline.js');
 // Browser build version. Keep in sync with package.json on each release; the
 // browser bundle cannot read package.json at runtime the way the Node wrapper
 // does, so this is a maintained constant.
-const VERSION = '4.4.2';
+const VERSION = '5.0.0';
 
 /**
  * Browser microphone capture.

--- a/npm/platform-darwin-arm64/package.json
+++ b/npm/platform-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-darwin-arm64",
-  "version": "4.4.2",
+  "version": "5.0.0",
   "os": ["darwin"],
   "cpu": ["arm64"],
   "main": "decibri.darwin-arm64.node",

--- a/npm/platform-linux-arm64-gnu/package.json
+++ b/npm/platform-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-arm64-gnu",
-  "version": "4.4.2",
+  "version": "5.0.0",
   "os": ["linux"],
   "cpu": ["arm64"],
   "main": "decibri.linux-arm64-gnu.node",

--- a/npm/platform-linux-x64-gnu/package.json
+++ b/npm/platform-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-x64-gnu",
-  "version": "4.4.2",
+  "version": "5.0.0",
   "os": ["linux"],
   "cpu": ["x64"],
   "main": "decibri.linux-x64-gnu.node",

--- a/npm/platform-win32-x64-msvc/package.json
+++ b/npm/platform-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-win32-x64-msvc",
-  "version": "4.4.2",
+  "version": "5.0.0",
   "os": ["win32"],
   "cpu": ["x64"],
   "main": "decibri.win32-x64-msvc.node",


### PR DESCRIPTION
Bump the Rust workspace to 5.0.0 (crate decibri plus the decibri-node and decibri-python crates), npm to 5.0.0 (main package, its four optionalDependencies pins, and the four platform packages), and the Python wheel to 0.5.0 (pyproject, __version__, the VersionInfo.binding Rust mirror, and the five wheel/core version test assertions). Widen the python crate's path-dep range to 5.0 so the workspace lints. Regenerate Cargo.lock, uv.lock, and the rolldown browser bundle (VERSION 5.0.0). Finalize the three changelogs by renaming the Unreleased headers to the cut versions dated 2026-06-24. All breaking changes for 5.0 were banked in prior commits; this is the version bump only.
