### PR TITLE
chore(release): 5.2.1 (npm) and 0.7.1 (python)

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -8,7 +8,7 @@ For Rust core (`crates/decibri`) and npm package (`npm/decibri`) changes, see [t
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.1] - 2026-07-24
 
 ### Changed
 

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 This file tracks changes to the decibri Python package published to PyPI (`pip install decibri`).
 
-For Rust core (`crates/decibri`) and npm binding (`bindings/node`) changes, see [the root CHANGELOG.md](../../CHANGELOG.md). The Rust core and npm binding ship together at the same version under the `v*` tag pattern; the Python package has its own version trajectory aligned with API surface stability and ships under the `python-v*` tag pattern.
+For Rust core (`crates/decibri`) and npm package (`npm/decibri`) changes, see [the root CHANGELOG.md](../../CHANGELOG.md). Each package versions independently and releases under its own tag pattern: `crate-v*` for the Rust core, `npm-v*` for the npm package, and `python-v*` for the Python package.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "decibri"
-version = "0.7.0"
+version = "0.7.1"
 description = "Cross-platform audio capture, playback, and voice activity detection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/python/python/decibri/__init__.py
+++ b/bindings/python/python/decibri/__init__.py
@@ -70,7 +70,7 @@ from decibri.exceptions import (
     WavInvalid,
 )
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 
 def input_devices() -> list[MicrophoneInfo]:

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -491,7 +491,7 @@ fn build_version_info() -> VersionInfo {
     VersionInfo {
         decibri: env!("CARGO_PKG_VERSION").to_string(),
         audio_backend: format!("cpal {}", CPAL_VERSION),
-        binding: "0.7.0".to_string(),
+        binding: "0.7.1".to_string(),
     }
 }
 

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -18,7 +18,7 @@ import decibri
 
 
 def test_package_imports() -> None:
-    assert decibri.__version__ == "0.7.0"
+    assert decibri.__version__ == "0.7.1"
     # The bridges are hidden behind the private _decibri module. They are
     # NOT accessible at decibri.<X> top level (sync or async). The async
     # pair was never accessible at the top level; the sync pair
@@ -74,7 +74,7 @@ def test_version_info_fields() -> None:
     info = _decibri.MicrophoneBridge.version()
     assert info.decibri == "5.2.0"
     assert info.audio_backend == "cpal 0.17"
-    assert info.binding == "0.7.0"
+    assert info.binding == "0.7.1"
 
 
 def test_version_info_is_frozen() -> None:

--- a/bindings/python/tests/test_wheel_smoke.py
+++ b/bindings/python/tests/test_wheel_smoke.py
@@ -29,7 +29,7 @@ def test_import_decibri() -> None:
     """The package imports successfully from the installed wheel."""
     assert decibri is not None
     assert hasattr(decibri, "__version__")
-    assert decibri.__version__ == "0.7.0"
+    assert decibri.__version__ == "0.7.1"
 
 
 def test_construct_decibri_default() -> None:

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -68,7 +68,7 @@ wheels = [
 
 [[package]]
 name = "decibri"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions" },

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -13,6 +13,7 @@ For other decibri packages, see:
 
 ### Changed
 
+- Documented what `version().decibri` reports: the native core version in Node, and the installed package version in the browser build, which has no native core.
 - The consumed-`File` failure now carries the dedicated `code` `'FILE_CONSUMED'` instead of the generic `'DECIBRI_ERROR'`. The `DecibriError` class and the message are unchanged; branch on `err.code` to handle it specifically.
 - Flat `vadThreshold` and `vadHoldoff` options on `File` now raise the same migration error the `Microphone` raises, instead of being silently ignored. Pass them on the `vad` config object: `vad: { model: 'silero', threshold: 0.5, holdoffMs: 300 }`.
 

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -9,7 +9,7 @@ For other decibri packages, see:
 - Rust crate: [crates/decibri/CHANGELOG.md](../../crates/decibri/CHANGELOG.md)
 - Python wheel: [bindings/python/CHANGELOG.md](../../bindings/python/CHANGELOG.md)
 
-## [Unreleased]
+## [5.2.1] - 2026-07-24
 
 ### Changed
 

--- a/npm/decibri/README.md
+++ b/npm/decibri/README.md
@@ -235,7 +235,7 @@ Same options as Node.js, plus:
 | `noiseSuppression` | boolean | true | Browser noise suppression |
 | `workletUrl` | string | inline blob | Custom worklet URL for strict CSP |
 
-The browser runs energy-mode VAD only, so its `vad` option accepts `false` or `'energy'`. The browser `version()` returns `{ decibri }` only.
+The browser runs energy-mode VAD only, so its `vad` option accepts `false` or `'energy'`. The browser `version()` returns `{ decibri }` only: the browser build has no native core, so `decibri` reports the installed package version. In Node, `version().decibri` reports the native core version.
 
 ### Key differences from Node.js
 

--- a/npm/decibri/examples/decibri.browser.js
+++ b/npm/decibri/examples/decibri.browser.js
@@ -70,7 +70,7 @@ var decibri = (function() {
 	var require_decibri_browser = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		const { Emitter } = require_emitter();
 		const { WORKLET_SOURCE } = require_worklet_inline();
-		const VERSION = "5.2.0";
+		const VERSION = "5.2.1";
 		/**
 		* Browser microphone capture.
 		*

--- a/npm/decibri/package.json
+++ b/npm/decibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decibri",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Cross-platform audio capture, playback, and processing for Node.js and browsers",
   "main": "src/decibri.js",
   "types": "src/decibri.d.ts",
@@ -72,10 +72,10 @@
     "MIGRATION.md"
   ],
   "optionalDependencies": {
-    "@decibri/decibri-win32-x64-msvc": "5.2.0",
-    "@decibri/decibri-darwin-arm64": "5.2.0",
-    "@decibri/decibri-linux-x64-gnu": "5.2.0",
-    "@decibri/decibri-linux-arm64-gnu": "5.2.0"
+    "@decibri/decibri-win32-x64-msvc": "5.2.1",
+    "@decibri/decibri-darwin-arm64": "5.2.1",
+    "@decibri/decibri-linux-x64-gnu": "5.2.1",
+    "@decibri/decibri-linux-arm64-gnu": "5.2.1"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.7.0"

--- a/npm/decibri/src/browser/decibri-browser.js
+++ b/npm/decibri/src/browser/decibri-browser.js
@@ -6,7 +6,7 @@ const { WORKLET_SOURCE } = require('./worklet-inline.js');
 // Browser build version. Keep in sync with package.json on each release; the
 // browser bundle cannot read package.json at runtime the way the Node wrapper
 // does, so this is a maintained constant.
-const VERSION = '5.2.0';
+const VERSION = '5.2.1';
 
 /**
  * Browser microphone capture.

--- a/npm/decibri/src/browser/index.d.ts
+++ b/npm/decibri/src/browser/index.d.ts
@@ -8,10 +8,11 @@ export interface MicrophoneInfo {
   groupId: string;
 }
 
-/** Version information (browser). The browser surface has no native audio
- *  backend, so it reports only the decibri version. */
+/** Version information (browser). The browser build has no native core, so
+ *  `decibri` reports the installed package version. In Node, `version().decibri`
+ *  reports the native core version. */
 export interface VersionInfo {
-  /** decibri version. */
+  /** The installed decibri package version. */
   decibri: string;
 }
 

--- a/npm/platform-darwin-arm64/package.json
+++ b/npm/platform-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-darwin-arm64",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "os": ["darwin"],
   "cpu": ["arm64"],
   "main": "decibri.darwin-arm64.node",

--- a/npm/platform-linux-arm64-gnu/package.json
+++ b/npm/platform-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-arm64-gnu",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "os": ["linux"],
   "cpu": ["arm64"],
   "main": "decibri.linux-arm64-gnu.node",

--- a/npm/platform-linux-x64-gnu/package.json
+++ b/npm/platform-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-x64-gnu",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "os": ["linux"],
   "cpu": ["x64"],
   "main": "decibri.linux-x64-gnu.node",

--- a/npm/platform-win32-x64-msvc/package.json
+++ b/npm/platform-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-win32-x64-msvc",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "os": ["win32"],
   "cpu": ["x64"],
   "main": "decibri.win32-x64-msvc.node",

--- a/tests/browser/decibri-browser.test.js
+++ b/tests/browser/decibri-browser.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import pkg from '../../npm/decibri/package.json';
 
 // ── Browser API mocks ────────────────────────────────────────────────────────
 
@@ -555,5 +556,11 @@ describe('Microphone.version()', () => {
     const v = Microphone.version();
     expect(v).toHaveProperty('decibri');
     expect(typeof v.decibri).toBe('string');
+  });
+
+  it('reports the package version', () => {
+    // The browser VERSION constant is maintained by hand; it must match the
+    // package version in npm/decibri/package.json.
+    expect(Microphone.version().decibri).toBe(pkg.version);
   });
 });


### PR DESCRIPTION
Bump the npm package from 5.2.0 to 5.2.1 across the package manifest, the four platform pins and manifests, and the browser version with its regenerated bundle. Bump the Python package from 0.7.0 to 0.7.1 across the project metadata, the version mirrors, the lockfile, and the package version assertions. The Rust core and the published crate are unchanged and stay at 5.2.0, so the core version assertions are unchanged and no crate release accompanies this one.

Add a test asserting the browser version matches the package version, document that version().decibri reports the native core version in Node and the installed package version in the browser build, which has no native core, and correct the Python changelog note on how the packages are versioned and tagged.