### PR TITLE
fix(errors): report device failures instead of discarding them

### DIFF
--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -687,6 +687,29 @@ fn to_napi_error(e: decibri::error::DecibriError) -> Error {
     Error::new(status, e.to_string())
 }
 
+/// Resolve the cause behind a failed playback operation.
+///
+/// The core reports [`SpeakerStreamClosed`](decibri::error::DecibriError::SpeakerStreamClosed)
+/// for both a deliberate stop and a device that died under it, and stashes the
+/// typed cause in the latter case. `take` drains that slot, and is called only
+/// for the closed-stream error so any other failure is passed through with its
+/// own cause intact. A deliberate stop stashes nothing, so it keeps reporting
+/// the closed-stream error.
+fn speaker_failure_cause<F>(
+    err: decibri::error::DecibriError,
+    take: F,
+) -> decibri::error::DecibriError
+where
+    F: FnOnce() -> Option<decibri::error::DecibriError>,
+{
+    match err {
+        decibri::error::DecibriError::SpeakerStreamClosed => {
+            take().unwrap_or(decibri::error::DecibriError::SpeakerStreamClosed)
+        }
+        other => other,
+    }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // DecibriOutputBridge: audio playback
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -793,7 +816,9 @@ impl SpeakerParts {
 /// of the stream's crossbeam `Sender` (wrapped in a `SpeakerSink`) and the
 /// already-converted samples. The `cpal::Stream` is not touched here; because the
 /// sink is lock-free, the offloaded `send` cannot block the JS thread's `stop` or
-/// `is_playing`. A closed stream rejects the Promise with `SpeakerStreamClosed`.
+/// `is_playing`. A stopped stream rejects the Promise with `SpeakerStreamClosed`;
+/// a stream the device died under rejects with the stashed `DeviceFailed`, which
+/// the sink reaches through the slot it shares with its stream.
 /// An empty task (no sink) is a no-op for empty writes.
 pub struct WriteTask {
     sink: Option<SpeakerSink>,
@@ -806,7 +831,8 @@ impl Task for WriteTask {
 
     fn compute(&mut self) -> Result<Self::Output> {
         if let (Some(sink), Some(samples)) = (self.sink.as_ref(), self.samples.take()) {
-            sink.send(samples).map_err(to_napi_error)?;
+            sink.send(samples)
+                .map_err(|e| to_napi_error(speaker_failure_cause(e, || sink.take_last_error())))?;
         }
         Ok(())
     }
@@ -822,6 +848,8 @@ impl Task for WriteTask {
 /// because the sink is lock-free, a long drain never blocks the JS thread's
 /// `stop` or `is_playing`. With no stream yet created the sink is `None` and the
 /// drain is a no-op that resolves immediately, matching the synchronous `drain`.
+/// A device that died while audio was still queued rejects the Promise with the
+/// stashed `DeviceFailed`; a deliberate stop stashes nothing and resolves.
 pub struct DrainTask {
     sink: Option<SpeakerSink>,
 }
@@ -833,6 +861,9 @@ impl Task for DrainTask {
     fn compute(&mut self) -> Result<Self::Output> {
         if let Some(sink) = self.sink.as_ref() {
             sink.drain();
+            if let Some(cause) = sink.take_last_error() {
+                return Err(to_napi_error(cause));
+            }
         }
         Ok(())
     }
@@ -910,11 +941,10 @@ impl DecibriOutputBridge {
             SampleFormat::Float32 => sample::f32_le_bytes_to_f32(&buffer),
         };
 
-        self.stream
-            .as_ref()
-            .unwrap()
+        let stream = self.stream.as_ref().unwrap();
+        stream
             .send(samples)
-            .map_err(to_napi_error)
+            .map_err(|e| to_napi_error(speaker_failure_cause(e, || stream.take_last_error())))
     }
 
     /// Non-blocking write: convert the samples and start the stream on the JS
@@ -947,10 +977,20 @@ impl DecibriOutputBridge {
     }
 
     /// Graceful drain: blocks until all queued samples have been played.
+    ///
+    /// Fails when the device died while the audio was still queued: the drain
+    /// returns early once the stream stops running, which covers a deliberate
+    /// stop and a driver failure alike, and only the failure stashes a typed
+    /// cause. An empty slot therefore leaves a normal drain silent.
     #[napi]
-    pub fn drain(&self) {
-        if let Some(stream) = self.stream.as_ref() {
-            stream.drain();
+    pub fn drain(&self) -> Result<()> {
+        let Some(stream) = self.stream.as_ref() else {
+            return Ok(());
+        };
+        stream.drain();
+        match stream.take_last_error() {
+            Some(cause) => Err(to_napi_error(cause)),
+            None => Ok(()),
         }
     }
 

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -15,6 +15,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `Speaker.underrun_count`: a read-only property exposing the core stream's silence-fill counter, in samples. 0 while the producer keeps the queue fed; a rising value means playback is papering over gaps with silence.
 - `File.input_rate` and `AsyncFile.input_rate`: read-only properties reporting the source's native rate, from the WAV header or the explicit `input_rate` of `buffer`.
 
+### Changed
+
+- **A device that fails mid-stream now raises `DeviceFailed`, where `MicrophoneStreamClosed` or `SpeakerStreamClosed` was raised before.** `DeviceFailed` derives from `DecibriError`, not from either closed-stream class, so code that catches `MicrophoneStreamClosed` or `SpeakerStreamClosed` to handle a disconnect stops catching one. Catch `DecibriError`, or `DeviceFailed` itself. The exception carries the driver's own cause in its message. `DeviceFailed` was previously documented but unreachable from any capture or playback path.
+- A deliberate `stop()` or `close()` is unchanged: it still raises `MicrophoneStreamClosed` or `SpeakerStreamClosed`, and is never reported as a device failure.
+- `Speaker.drain()` and `AsyncSpeaker.drain()` raise `DeviceFailed` when the device failed while the queued audio was still playing, instead of returning normally.
+- A playback device failure surfaces on the next `write()` or `drain()`, so a producer that has stopped writing is not told; `is_playing` goes false immediately either way.
+
 ## [0.7.2] - 2026-07-25
 
 ### Added

--- a/bindings/python/python/decibri/_async_classes.py
+++ b/bindings/python/python/decibri/_async_classes.py
@@ -105,10 +105,14 @@ class AsyncMicrophone:
 
     Cleanup and disconnect:
         Mid-stream device disconnect (USB unplug, default-device switch,
-        driver error) is surfaced as a ``MicrophoneStreamClosed`` raised on
-        the next ``await read()``. cpal detects the disconnect and
-        closes the underlying stream within roughly 20ms; the bridge
-        then reports the closed state on its next read attempt.
+        driver error) is surfaced as a ``DeviceFailed`` raised on the next
+        ``await read()``, carrying the driver's own cause. cpal detects the
+        disconnect and closes the underlying stream within roughly 20ms; the
+        bridge then reports the closed state on its next read attempt.
+        ``DeviceFailed`` derives from ``DecibriError``, not from
+        ``MicrophoneStreamClosed``, so catch ``DecibriError`` (or
+        ``DeviceFailed`` itself) to handle a disconnect. A deliberate
+        ``stop()`` still raises ``MicrophoneStreamClosed``.
 
         Sibling-task cancellation works correctly here: cancelling a
         concurrent ``await stop()`` from another asyncio task while a
@@ -666,6 +670,15 @@ class AsyncSpeaker:
     immediately followed by another write/drain cycle (spawn_blocking does
     not cooperatively cancel OS threads); for production use, complete
     drains before initiating new writes.
+
+    Disconnect:
+        A playback device that fails mid-stream (USB unplug, driver reset)
+        raises ``DeviceFailed`` from the next ``await write()`` or
+        ``await drain()``, carrying the driver's own cause. A producer that
+        has stopped writing is not told; ``is_playing`` goes false
+        immediately either way. A deliberate ``await stop()`` is never
+        reported as a device failure: a later write raises
+        ``SpeakerStreamClosed`` as before.
 
     Resource cleanup:
         Always use ``async with AsyncSpeaker(...) as o:`` or call

--- a/bindings/python/python/decibri/_classes.py
+++ b/bindings/python/python/decibri/_classes.py
@@ -324,10 +324,16 @@ class Microphone:
 
     Cleanup and disconnect:
         Mid-stream device disconnect (USB unplug, default-device switch,
-        driver error) is surfaced as a ``MicrophoneStreamClosed`` raised on
-        the next ``read()``. cpal detects the disconnect and closes the
-        underlying stream within roughly 20ms; the wrapper then sees the
-        closed state on its next read attempt and raises.
+        driver error) is surfaced as a ``DeviceFailed`` raised on the next
+        ``read()``, carrying the driver's own cause. cpal detects the
+        disconnect and closes the underlying stream within roughly 20ms; the
+        wrapper then sees the closed state on its next read attempt and
+        raises. ``DeviceFailed`` derives from ``DecibriError``, not from
+        ``MicrophoneStreamClosed``, so catch ``DecibriError`` (or
+        ``DeviceFailed`` itself) to handle a disconnect.
+
+        A deliberate ``stop()`` or ``close()`` is never reported as a device
+        failure: it raises ``MicrophoneStreamClosed`` as before.
 
         Threaded shutdown: calling ``stop()`` from a thread other than
         the one currently blocked inside ``read()`` is safe. It
@@ -898,6 +904,14 @@ class Speaker:
         with Speaker(sample_rate=16000, channels=1) as out:
             out.write(audio_bytes)
             out.drain()
+
+    Disconnect:
+        A playback device that fails mid-stream (USB unplug, driver reset)
+        raises ``DeviceFailed`` from the next ``write()`` or ``drain()``,
+        carrying the driver's own cause. A producer that has stopped writing
+        is not told; ``is_playing`` goes false immediately either way. A
+        deliberate ``stop()`` or ``close()`` is never reported as a device
+        failure: a later ``write()`` raises ``SpeakerStreamClosed`` as before.
     """
 
     def __init__(

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -210,6 +210,40 @@ fn exception_class<'py>(py: Python<'py>, name: &'static str) -> PyResult<Bound<'
 // so the Python __init__ override can store named attributes.
 // ---------------------------------------------------------------------------
 
+/// Resolve the cause behind a failed capture read.
+///
+/// The core reports `MicrophoneStreamClosed` for both a deliberate stop and a
+/// device that died under it, and stashes the typed cause in the latter case.
+/// `take` drains that slot, and is called only for the closed-stream error so
+/// any other read failure is passed through with its own cause intact. A
+/// deliberate stop stashes nothing, so it keeps raising `MicrophoneStreamClosed`.
+fn capture_failure_cause<F>(err: CoreDecibriError, take: F) -> CoreDecibriError
+where
+    F: FnOnce() -> Option<CoreDecibriError>,
+{
+    match err {
+        CoreDecibriError::MicrophoneStreamClosed => {
+            take().unwrap_or(CoreDecibriError::MicrophoneStreamClosed)
+        }
+        other => other,
+    }
+}
+
+/// The playback counterpart of [`capture_failure_cause`]. A stopped speaker
+/// keeps raising `SpeakerStreamClosed`; one whose device died raises the
+/// stashed `DeviceFailed`.
+fn speaker_failure_cause<F>(err: CoreDecibriError, take: F) -> CoreDecibriError
+where
+    F: FnOnce() -> Option<CoreDecibriError>,
+{
+    match err {
+        CoreDecibriError::SpeakerStreamClosed => {
+            take().unwrap_or(CoreDecibriError::SpeakerStreamClosed)
+        }
+        other => other,
+    }
+}
+
 type ExceptionRaiser = Box<dyn FnOnce(Bound<'_, PyType>) -> PyErr>;
 
 fn to_py_err(py: Python<'_>, err: CoreDecibriError) -> PyErr {
@@ -874,7 +908,10 @@ impl MicrophoneBridge {
         let result: Result<Option<AudioChunk>, CoreDecibriError> =
             py.detach(|| stream.next_chunk(samples, timeout));
 
-        let Some(chunk) = result.map_err(|e| to_py_err(py, e))? else {
+        let Some(chunk) = result
+            .map_err(|e| capture_failure_cause(e, || stream.take_last_error()))
+            .map_err(|e| to_py_err(py, e))?
+        else {
             return Ok(None);
         };
 
@@ -1287,6 +1324,7 @@ impl SpeakerBridge {
             BindingSampleFormat::Float32 => py.detach(|| f32_le_bytes_to_f32(&owned_samples)),
         };
         py.detach(|| stream.send(samples_f32))
+            .map_err(|e| speaker_failure_cause(e, || stream.take_last_error()))
             .map_err(|e| to_py_err(py, e))?;
         Ok(())
     }
@@ -1303,6 +1341,7 @@ impl SpeakerBridge {
         let samples_f32: Vec<f32> =
             py.detach(|| owned.iter().map(|&s| s as f32 / 32768.0).collect());
         py.detach(|| stream.send(samples_f32))
+            .map_err(|e| speaker_failure_cause(e, || stream.take_last_error()))
             .map_err(|e| to_py_err(py, e))?;
         Ok(())
     }
@@ -1314,6 +1353,7 @@ impl SpeakerBridge {
             .ok_or_else(|| raise_named(py, "SpeakerStreamClosed", "output is not running"))?;
         let samples_f32: Vec<f32> = samples.to_vec();
         py.detach(|| stream.send(samples_f32))
+            .map_err(|e| speaker_failure_cause(e, || stream.take_last_error()))
             .map_err(|e| to_py_err(py, e))?;
         Ok(())
     }
@@ -1428,7 +1468,13 @@ impl SpeakerBridge {
             .as_mut()
             .ok_or_else(|| raise_named(py, "SpeakerStreamClosed", "output is not running"))?;
         py.detach(|| stream.drain());
-        Ok(())
+        // The drain returns early once the stream stops running, which covers a
+        // deliberate stop and a driver failure alike; only the failure stashes a
+        // typed cause, so an empty slot leaves a normal drain silent.
+        match stream.take_last_error() {
+            Some(cause) => Err(to_py_err(py, cause)),
+            None => Ok(()),
+        }
     }
 
     fn stop(&mut self) -> PyResult<()> {

--- a/bindings/python/tests/test_exceptions.py
+++ b/bindings/python/tests/test_exceptions.py
@@ -275,6 +275,25 @@ def test_onnx_backend_failed_is_dedicated_direct_subclass() -> None:
         raise OnnxBackendFailed("backend boom")
 
 
+def test_device_failed_is_not_a_stream_closed_subclass() -> None:
+    """A device failure is reported as ``DeviceFailed``, not as a closed stream.
+
+    Pins the catch-target consequence: code that catches
+    ``MicrophoneStreamClosed`` or ``SpeakerStreamClosed`` to handle a
+    disconnect no longer catches one, and has to catch ``DecibriError`` (or
+    ``DeviceFailed``) instead.
+    """
+    assert not issubclass(DeviceFailed, MicrophoneStreamClosed)
+    assert not issubclass(DeviceFailed, SpeakerStreamClosed)
+    # The reverse also holds: a deliberate stop is not a device failure.
+    assert not issubclass(MicrophoneStreamClosed, DeviceFailed)
+    assert not issubclass(SpeakerStreamClosed, DeviceFailed)
+    # Both remain reachable from the one catch-root a consumer can rely on.
+    for cls in (DeviceFailed, MicrophoneStreamClosed, SpeakerStreamClosed):
+        with pytest.raises(DecibriError):
+            raise cls("boom")
+
+
 def test_new_error_types_importable_from_top_level() -> None:
     """Both are reachable via attribute lookup on the package (not just the
     exceptions submodule), even though they are not in ``__all__``."""

--- a/bindings/python/tests/test_lifecycle.py
+++ b/bindings/python/tests/test_lifecycle.py
@@ -305,6 +305,127 @@ def test_sync_iterator_propagates_capture_closed_from_bridge() -> None:
     assert bridge.read_calls == 1
 
 
+def test_sync_read_propagates_device_failed_from_bridge() -> None:
+    """A device failure drained by the bridge reaches the caller as DeviceFailed.
+
+    The wrapper must not translate or swallow it: a disconnect is no longer
+    reported as a closed stream, so ``except MicrophoneStreamClosed`` does not
+    catch it.
+    """
+    from decibri import DecibriError, DeviceFailed, MicrophoneStreamClosed
+
+    class _FailedBridge(_MockBridge):
+        def read(self, timeout_ms: int | None = None) -> bytes | None:
+            raise DeviceFailed("decibri: audio device error: device unplugged")
+
+    d = _make_decibri_with_mock_bridge(_FailedBridge())
+
+    with pytest.raises(DeviceFailed):
+        d.read(timeout_ms=100)
+    # It is still a DecibriError, and it is NOT a closed stream.
+    with pytest.raises(DecibriError):
+        d.read(timeout_ms=100)
+    with pytest.raises(DeviceFailed):
+        try:
+            d.read(timeout_ms=100)
+        except MicrophoneStreamClosed:  # pragma: no cover - must not catch
+            pytest.fail("a device failure must not be caught as MicrophoneStreamClosed")
+
+
+def test_sync_iterator_propagates_device_failed_from_bridge() -> None:
+    """The iterator surface propagates a device failure rather than ending."""
+    from decibri import DeviceFailed
+
+    class _FailedBridge(_MockBridge):
+        def read(self, timeout_ms: int | None = None) -> bytes | None:
+            raise DeviceFailed("decibri: audio device error: device unplugged")
+
+    d = _make_decibri_with_mock_bridge(_FailedBridge())
+
+    with pytest.raises(DeviceFailed):
+        next(iter(d))
+
+
+def test_capture_never_started_is_not_reported_as_a_device_failure() -> None:
+    """A read on a stream that was never started is a closed stream, not a fault.
+
+    Exercises the real bridge: the guard for an inactive capture sits before
+    the read that drains the device-error slot, so it cannot be mislabelled.
+    """
+    from decibri import DeviceFailed, MicrophoneStreamClosed
+
+    d = Microphone()
+    with pytest.raises(MicrophoneStreamClosed):
+        d.read(timeout_ms=100)
+    try:
+        d.read(timeout_ms=100)
+    except DeviceFailed:  # pragma: no cover - must not fire
+        pytest.fail("an inactive capture must not be reported as a device failure")
+    except MicrophoneStreamClosed:
+        pass
+
+
+def test_output_never_started_is_not_reported_as_a_device_failure() -> None:
+    """The playback twin: write() and drain() before start() are closed-stream."""
+    from decibri import DeviceFailed, Speaker, SpeakerStreamClosed
+
+    o = Speaker()
+    for call in (lambda: o.write(b"\x00" * 100), o.drain):
+        with pytest.raises(SpeakerStreamClosed):
+            call()
+        try:
+            call()
+        except DeviceFailed:  # pragma: no cover - must not fire
+            pytest.fail("an inactive speaker must not be reported as a device failure")
+        except SpeakerStreamClosed:
+            pass
+
+
+@pytest.mark.requires_audio_input
+def test_deliberate_stop_is_not_reported_as_a_device_failure() -> None:
+    """An explicit stop() raises the closed-stream error, never DeviceFailed.
+
+    This is the regression the device-failure wiring most risks: the bridge
+    drains its error slot on a failing read, and a deliberate stop leaves that
+    slot empty. Needs a real device, since the slot only exists once a stream
+    has been opened.
+    """
+    from decibri import DeviceFailed, MicrophoneStreamClosed
+
+    d = Microphone()
+    d.start()
+    d.stop()
+
+    with pytest.raises(MicrophoneStreamClosed):
+        d.read(timeout_ms=100)
+    try:
+        d.read(timeout_ms=100)
+    except DeviceFailed:  # pragma: no cover - must not fire
+        pytest.fail("a deliberate stop() must not be reported as a device failure")
+    except MicrophoneStreamClosed:
+        pass
+
+
+@pytest.mark.requires_audio_output
+def test_deliberate_speaker_stop_is_not_reported_as_a_device_failure() -> None:
+    """The playback twin: a write after an explicit stop() is a closed stream."""
+    from decibri import DeviceFailed, Speaker, SpeakerStreamClosed
+
+    o = Speaker()
+    o.start()
+    o.write(b"\x00" * 320)
+    o.stop()
+
+    with pytest.raises(SpeakerStreamClosed):
+        o.write(b"\x00" * 320)
+    try:
+        o.write(b"\x00" * 320)
+    except DeviceFailed:  # pragma: no cover - must not fire
+        pytest.fail("a deliberate stop() must not be reported as a device failure")
+    except SpeakerStreamClosed:
+        pass
+
+
 @pytest.mark.requires_audio_input
 def test_async_read_after_stop_raises_capture_closed() -> None:
     """After await stop(), the next await read() raises MicrophoneStreamClosed."""

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -11,9 +11,14 @@ For other decibri packages, see:
 
 ## [Unreleased]
 
+### Added
+
+- `SpeakerSink::take_last_error`, reporting the device or driver failure recorded while streaming. It reads the same slot as `SpeakerStream::take_last_error`, so a caller holding only a sink can tell a driver failure apart from an explicit `stop()`.
+
 ### Changed
 
 - Whole-recording analysis (`File::analyze`, `File::analyse`) is faster: it runs only the channel and rate normalization the detector reads, not the conditioning transform. The report is unchanged, and iterating a `File` still applies conditioning in full.
+- `SpeakerStream::take_last_error` and `MicrophoneStream::take_last_error` document that the slot holds one error and taking it clears it, so the first observer wins. Keep to one draining call site per consumer.
 
 ## [5.2.1] - 2026-07-25
 

--- a/crates/decibri/src/microphone.rs
+++ b/crates/decibri/src/microphone.rs
@@ -740,6 +740,11 @@ impl MicrophoneStream {
     /// Reading it here drains it (returns `None` afterwards), letting a
     /// consumer that observes a closed stream tell a driver failure apart from
     /// an explicit [`stop`](Self::stop).
+    ///
+    /// The slot holds one error and taking it clears it, so the first observer
+    /// wins. Keep to one draining call site per consumer: a second site that
+    /// takes the error for a different purpose swallows the one the first was
+    /// going to report. A non-consuming read needs its own accessor.
     pub fn take_last_error(&self) -> Option<DecibriError> {
         self.last_error.lock().ok().and_then(|mut slot| slot.take())
     }

--- a/crates/decibri/src/speaker.rs
+++ b/crates/decibri/src/speaker.rs
@@ -282,6 +282,12 @@ impl SpeakerStream {
     /// playback. Reading it here drains it (returns `None` afterwards), letting
     /// a consumer that observes a closed stream tell a driver failure apart
     /// from an explicit [`stop`](Self::stop).
+    ///
+    /// The slot holds one error and taking it clears it, so the first observer
+    /// wins. This stream and every [`SpeakerSink`] it hands out read the same
+    /// slot. Keep to one draining call site per consumer: a second site that
+    /// takes the error for a different purpose swallows the one the first was
+    /// going to report. A non-consuming read needs its own accessor.
     pub fn take_last_error(&self) -> Option<DecibriError> {
         self.last_error.lock().ok().and_then(|mut slot| slot.take())
     }
@@ -321,8 +327,9 @@ impl SpeakerStream {
     /// off-thread `send` and `drain` never block a holder of the stream that
     /// needs `stop` or `is_playing`.
     ///
-    /// The handle shares the same crossbeam channel and atomic drain flags as
-    /// the stream, so [`SpeakerSink::send`] and [`SpeakerSink::drain`] behave
+    /// The handle shares the same crossbeam channel, atomic drain flags and
+    /// device-error slot as the stream, so [`SpeakerSink::send`],
+    /// [`SpeakerSink::drain`] and [`SpeakerSink::take_last_error`] behave
     /// exactly like their [`SpeakerStream`] counterparts. The stream must stay
     /// alive while a sink is in use: dropping the `SpeakerStream` releases the
     /// device, after which a `send` on a surviving sink returns
@@ -333,6 +340,7 @@ impl SpeakerStream {
             running: self.running.clone(),
             sentinel_seq: self.sentinel_seq.clone(),
             sentinels_played: self.sentinels_played.clone(),
+            last_error: self.last_error.clone(),
         }
     }
 }
@@ -375,6 +383,10 @@ pub struct SpeakerSink {
     running: Arc<AtomicBool>,
     sentinel_seq: Arc<AtomicUsize>,
     sentinels_played: Arc<AtomicUsize>,
+    // Shares the originating stream's device-error slot, so a caller holding
+    // only a sink (an off-thread writer) can tell a driver failure apart from
+    // an explicit stop. See [`SpeakerSink::take_last_error`].
+    last_error: Arc<Mutex<Option<DecibriError>>>,
 }
 
 #[cfg(feature = "playback")]
@@ -397,6 +409,18 @@ impl SpeakerSink {
             &self.sentinel_seq,
             &self.sentinels_played,
         );
+    }
+
+    /// Take the last device/driver error reported while streaming, if any.
+    ///
+    /// Reads the same slot as [`SpeakerStream::take_last_error`], so a caller
+    /// that holds only a sink can tell a driver failure apart from an explicit
+    /// [`SpeakerStream::stop`] after a [`send`](Self::send) returns
+    /// [`DecibriError::SpeakerStreamClosed`]. Taking the error clears it, and
+    /// the stream and all its sinks share the one slot, so the first observer
+    /// wins.
+    pub fn take_last_error(&self) -> Option<DecibriError> {
+        self.last_error.lock().ok().and_then(|mut slot| slot.take())
     }
 }
 
@@ -747,6 +771,83 @@ mod tests {
         assert!(
             stream.send(Vec::new()).is_ok(),
             "an empty send is a documented no-op even after stop"
+        );
+    }
+
+    /// Record a device failure the way the cpal output error callback does:
+    /// stash the typed cause, then mark the stream stopped.
+    fn fail_device(stream: &SpeakerStream) {
+        *stream.last_error.lock().unwrap() = Some(DecibriError::DeviceFailed {
+            source: "device disconnected".into(),
+        });
+        stream.running.store(false, Ordering::Relaxed);
+    }
+
+    #[test]
+    fn test_sink_takes_the_device_error_from_the_shared_slot() {
+        let (stream, _receiver, _played) = test_stream();
+        let sink = stream.sink();
+        assert!(
+            sink.take_last_error().is_none(),
+            "a healthy stream's sink has no error to report"
+        );
+
+        fail_device(&stream);
+
+        let err = sink
+            .send(vec![1.0_f32; 4])
+            .expect_err("a send after a device failure must fail");
+        assert!(
+            matches!(err, DecibriError::SpeakerStreamClosed),
+            "the send itself still reports the generic closed-stream error"
+        );
+        let cause = sink
+            .take_last_error()
+            .expect("the sink must reach the stream's device-error slot");
+        assert!(
+            matches!(cause, DecibriError::DeviceFailed { .. }),
+            "the drained cause must be the typed device failure"
+        );
+    }
+
+    #[test]
+    fn test_explicit_stop_leaves_the_error_slot_empty() {
+        let (stream, _receiver, _played) = test_stream();
+        let sink = stream.sink();
+        stream.stop();
+
+        let err = stream
+            .send(vec![1.0_f32; 4])
+            .expect_err("a send after stop() must fail");
+        assert!(matches!(err, DecibriError::SpeakerStreamClosed));
+        assert!(
+            stream.take_last_error().is_none(),
+            "an explicit stop() must never be reported as a device failure"
+        );
+        assert!(
+            sink.take_last_error().is_none(),
+            "an explicit stop() must never be reported as a device failure via a sink"
+        );
+    }
+
+    #[test]
+    fn test_error_slot_is_taken_once_across_stream_and_sinks() {
+        let (stream, _receiver, _played) = test_stream();
+        let sink_a = stream.sink();
+        let sink_b = stream.sink();
+        fail_device(&stream);
+
+        assert!(
+            sink_a.take_last_error().is_some(),
+            "the first observer takes the error"
+        );
+        assert!(
+            sink_b.take_last_error().is_none(),
+            "the slot holds one error and taking it clears it for every holder"
+        );
+        assert!(
+            stream.take_last_error().is_none(),
+            "the stream reads the same slot its sinks do"
         );
     }
 

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -15,6 +15,16 @@ For other decibri packages, see:
 
 - `underrunCount`: a read-only accessor on `Speaker` exposing the core stream's silence-fill counter, in samples. 0 while the producer keeps the queue fed; a rising value means playback is papering over gaps with silence.
 
+### Changed
+
+- Every error that reaches a consumer is a `DecibriError` carrying a `code`. The `Microphone` `'error'` event and the `Speaker` `write()` and `end()` paths previously delivered the raw native error, which reported `name: 'Error'` and the native status string `'GenericFailure'` in `code` for a permission denial, a device loss and a failed open alike, and did not satisfy `instanceof DecibriError`.
+- A playback device that fails mid-stream is reported as `code: 'DEVICE_FAILED'` on the `Speaker` `'error'` event, or as a rejection from `writeAsync()` and `drainAsync()`, instead of the generic closed-stream error. It surfaces on the next write or drain, so a producer that has stopped writing is not told; `isPlaying` goes false immediately either way.
+- `end()` reports a device that failed while the queued tail was still playing, instead of resolving silently. The stream is still stopped and the device released on that path.
+
+### Fixed
+
+- A capture failure raised as `start()` is called (a failed device open, a denied permission) reaches the `'error'` event as a `DecibriError`, instead of escaping as a raw native error.
+
 ## [5.2.2] - 2026-07-25
 
 ### Added

--- a/npm/decibri/src/decibri-output.js
+++ b/npm/decibri/src/decibri-output.js
@@ -10,6 +10,14 @@ const PACKAGE_VERSION = require('../package.json').version;
 
 // ─── Speaker (Writable) ─────────────────────────────────────────────────────
 
+/**
+ * A playback device that fails mid-stream (USB unplug, driver reset) surfaces
+ * on the next write or drain, as a `DecibriError` with `code === 'DEVICE_FAILED'`
+ * on the `'error'` event (or as a rejection from `writeAsync()` / `drainAsync()`).
+ * A producer that has stopped writing is not told; `isPlaying` goes false
+ * immediately either way. A deliberate `stop()` is never reported as a device
+ * failure.
+ */
 class Speaker extends Writable {
   /**
    * @param {import('./decibri').SpeakerOptions} [options]
@@ -143,24 +151,31 @@ class Speaker extends Writable {
       this._native.write(chunk);
       callback();
     } catch (err) {
-      callback(err);
+      callback(wrapNativeError(err));
     }
   }
 
   /** @internal Called by end() after all buffered writes complete. */
   _final(callback) {
+    // end() is terminal: flush all queued audio, then stop. drain() blocks
+    // until everything queued has played (it is a non-terminal flush in the
+    // core), and stop() then ends the stream so isPlaying is false once the
+    // audio has finished. The flush-then-stop order plays the tail to
+    // completion before stopping; reversing it would truncate the audio.
+    // A drain that reports a device failure still has to stop, so the device is
+    // released on the failing path exactly as it is on the clean one.
+    let failure;
     try {
-      // end() is terminal: flush all queued audio, then stop. drain() blocks
-      // until everything queued has played (it is a non-terminal flush in the
-      // core), and stop() then ends the stream so isPlaying is false once the
-      // audio has finished. The flush-then-stop order plays the tail to
-      // completion before stopping; reversing it would truncate the audio.
       this._native.drain();
-      this._native.stop();
-      callback();
     } catch (err) {
-      callback(err);
+      failure = wrapNativeError(err);
     }
+    try {
+      this._native.stop();
+    } catch (err) {
+      failure = failure || wrapNativeError(err);
+    }
+    callback(failure);
   }
 
   /**

--- a/npm/decibri/src/decibri.js
+++ b/npm/decibri/src/decibri.js
@@ -75,6 +75,12 @@ function resolveBundledOrtPath() {
 
 // ─── Microphone (Readable) ──────────────────────────────────────────────────
 
+/**
+ * Failures that reach the consumer arrive on the `'error'` event as a
+ * `DecibriError` carrying a `code`: a failed open or a denied permission when
+ * capture starts, and a device lost mid-capture (`code === 'DEVICE_FAILED'`).
+ * A deliberate `stop()` ends the stream cleanly and raises nothing.
+ */
 class Microphone extends Readable {
   /**
    * @param {import('./decibri').MicrophoneOptions} [options]
@@ -408,39 +414,45 @@ class Microphone extends Readable {
     if (this._started || this._stopped) return;
     this._started = true;
 
-    this._native.start((err, chunk) => {
-      if (err) {
-        this._started = false;
-        // A start()-time failure is delivered here as the raw native error (not
-        // via wrapNativeError), so no decibri `code` is attached on the 'error'
-        // event, as with device-open failures; the dedicated MODEL_LOAD_FAILED
-        // code is reachable through wrapNativeError, not on this streaming path.
-        this.destroy(err);
-        return;
-      }
+    // Both exits from start() reach the consumer on the 'error' event, so both
+    // carry a decibri class and `code`: the synchronous throw below (a failed
+    // device open, a denied permission) and the streaming failure delivered to
+    // the callback (a device lost mid-capture).
+    try {
+      this._native.start((err, chunk) => {
+        if (err) {
+          this._started = false;
+          this.destroy(wrapNativeError(err));
+          return;
+        }
 
-      // On close the native pump flushes the buffered tail; that final data
-      // callback can run after stop() has begun ending the stream. Once the
-      // end-of-stream push(null) has been issued (or the stream was destroyed),
-      // drop any straggler rather than pushing past EOF.
-      if (this._ended || this.destroyed) {
-        return;
-      }
+        // On close the native pump flushes the buffered tail; that final data
+        // callback can run after stop() has begun ending the stream. Once the
+        // end-of-stream push(null) has been issued (or the stream was
+        // destroyed), drop any straggler rather than pushing past EOF.
+        if (this._ended || this.destroyed) {
+          return;
+        }
 
-      // push returns false when the consumer is slow. We can't pause a mic,
-      // but we surface the backpressure warning so callers can react.
-      if (!this.push(chunk)) {
-        this.emit('backpressure');
-      }
+        // push returns false when the consumer is slow. We can't pause a mic,
+        // but we surface the backpressure warning so callers can react.
+        if (!this.push(chunk)) {
+          this.emit('backpressure');
+        }
 
-      if (this._vad) {
-        // Both modes read the score from native: the Silero speech probability
-        // or, in energy mode, the RMS of the pre-enhancement signal. The native
-        // pump computes both on the signal before the opt-in enhancement step,
-        // so enabling enhancement does not change detection in either mode.
-        this._processVadValue(this._native.vadProbability);
-      }
-    });
+        if (this._vad) {
+          // Both modes read the score from native: the Silero speech
+          // probability or, in energy mode, the RMS of the pre-enhancement
+          // signal. The native pump computes both on the signal before the
+          // opt-in enhancement step, so enabling enhancement does not change
+          // detection in either mode.
+          this._processVadValue(this._native.vadProbability);
+        }
+      });
+    } catch (err) {
+      this._started = false;
+      this.destroy(wrapNativeError(err));
+    }
   }
 
   /** @internal Common speech/silence state machine */

--- a/tests/test-ci.js
+++ b/tests/test-ci.js
@@ -803,11 +803,173 @@ async function asyncWriteDrainTests() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// Group 11: every path that delivers an error to a consumer carries a decibri
+// class and code
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// The four delivery paths (Microphone 'error', Speaker write, Speaker end, and
+// the async writeAsync/drainAsync pair) can only fail against a real device that
+// dies mid-stream, so each one is driven here by swapping the native handle for
+// a stub that throws the frozen core Display string a live failure would carry.
+// Assertions are by class and code, never by message text.
+
+// The core's Display strings for the two failures a consumer most needs to tell
+// apart, and a driver failure the core stashes and reports on the next call.
+const DEVICE_LOST = 'decibri: audio device error: device unplugged';
+const PERMISSION_DENIED = 'Microphone permission denied. Check system settings.';
+
+// A native handle stub. `failing` names the call that fails, so every other call
+// behaves normally: 'write', 'drain', 'startCallback' (the pump reports a
+// mid-stream failure), 'start' (the synchronous throw), 'async' (both async
+// methods reject), or 'none' (healthy throughout).
+function nativeStub(message, failing) {
+  const boom = () => {
+    throw new Error(message);
+  };
+  const calls = { stopped: false };
+  return {
+    calls,
+    write: failing === 'write' ? boom : () => {},
+    drain: failing === 'drain' ? boom : () => {},
+    stop() {
+      calls.stopped = true;
+    },
+    start(cb) {
+      if (failing === 'start') boom();
+      // The real pump delivers to this callback from its own thread, never
+      // synchronously inside start().
+      if (failing === 'startCallback') setImmediate(() => cb(new Error(message)));
+    },
+    writeAsync: () => (failing === 'none' ? Promise.resolve() : Promise.reject(new Error(message))),
+    drainAsync: () => (failing === 'none' ? Promise.resolve() : Promise.reject(new Error(message))),
+    get isPlaying() {
+      return false;
+    },
+    get underrunCount() {
+      return 0;
+    },
+    get vadProbability() {
+      return 0;
+    },
+  };
+}
+
+/** Resolve with the first 'error' emitted, or reject if none arrives. */
+function nextError(emitter) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('no error event was emitted')), 2000);
+    emitter.once('error', (err) => {
+      clearTimeout(timer);
+      resolve(err);
+    });
+  });
+}
+
+async function errorDeliveryTests() {
+  console.log('--- Group 11: typed errors on every delivery path ---');
+
+  // PATH 1a: a device lost mid-capture, delivered to the pump callback.
+  {
+    const mic = new Microphone({ sampleRate: 16000, channels: 1 });
+    mic._native = nativeStub(DEVICE_LOST, 'startCallback');
+    mic._read();
+    const err = await nextError(mic);
+    assert(err instanceof DecibriError, 'mic stream failure is a DecibriError');
+    assert(err.code === 'DEVICE_FAILED', `mic stream failure code is DEVICE_FAILED (got ${err.code})`);
+    assert(mic._started === false, 'a stream failure clears _started');
+  }
+
+  // PATH 1b: capture that fails to start at all. The synchronous throw out of
+  // native start() reaches the consumer on the same 'error' event. A permission
+  // denial has no prefix of its own in wrapNativeError, so it carries the
+  // unclassified code; the class and the code are both asserted so a later
+  // narrowing of the code table has to change this line deliberately.
+  {
+    const mic = new Microphone({ sampleRate: 16000, channels: 1 });
+    mic._native = nativeStub(PERMISSION_DENIED, 'start');
+    mic._read();
+    const err = await nextError(mic);
+    assert(err instanceof DecibriError, 'a failed capture start is a DecibriError');
+    assert(err.code === 'DECIBRI_ERROR', `failed-start code is DECIBRI_ERROR (got ${err.code})`);
+    assert(mic._started === false, 'a failed start clears _started');
+  }
+
+  // PATH 2: a device lost under a synchronous write.
+  {
+    const spk = new Speaker({ sampleRate: 16000, channels: 1 });
+    spk._native = nativeStub(DEVICE_LOST, 'write');
+    spk.write(Buffer.alloc(64));
+    const err = await nextError(spk);
+    assert(err instanceof DecibriError, 'speaker write failure is a DecibriError');
+    assert(err.code === 'DEVICE_FAILED', `speaker write failure code is DEVICE_FAILED (got ${err.code})`);
+  }
+
+  // PATH 3: a device lost while end() flushes the tail. The device must still
+  // be released on the failing path.
+  {
+    const spk = new Speaker({ sampleRate: 16000, channels: 1 });
+    const native = nativeStub(DEVICE_LOST, 'drain');
+    spk._native = native;
+    spk.end();
+    const err = await nextError(spk);
+    assert(err instanceof DecibriError, 'speaker end() failure is a DecibriError');
+    assert(err.code === 'DEVICE_FAILED', `speaker end() failure code is DEVICE_FAILED (got ${err.code})`);
+    assert(native.calls.stopped === true, 'end() still stops the stream when the drain fails');
+  }
+
+  // PATH 4: the async pair. These already wrapped before this change; they are
+  // pinned here so all four paths are asserted together. This exercises the JS
+  // wrap only: the native tasks that now report a stashed failure cannot be
+  // driven without a device that actually dies.
+  {
+    const spk = new Speaker({ sampleRate: 16000, channels: 1 });
+    spk._native = nativeStub(DEVICE_LOST, 'async');
+    await assertRejects(() => spk.writeAsync(Buffer.alloc(64)), DecibriError, 'audio device error');
+    await assertRejects(() => spk.drainAsync(), DecibriError, 'audio device error');
+    const rejected = await spk.drainAsync().catch((e) => e);
+    assert(rejected.code === 'DEVICE_FAILED', `drainAsync code is DEVICE_FAILED (got ${rejected.code})`);
+    spk.destroy();
+  }
+
+  // THE REGRESSION THAT MATTERS: a deliberate close is not a device fault.
+  // A healthy native ends cleanly, with 'finish' and no 'error'.
+  {
+    const spk = new Speaker({ sampleRate: 16000, channels: 1 });
+    const native = nativeStub(DEVICE_LOST, 'none');
+    spk._native = native;
+    const outcome = await new Promise((resolve) => {
+      spk.once('error', (e) => resolve({ errored: true, e }));
+      spk.once('finish', () => resolve({ errored: false }));
+      spk.end(Buffer.alloc(64));
+    });
+    assert(outcome.errored === false, 'a deliberate end() is not reported as a device failure');
+    assert(native.calls.stopped === true, 'a clean end() stops the stream');
+  }
+
+  // A deliberate microphone stop() ends the stream cleanly with no 'error'.
+  {
+    const mic = new Microphone({ sampleRate: 16000, channels: 1 });
+    mic._native = nativeStub(DEVICE_LOST, 'none');
+    mic._read();
+    mic.stop();
+    const outcome = await new Promise((resolve) => {
+      mic.once('error', (e) => resolve({ errored: true, e }));
+      mic.once('end', () => resolve({ errored: false }));
+      mic.resume();
+    });
+    assert(outcome.errored === false, 'a deliberate mic stop() is not reported as a device failure');
+  }
+
+  console.log('  Group 11 done\n');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // Summary (runs after the async groups resolve)
 // ═══════════════════════════════════════════════════════════════════════════════
 
 asyncOpenTests()
   .then(asyncWriteDrainTests)
+  .then(errorDeliveryTests)
   .then(() =>
     // The offline File source cases (conditioning, per-chunk VAD in file
     // time, whole-file analysis), sharing this run's counters.


### PR DESCRIPTION
- deliver a typed decibri error from every path that reaches a consumer, replacing the raw native error on the microphone and speaker paths
- drain the core's stashed device failure at the next failing call, so a device fault is distinguishable from a deliberate stop