### PR TITLE
Add CLA enforcement workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,19 @@
+name: CLA
+on:
+  pull_request_target:
+    types: [opened, synchronize, closed]
+  issue_comment:
+    types: [created]
+
+permissions:
+  checks: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: decibri/decibri-cla-action@v1
+        with:
+          store-token: ${{ secrets.CLA_STORE_TOKEN }}


### PR DESCRIPTION
Adds .github/workflows/cla.yml, the caller that runs decibri/decibri-cla-action on pull_request_target and issue_comment. Includes the required permissions block. After this merges, the CLA check will run on PRs; it is armed once the CLA check is marked required in the repo ruleset.