### PR TITLE
ci: run npm publish and node jobs on node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
           shared-key: "rust"
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json
@@ -149,7 +149,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - name: Install vitest

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -125,7 +125,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Platform setup
         if: matrix.setup
@@ -276,7 +276,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm for trusted publishing

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -6,9 +6,10 @@ name: Publish to PyPI
 #
 # Tag namespacing per LD-10-11 (Option 1, approved 2026-05-02):
 #   python-v0.1.0a1, python-v0.1.0     -> this workflow
-#   v3.4.0, v3.5.0                     -> release.yml (npm + crates.io)
-# release.yml's tag filter excludes 'python-v*' so the two workflows
-# never fire on the same tag.
+#   npm-v5.0.0                         -> publish-npm.yml (npm)
+#   crate-v5.0.0                       -> publish-crates.yml (crates.io)
+# Every publish workflow's tag filter is prefix-namespaced, so no two
+# publish workflows ever fire on the same tag.
 #
 # Design adjudication: Option D from phase-10-design-adjudication.md.
 # Tag-routed publish workflow that mirrors python-ci.yml's existing
@@ -46,10 +47,10 @@ permissions:
 
 env:
   # Single source of truth for the bundled ONNX Runtime version.
-  # MUST stay in sync with .github/workflows/python-ci.yml (line 52)
-  # and .github/workflows/release.yml (line 20). Updating ORT requires
-  # bumping all three workflows in lockstep per the workspace Cargo.toml
-  # maintainer comment.
+  # MUST stay in sync with .github/workflows/python-ci.yml and
+  # .github/workflows/publish-npm.yml (their workflow-level env blocks).
+  # Updating ORT requires bumping all three workflows in lockstep per
+  # the workspace Cargo.toml maintainer comment.
   ORT_VERSION: 1.24.4
   # Required for maturin abi3 builds on Python 3.14 hosts targeting py310
   # abi3. See PyO3 issue #5505. Workflow-level setting applies to every

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -43,12 +43,12 @@ env:
   # hosts and only takes effect for the 3.14 entries.
   PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
   # Single source of truth for the bundled ONNX Runtime version, mirroring
-  # release.yml's pattern (release.yml line 20). Read by the per-platform
-  # preflight + download steps below. Also parsed by check-upstream.yml's
-  # ONNX Runtime drift check (the workflow greps release.yml for
-  # ORT_VERSION; the Python wheel pipeline pins to the same value here).
-  # Update in lockstep with release.yml at every ort-crate upgrade per the
-  # workspace Cargo.toml maintainer comment (steps 2 and 3 of that comment).
+  # publish-npm.yml's pattern (its workflow-level env block). Read by the
+  # per-platform preflight + download steps below. Also parsed by
+  # check-upstream.yml's ONNX Runtime drift check (the workflow greps
+  # publish-npm.yml for ORT_VERSION; the wheel pipeline pins to the same
+  # value here). Update in lockstep with publish-npm.yml at every ort-crate
+  # upgrade per the workspace Cargo.toml maintainer comment (steps 2 and 3).
   ORT_VERSION: 1.24.4
   # Phase 7 wheel size thresholds. Soft warning continues the Phase 3
   # alarm (150 MB; today's bundled wheel is ~30 to 50 MB). Hard fail at


### PR DESCRIPTION
npm install -g npm@latest now installs npm 12, which requires Node >= 22. The publish job in publish-npm.yml ran on Node 20, so the npm leg failed at the toolchain step, before any of the five npm packages published, while the independently tag-triggered crates.io and PyPI legs would still go out. Bumping the publish job to Node 22 fixes the trap and keeps the trusted-publishing npm floor (>= 11.5.1) satisfied via npm 12.

The build, test-node, and test-browser jobs move to Node 22 for consistency; they were not the trap (no npm CLI upgrade), but Node 20 is aging out. No version change and no published-artifact change; the native napi addons remain ABI-compatible with the consumer engines floor of >=18, which is unchanged.

Also corrects stale header comments in python-ci.yml and publish-pypi.yml that referenced the retired release.yml, which was split into publish-npm.yml and publish-crates.yml.