### PR TITLE
chore(release): 5.1.0 (npm, crate) and 0.6.0 (python)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "decibri"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "cpal",
  "crossbeam-channel",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "decibri-node"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "decibri",
  "napi",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "decibri-python"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "decibri",
  "numpy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,7 @@ dependencies = [
  "cpal",
  "crossbeam-channel",
  "decibri-resampler",
+ "libloading",
  "ort",
  "thiserror 2.0.18",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "5.0.0"
+version = "5.1.0"
 edition = "2021"
 # MSRV empirically verified 2026-04-22: rustc 1.88 is the minimum version
 # that compiles the workspace. Floors: ort 2.0.0-rc.12 declares

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -8,7 +8,7 @@ For Rust core (`crates/decibri`) and npm binding (`bindings/node`) changes, see 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.0] - Unreleased
+## [0.6.0] - 2026-07-17
 
 ### Added
 

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -28,7 +28,7 @@ crate-type = ["cdylib"]
 # features across both bindings silently; diverging overrides produce a build
 # that neither binding tests in isolation. Both bindings inherit decibri's
 # default features (capture, playback, vad, denoise, gain, ort-load-dynamic).
-decibri = { version = "5.0", path = "../../crates/decibri" }
+decibri = { version = "5.1", path = "../../crates/decibri" }
 
 # PyO3 0.29 line (MSRV 1.83, below the workspace 1.88 floor, so headroom is
 # preserved). Bumped from 0.28 to take the RUSTSEC-2026-0176 and -0177 fixes,

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "decibri"
-version = "0.5.0"
+version = "0.6.0"
 description = "Cross-platform audio capture, playback, and voice activity detection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/python/python/decibri/__init__.py
+++ b/bindings/python/python/decibri/__init__.py
@@ -69,7 +69,7 @@ from decibri.exceptions import (
     WavInvalid,
 )
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 
 def input_devices() -> list[MicrophoneInfo]:

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -490,7 +490,7 @@ fn build_version_info() -> VersionInfo {
     VersionInfo {
         decibri: env!("CARGO_PKG_VERSION").to_string(),
         audio_backend: format!("cpal {}", CPAL_VERSION),
-        binding: "0.5.0".to_string(),
+        binding: "0.6.0".to_string(),
     }
 }
 

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -16,7 +16,7 @@ import decibri
 
 
 def test_package_imports() -> None:
-    assert decibri.__version__ == "0.5.0"
+    assert decibri.__version__ == "0.6.0"
     # The bridges are hidden behind the private _decibri module. They are
     # NOT accessible at decibri.<X> top level (sync or async). The async
     # pair was never accessible at the top level; the sync pair
@@ -54,7 +54,7 @@ def test_version_decibri_matches_rust_core() -> None:
     # Literal equality is intentional. When the Rust workspace bumps past
     # 4.0.0 this assertion breaks deliberately, to force a conscious update of
     # the Python expectation alongside the Rust version bump.
-    assert _decibri.MicrophoneBridge.version().decibri == "5.0.0"
+    assert _decibri.MicrophoneBridge.version().decibri == "5.1.0"
 
 
 def test_version_audio_backend_matches_cpal() -> None:
@@ -70,9 +70,9 @@ def test_version_info_fields() -> None:
     from decibri import _decibri
 
     info = _decibri.MicrophoneBridge.version()
-    assert info.decibri == "5.0.0"
+    assert info.decibri == "5.1.0"
     assert info.audio_backend == "cpal 0.17"
-    assert info.binding == "0.5.0"
+    assert info.binding == "0.6.0"
 
 
 def test_version_info_is_frozen() -> None:

--- a/bindings/python/tests/test_wheel_smoke.py
+++ b/bindings/python/tests/test_wheel_smoke.py
@@ -29,7 +29,7 @@ def test_import_decibri() -> None:
     """The package imports successfully from the installed wheel."""
     assert decibri is not None
     assert hasattr(decibri, "__version__")
-    assert decibri.__version__ == "0.5.0"
+    assert decibri.__version__ == "0.6.0"
 
 
 def test_construct_decibri_default() -> None:

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -27,7 +27,7 @@ wheels = [
 
 [[package]]
 name = "decibri"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions" },

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -9,7 +9,7 @@ For other decibri packages, see:
 - npm package: [npm/decibri/CHANGELOG.md](../../npm/decibri/CHANGELOG.md)
 - Python package: [bindings/python/CHANGELOG.md](../../bindings/python/CHANGELOG.md)
 
-## [5.1.0] - Unreleased
+## [5.1.0] - 2026-07-17
 
 ### Added
 

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -11,6 +11,10 @@ For other decibri packages, see:
 
 ## [5.1.0] - 2026-07-17
 
+### Fixed
+
+- Guard the ONNX Runtime load when no library path is configured, so a missing or unresolvable runtime fails with a clear error instead of hanging inside the load.
+
 ### Added
 
 - `File`, an offline source: conditions a WAV recording (`File::open`, with the `File::new` alias) or in-memory samples (`File::buffer`) through the same chain as live capture, delivered as a finite iterator of conditioned chunks that ends after the chain's end-of-stream tail. WAV support covers 16-bit PCM and 32-bit float; no decode dependency is added.

--- a/crates/decibri/Cargo.toml
+++ b/crates/decibri/Cargo.toml
@@ -45,7 +45,7 @@ gain = []
 
 # ORT distribution mode (mutually exclusive; pick exactly one).
 # A compile_error! guard in src/lib.rs enforces the exclusivity.
-ort-load-dynamic = ["ort?/load-dynamic"]
+ort-load-dynamic = ["ort?/load-dynamic", "dep:libloading"]
 ort-download-binaries = ["ort?/download-binaries", "ort?/tls-native"]
 
 # Execution-provider passthrough features. Off by default.
@@ -63,6 +63,11 @@ ort = { workspace = true, optional = true }
 # Capture-path resampler: converts a device's native sample rate to the
 # requested target rate. Optional, pulled by the `capture` feature only.
 decibri-resampler = { version = "0.2", optional = true }
+# System-loader probe for the ORT pre-check under `ort-load-dynamic`: verifies
+# the runtime library is resolvable before `ort::init()` runs, turning a
+# potential hang into a clean typed error. Already in the tree via `ort`
+# (which loads through the same crate), so this adds no new build input.
+libloading = { version = "0.9", optional = true }
 
 # Auto-discovered example targets that use a feature-gated module must declare
 # the feature they need, so cargo skips them when that feature is off instead of

--- a/crates/decibri/src/onnx.rs
+++ b/crates/decibri/src/onnx.rs
@@ -75,6 +75,84 @@ pub(crate) enum ExecutionProvider {
 // the process-global state. This is a relocation of the machinery that
 // previously lived in `vad.rs`; the first-wins semantics are unchanged.
 
+/// The platform library name ONNX Runtime's default loader resolves when no
+/// explicit path is configured, used by the pre-check in [`init_ort_once`] to
+/// probe the system loader before `ort::init()` runs. Matches the names the
+/// packages bundle per platform.
+#[cfg(all(feature = "ort-load-dynamic", target_os = "windows"))]
+const ORT_DEFAULT_LIBRARY: &str = "onnxruntime.dll";
+
+#[cfg(all(feature = "ort-load-dynamic", target_os = "macos"))]
+const ORT_DEFAULT_LIBRARY: &str = "libonnxruntime.dylib";
+
+#[cfg(all(
+    feature = "ort-load-dynamic",
+    not(any(target_os = "windows", target_os = "macos"))
+))]
+const ORT_DEFAULT_LIBRARY: &str = "libonnxruntime.so";
+
+/// The candidate `path` resolved against the executable's directory,
+/// mirroring ort's own resolution, which tries that placement before the
+/// bare path. `None` when the executable's location is unavailable.
+#[cfg(feature = "ort-load-dynamic")]
+fn exe_sibling(path: &Path) -> Option<PathBuf> {
+    Some(std::env::current_exe().ok()?.parent()?.join(path))
+}
+
+/// The on-disk location of an already-loaded module, by its load name.
+/// Queries the loader directly (`GetModuleHandleW` does not change the
+/// module's reference count), so the probe's `Library` handle stays intact.
+#[cfg(all(feature = "ort-load-dynamic", target_os = "windows"))]
+fn windows_module_path(name: &str) -> Option<PathBuf> {
+    use std::os::windows::ffi::OsStringExt;
+
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn GetModuleHandleW(name: *const u16) -> *mut core::ffi::c_void;
+        fn GetModuleFileNameW(module: *mut core::ffi::c_void, filename: *mut u16, size: u32)
+            -> u32;
+    }
+
+    let wide: Vec<u16> = name.encode_utf16().chain(std::iter::once(0)).collect();
+    // SAFETY: both calls take only the pointers passed here; `wide` is a
+    // valid NUL-terminated wide string and `buf` a writable buffer whose
+    // length is passed alongside it.
+    unsafe {
+        let module = GetModuleHandleW(wide.as_ptr());
+        if module.is_null() {
+            return None;
+        }
+        let mut buf = [0u16; 1024];
+        let len = GetModuleFileNameW(module, buf.as_mut_ptr(), buf.len() as u32);
+        if len == 0 || len as usize >= buf.len() {
+            return None;
+        }
+        Some(PathBuf::from(std::ffi::OsString::from_wide(
+            &buf[..len as usize],
+        )))
+    }
+}
+
+/// Whether a resolved module path is the Windows in-box ONNX Runtime (the
+/// Windows ML copy under System32 or SysWOW64), which is not the API version
+/// `ort` requires and hangs the load if used.
+#[cfg(all(feature = "ort-load-dynamic", target_os = "windows"))]
+fn windows_in_box_runtime(resolved: &Path) -> bool {
+    let Some(system_root) = std::env::var_os("SystemRoot") else {
+        return false;
+    };
+    let resolved = resolved.as_os_str().to_string_lossy().to_lowercase();
+    let root = PathBuf::from(system_root)
+        .as_os_str()
+        .to_string_lossy()
+        .to_lowercase();
+    // Trim any trailing separator so a root-drive SystemRoot ("C:\") does
+    // not produce a doubled backslash that would never match.
+    let root = root.trim_end_matches('\\');
+    resolved.starts_with(&format!("{root}\\system32\\"))
+        || resolved.starts_with(&format!("{root}\\syswow64\\"))
+}
+
 /// Process-global ORT init tracker. Stores the library path used on first
 /// successful init (None if init used `ort::init()` with env-var fallback).
 /// Subsequent `init_ort_once` calls see this as populated and return immediately.
@@ -162,30 +240,116 @@ pub(crate) fn init_ort_once(path: Option<&Path>) -> Result<(), DecibriError> {
         return Ok(());
     }
 
-    // Defensive pre-check (load-dynamic only): verify the path points at a
-    // regular file before handing it to `ort::init_from`. A nonexistent path
-    // or a path that points at a directory causes `ort::init_from` on Windows
-    // to hang indefinitely (reproduced 2026-04-22 against pyke/ort
-    // 2.0.0-rc.12 + onnxruntime 1.24.4). Failing fast here turns that hang
-    // into a clean typed error that Node, Python, and mobile consumers can
-    // surface to users.
+    // Defensive pre-check (load-dynamic only): verify the runtime ORT would
+    // load is actually there before handing control to ORT. A failing ORT
+    // load hangs indefinitely on Windows instead of erroring (reproduced
+    // 2026-04-22 against pyke/ort 2.0.0-rc.12 + onnxruntime 1.24.4 for an
+    // invalid `ort::init_from` path, and 2026-07-17 for `ort::init()` with
+    // no resolvable runtime at all), because constructing the failure's
+    // `ort::Error` itself re-triggers the dylib load. Failing fast here
+    // turns that hang into a clean typed error that Node, Python, and
+    // mobile consumers can surface to users.
+    //
+    // Both branches are covered:
+    // - `Some(path)`: the path must be a regular file before it reaches
+    //   `ort::init_from`.
+    // - `None`: `ort::init()` resolves the runtime itself, from the
+    //   `ORT_DYLIB_PATH` environment variable when set, otherwise from the
+    //   platform library name through the system loader. Pre-validate the
+    //   same resolution: a set `ORT_DYLIB_PATH` must point at a regular
+    //   file, and with the variable unset the system loader must actually
+    //   resolve the platform library (probed through `libloading`, the same
+    //   loader `ort` itself uses, which returns an error rather than
+    //   hanging). A successful probe keeps the library resident, the state
+    //   `ort::init()` produces anyway.
     //
     // The check is intentionally scoped to `load-dynamic`: under
-    // `download-binaries`, ORT is statically linked and the path argument
-    // is ignored, so there is nothing to pre-validate.
+    // `download-binaries`, ORT is statically linked and there is nothing to
+    // pre-validate.
     #[cfg(feature = "ort-load-dynamic")]
-    if let Some(p) = path {
-        if !p.is_file() {
-            // Use `OrtPathInvalid`, not `OrtLoadFailed`, precisely because
-            // constructing an `ort::Error` here would call `ortsys![
-            // CreateStatus]`, which triggers the ORT dylib load that this
-            // pre-check is designed to prevent. `OrtPathInvalid` is
-            // string-only and never touches ORT symbols.
-            return Err(DecibriError::OrtPathInvalid {
-                path: p.to_path_buf(),
-                reason: "path does not exist or is not a regular file",
-            });
+    match path {
+        Some(p) => {
+            if !p.is_file() {
+                // Use `OrtPathInvalid`, not `OrtLoadFailed`, precisely because
+                // constructing an `ort::Error` here would call `ortsys![
+                // CreateStatus]`, which triggers the ORT dylib load that this
+                // pre-check is designed to prevent. `OrtPathInvalid` is
+                // string-only and never touches ORT symbols.
+                return Err(DecibriError::OrtPathInvalid {
+                    path: p.to_path_buf(),
+                    reason: "path does not exist or is not a regular file",
+                });
+            }
         }
+        // Mirror ort's own resolution for the no-path case so this
+        // pre-check never rejects a configuration ort would load: a
+        // set-but-empty or non-Unicode ORT_DYLIB_PATH counts as unset
+        // (exactly as ort treats it), and every candidate is also resolved
+        // against the executable's directory (ort checks that placement
+        // first; the system loader does not search it on Linux or macOS).
+        None => match std::env::var("ORT_DYLIB_PATH")
+            .ok()
+            .filter(|value| !value.is_empty())
+        {
+            Some(env_path) => {
+                let env_path = PathBuf::from(env_path);
+                let exe_relative = exe_sibling(&env_path);
+                if !env_path.is_file() && !exe_relative.as_deref().is_some_and(Path::is_file) {
+                    return Err(DecibriError::OrtPathInvalid {
+                        path: env_path,
+                        reason: "ORT_DYLIB_PATH does not point to a regular file",
+                    });
+                }
+            }
+            None => match unsafe { libloading::Library::new(ORT_DEFAULT_LIBRARY) } {
+                Ok(library) => {
+                    // Windows ships an in-box `onnxruntime.dll` in System32
+                    // (the Windows ML copy). The loader searches System32
+                    // before PATH, so a bare-name load resolves that copy on
+                    // any host without a runtime earlier in the search order,
+                    // and its API version is not the one `ort` requires:
+                    // proceeding hangs exactly like a missing runtime does.
+                    // decibri's documented resolution (the bundled library or
+                    // ORT_DYLIB_PATH) never means the in-box copy, so reject
+                    // it as unusable rather than letting `ort::init()` hang
+                    // on it.
+                    #[cfg(target_os = "windows")]
+                    if let Some(resolved) = windows_module_path(ORT_DEFAULT_LIBRARY) {
+                        if windows_in_box_runtime(&resolved) {
+                            drop(library);
+                            return Err(DecibriError::OrtPathInvalid {
+                                path: resolved,
+                                reason: "no usable ONNX Runtime found: \
+                                         ORT_DYLIB_PATH is not set and the \
+                                         system loader resolves only the \
+                                         Windows in-box runtime, which is not \
+                                         compatible",
+                            });
+                        }
+                    }
+                    // Keep the runtime resident rather than unloading it:
+                    // `ort::init()` loads the same library next, so this
+                    // avoids a pointless unload/reload cycle and matches the
+                    // process state a successful init produces.
+                    std::mem::forget(library);
+                }
+                Err(_) => {
+                    // ort also resolves the bare library name against the
+                    // executable's directory, which the system loader does
+                    // not search on Linux and macOS; accept that placement
+                    // and leave the load to `ort::init()` itself.
+                    let beside_exe = exe_sibling(Path::new(ORT_DEFAULT_LIBRARY));
+                    if !beside_exe.as_deref().is_some_and(Path::is_file) {
+                        return Err(DecibriError::OrtPathInvalid {
+                            path: PathBuf::from(ORT_DEFAULT_LIBRARY),
+                            reason: "no ONNX Runtime is resolvable: ORT_DYLIB_PATH \
+                                     is not set and the system loader cannot find \
+                                     the runtime library",
+                        });
+                    }
+                }
+            },
+        },
     }
 
     match do_ort_init(path) {

--- a/crates/decibri/tests/vad_ort_load_failure.rs
+++ b/crates/decibri/tests/vad_ort_load_failure.rs
@@ -36,9 +36,16 @@
 #![cfg(all(feature = "vad", feature = "ort-load-dynamic"))]
 
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, PoisonError};
 
 use decibri::error::DecibriError;
 use decibri::vad::{SileroVad, VadConfig};
+
+/// Serializes the tests in this binary. One test mutates `ORT_DYLIB_PATH`
+/// while the others read the environment (`temp_dir` consults it), and
+/// concurrent environment mutation and reads are unsound on some platforms;
+/// taking this lock first makes each test's environment access exclusive.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 fn bundled_model_path() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -55,6 +62,7 @@ fn bundled_model_path() -> PathBuf {
 /// short-circuits that case without constructing an `ort::Error`.
 #[test]
 fn test_ort_load_fails_with_nonexistent_path() {
+    let _env = ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
     let bogus = std::env::temp_dir().join("does-not-exist-onnxruntime-dylib-xyz");
 
     // `VadConfig` is `#[non_exhaustive]`: default-construct then assign the
@@ -90,6 +98,47 @@ fn test_ort_load_fails_with_nonexistent_path() {
     );
 }
 
+/// With NO `ort_library_path` at all, the pre-check must still protect the
+/// load: `ort::init()` resolves the runtime from `ORT_DYLIB_PATH` (or the
+/// system loader), and a bogus `ORT_DYLIB_PATH` previously reached the
+/// unguarded `ort::init()`, which hangs instead of erroring when the
+/// resolution fails. The extended pre-check validates the environment
+/// variable exactly as it validates an explicit path.
+///
+/// Environment note: this test sets `ORT_DYLIB_PATH` for its own scope. The
+/// other tests in this binary pass an explicit `ort_library_path`, which
+/// never consults the environment, so the mutation cannot race them.
+#[test]
+fn test_ort_load_fails_with_bogus_env_var_and_no_path() {
+    let _env = ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+    let bogus = std::env::temp_dir().join("does-not-exist-onnxruntime-env-xyz");
+    std::env::set_var("ORT_DYLIB_PATH", &bogus);
+
+    let mut config = VadConfig::default();
+    config.model_path = bundled_model_path();
+    config.ort_library_path = None;
+    let result = SileroVad::new(config);
+    std::env::remove_var("ORT_DYLIB_PATH");
+
+    let err = result
+        .err()
+        .expect("expected OrtPathInvalid for a bogus ORT_DYLIB_PATH");
+    match &err {
+        DecibriError::OrtPathInvalid { path, reason } => {
+            assert!(
+                path.ends_with("does-not-exist-onnxruntime-env-xyz"),
+                "OrtPathInvalid.path should carry the ORT_DYLIB_PATH value, got {}",
+                path.display()
+            );
+            assert!(
+                reason.contains("ORT_DYLIB_PATH"),
+                "OrtPathInvalid.reason should name ORT_DYLIB_PATH, got: {reason}"
+            );
+        }
+        other => panic!("expected OrtPathInvalid, got {other:?}"),
+    }
+}
+
 /// An `ort_library_path` that points at a directory (e.g. a user mistakenly
 /// passing the directory containing the dylib instead of the dylib itself)
 /// must also fail fast with `OrtPathInvalid`. Without the pre-check, pyke/ort
@@ -97,6 +146,7 @@ fn test_ort_load_fails_with_nonexistent_path() {
 /// not validate the input is a regular file.
 #[test]
 fn test_ort_load_fails_when_path_is_directory() {
+    let _env = ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
     // `temp_dir()` is guaranteed to exist and is a directory on every platform.
     let dir_path = std::env::temp_dir();
 

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -9,7 +9,7 @@ For other decibri packages, see:
 - Rust crate: [crates/decibri/CHANGELOG.md](../../crates/decibri/CHANGELOG.md)
 - Python wheel: [bindings/python/CHANGELOG.md](../../bindings/python/CHANGELOG.md)
 
-## [5.1.0] - Unreleased
+## [5.1.0] - 2026-07-17
 
 ### Added
 

--- a/npm/decibri/examples/decibri.browser.js
+++ b/npm/decibri/examples/decibri.browser.js
@@ -70,7 +70,7 @@ var decibri = (function() {
 	var require_decibri_browser = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		const { Emitter } = require_emitter();
 		const { WORKLET_SOURCE } = require_worklet_inline();
-		const VERSION = "5.0.0";
+		const VERSION = "5.1.0";
 		/**
 		* Browser microphone capture.
 		*

--- a/npm/decibri/package.json
+++ b/npm/decibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decibri",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Cross-platform audio capture, playback, and processing for Node.js and browsers",
   "main": "src/decibri.js",
   "types": "src/decibri.d.ts",
@@ -72,10 +72,10 @@
     "MIGRATION.md"
   ],
   "optionalDependencies": {
-    "@decibri/decibri-win32-x64-msvc": "5.0.0",
-    "@decibri/decibri-darwin-arm64": "5.0.0",
-    "@decibri/decibri-linux-x64-gnu": "5.0.0",
-    "@decibri/decibri-linux-arm64-gnu": "5.0.0"
+    "@decibri/decibri-win32-x64-msvc": "5.1.0",
+    "@decibri/decibri-darwin-arm64": "5.1.0",
+    "@decibri/decibri-linux-x64-gnu": "5.1.0",
+    "@decibri/decibri-linux-arm64-gnu": "5.1.0"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.7.0"

--- a/npm/decibri/src/browser/decibri-browser.js
+++ b/npm/decibri/src/browser/decibri-browser.js
@@ -6,7 +6,7 @@ const { WORKLET_SOURCE } = require('./worklet-inline.js');
 // Browser build version. Keep in sync with package.json on each release; the
 // browser bundle cannot read package.json at runtime the way the Node wrapper
 // does, so this is a maintained constant.
-const VERSION = '5.0.0';
+const VERSION = '5.1.0';
 
 /**
  * Browser microphone capture.

--- a/npm/platform-darwin-arm64/package.json
+++ b/npm/platform-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-darwin-arm64",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "os": ["darwin"],
   "cpu": ["arm64"],
   "main": "decibri.darwin-arm64.node",

--- a/npm/platform-linux-arm64-gnu/package.json
+++ b/npm/platform-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-arm64-gnu",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "os": ["linux"],
   "cpu": ["arm64"],
   "main": "decibri.linux-arm64-gnu.node",

--- a/npm/platform-linux-x64-gnu/package.json
+++ b/npm/platform-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-x64-gnu",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "os": ["linux"],
   "cpu": ["x64"],
   "main": "decibri.linux-x64-gnu.node",

--- a/npm/platform-win32-x64-msvc/package.json
+++ b/npm/platform-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-win32-x64-msvc",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "os": ["win32"],
   "cpu": ["x64"],
   "main": "decibri.win32-x64-msvc.node",


### PR DESCRIPTION
Release 5.1.0 (crate, npm) and 0.6.0 (python), adding the File source and guarding the ONNX runtime load.

## File source

File conditions a WAV recording or in-memory samples through the same chain as live capture, in the core and both packages. It is the recorded-audio companion to Microphone: same conditioning options, same iteration, same conditioned output. Because a File is a complete recording rather than a live stream, it also analyses the whole recording for speech, something a live source cannot do.

- Constructors: File.open(path) (with the bare-constructor spelling) reads 16-bit PCM or 32-bit float WAV; File.buffer(samples) wraps raw samples with an explicit input rate. Python adds the AsyncFile twin. Iteration delivers conditioned chunks as a finite stream that ends after the chain's flushed tail.
- VAD is opt-in through the same vad configuration Microphone takes. With no vad set, a File simply conditions audio. Per-chunk detection carries vad_score and the speaking state alongside the stream, with the holdoff and chunk timestamps measured in file time (sample positions), never wall-clock, so processing speed does not change the reported timing.
- Whole-file analysis: analyze() (also spelled analyse()) consumes the source in a single pass and returns a VadReport of per-window scores and merged speech segments, in seconds of file time. Analysis requires the silero model and rejects a missing configuration with a clear error. When the target rate is not a detector rate, the detector feed is resampled internally to 16 kHz while the conditioned output stays at the target rate.
- WAV and raw samples only; no decode dependency is added. The live capture, playback, and VAD surfaces are unchanged; this is additive public API.

## ONNX runtime guard

The runtime pre-check now covers both resolution branches. Previously, when no model path was resolved (for example an install without the platform package), the load reached ort::init() unguarded and could hang instead of failing. The check now mirrors the runtime's own resolution, so it never rejects a configuration the runtime would load, and returns a clear error when the runtime is genuinely unresolvable. Behaviour is unchanged when the runtime resolves normally.

## Versions

- crate and npm: 5.0.0 to 5.1.0
- python: 0.5.0 to 0.6.0

Every version site moves in lockstep: the workspace manifest, the python path-dependency range, both lockfiles, the npm optionalDependencies pins and the four platform packages, the browser VERSION and its regenerated bundle, the python version mirrors, and the version-assertion tests. 