### PR TITLE
fix(python): validate eagerly and use the core's exception classes

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -22,6 +22,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - A deliberate `stop()` or `close()` is unchanged: it still raises `MicrophoneStreamClosed` or `SpeakerStreamClosed`, and is never reported as a device failure.
 - `Speaker.drain()` and `AsyncSpeaker.drain()` raise `DeviceFailed` when the device failed while the queued audio was still playing, instead of returning normally.
 - A playback device failure surfaces on the next `write()` or `drain()`, so a producer that has stopped writing is not told; `is_playing` goes false immediately either way.
+- **Capture and playback options are validated at construction, where they were validated at `start()`.** A bad `sample_rate`, `channels` or `frames_per_buffer` raises from `Microphone(...)`, `AsyncMicrophone(...)`, `Speaker(...)` and `AsyncSpeaker(...)` rather than from the first `start()`. Code that constructs an invalid instance and handles the failure around `start()` moves that handling to the constructor. `File` already validated at construction and is unchanged.
+- **An out-of-range `agc` or `limiter` raises `AgcTargetOutOfRange` or `LimiterCeilingOutOfRange`, where a builtin `ValueError` was raised before.** Neither derives from `ValueError`, so code catching `ValueError` for these two options catches `DecibriError`, or the class itself, instead. A bad `vad`, `denoise` or `highpass` value still raises `ValueError`.
+- A `model_path` that does not exist is reported at construction. `File(..., vad='silero', model_path=...)` raises `VadModelLoadFailed` from the constructor instead of from the first `read()` or `analyze()`. The path is checked only where Silero VAD reads it, so `vad='energy'` and `vad=False` are unaffected.
+- A bundled model that cannot be located raises `VadModelLoadFailed` or `ModelLoadFailed`, where a builtin `ValueError` was raised before. Both derive from `DecibriError` and carry the model's packaged location in `path`. Code catching `ValueError` for a broken install catches `DecibriError` instead.
 
 ## [0.7.2] - 2026-07-25
 

--- a/bindings/python/python/decibri/_async_classes.py
+++ b/bindings/python/python/decibri/_async_classes.py
@@ -61,6 +61,8 @@ from decibri._classes import (
     File,
     Vad,
     VadReport,
+    _BUNDLED_DENOISE_MODEL,
+    _BUNDLED_VAD_MODEL,
     _DEFAULT_VAD_HOLDOFF_MS,
     _VadStateMachine,
     _VALID_DENOISE_MODELS,
@@ -239,6 +241,18 @@ class AsyncMicrophone:
         resolved_model_path: str | None = None
         if model_path is not None:
             resolved_model_path = str(Path(model_path))
+            # A user-supplied path is checked at construction, as in the sync
+            # Microphone, and only when Silero VAD reads it.
+            if (
+                vad_enabled
+                and vad_mode == "silero"
+                and not Path(resolved_model_path).is_file()
+            ):
+                raise exceptions.VadModelLoadFailed(
+                    f"Silero VAD model not found at {resolved_model_path}. "
+                    "Ensure model_path points to an existing ONNX model file.",
+                    resolved_model_path,
+                )
         elif vad_enabled and vad_mode == "silero":
             try:
                 model_resource = (
@@ -253,11 +267,12 @@ class AsyncMicrophone:
                     )
                 resolved_model_path = str(model_resource)
             except (FileNotFoundError, ModuleNotFoundError, AttributeError) as exc:
-                raise ValueError(
+                raise exceptions.VadModelLoadFailed(
                     "model_path was not provided and the bundled Silero "
                     "model could not be located in the installed wheel. "
                     "Ensure the models/ directory was included during "
-                    "installation, or pass model_path explicitly."
+                    "installation, or pass model_path explicitly.",
+                    _BUNDLED_VAD_MODEL,
                 ) from exc
 
         # Validate and resolve denoise. Same logic as sync Microphone: a
@@ -283,10 +298,11 @@ class AsyncMicrophone:
                     )
                 resolved_denoise_model_path = str(denoise_resource)
             except (FileNotFoundError, ModuleNotFoundError, AttributeError) as exc:
-                raise ValueError(
+                raise exceptions.ModelLoadFailed(
                     "the bundled denoise model could not be located in the "
                     "installed wheel. Ensure the models/ directory was included "
-                    "during installation."
+                    "during installation.",
+                    _BUNDLED_DENOISE_MODEL,
                 ) from exc
 
         # Validate high-pass. Same logic as the sync Microphone: a numeric cutoff
@@ -299,16 +315,18 @@ class AsyncMicrophone:
             )
 
         # Validate AGC. Same logic as the sync Microphone: an integer dBFS target
-        # in [-40, -3] (typical -18); absence leaves it off. The Rust core guards
-        # the same range as a backstop.
+        # in [-40, -3] (typical -18); absence leaves it off. The core names this
+        # failure, so the wrapper raises the core's class.
         if agc is not None and not -40 <= agc <= -3:
-            raise ValueError(f"agc must be in [-40, -3]; got {agc}")
+            raise exceptions.AgcTargetOutOfRange(f"agc must be in [-40, -3]; got {agc}")
 
         # Validate the limiter ceiling. Same logic as the sync Microphone: a
         # sample-peak ceiling in dBFS in [-3.0, 0.0] (typical -1.0); absence
-        # leaves it off. The Rust core guards the same range as a backstop.
+        # leaves it off. The core names this failure, so the wrapper raises its class.
         if limiter is not None and not -3.0 <= limiter <= 0.0:
-            raise ValueError(f"limiter must be in [-3.0, 0.0]; got {limiter}")
+            raise exceptions.LimiterCeilingOutOfRange(
+                f"limiter must be in [-3.0, 0.0]; got {limiter}"
+            )
 
         # Resolve the ORT dylib path via the same four-arm priority order
         # the sync wrapper uses (see _ort_resolver.resolve_ort_dylib_path).

--- a/bindings/python/python/decibri/_classes.py
+++ b/bindings/python/python/decibri/_classes.py
@@ -270,6 +270,11 @@ _VALID_FORMATS = frozenset({"int16", "float32"})
 _VALID_DENOISE_MODELS = frozenset({"fastenhancer-t"})
 _VALID_HIGHPASS = frozenset({80, 100})
 
+# Packaged locations of the bundled models, reported as the ``path`` attribute
+# when the resource cannot be resolved and there is no filesystem path to name.
+_BUNDLED_VAD_MODEL = "decibri/models/silero_vad.onnx"
+_BUNDLED_DENOISE_MODEL = "decibri/models/fastenhancer_t.onnx"
+
 
 class Microphone:
     """Audio capture with VAD policy.
@@ -480,6 +485,19 @@ class Microphone:
         resolved_model_path: str | None = None
         if model_path is not None:
             resolved_model_path = str(Path(model_path))
+            # A user-supplied path is checked at construction, so a path that
+            # does not exist is reported here rather than at the load. Checked
+            # only when Silero VAD reads it; the bridge ignores it otherwise.
+            if (
+                vad_enabled
+                and vad_mode == "silero"
+                and not Path(resolved_model_path).is_file()
+            ):
+                raise exceptions.VadModelLoadFailed(
+                    f"Silero VAD model not found at {resolved_model_path}. "
+                    "Ensure model_path points to an existing ONNX model file.",
+                    resolved_model_path,
+                )
         elif vad_enabled and vad_mode == "silero":
             try:
                 model_resource = (
@@ -498,11 +516,12 @@ class Microphone:
                     )
                 resolved_model_path = str(model_resource)
             except (FileNotFoundError, ModuleNotFoundError, AttributeError) as exc:
-                raise ValueError(
+                raise exceptions.VadModelLoadFailed(
                     "model_path was not provided and the bundled Silero "
                     "model could not be located in the installed wheel. "
                     "Ensure the models/ directory was included during "
-                    "installation, or pass model_path explicitly."
+                    "installation, or pass model_path explicitly.",
+                    _BUNDLED_VAD_MODEL,
                 ) from exc
 
         # Validate and resolve denoise. Closed-set selector mirroring the Silero
@@ -529,10 +548,11 @@ class Microphone:
                     )
                 resolved_denoise_model_path = str(denoise_resource)
             except (FileNotFoundError, ModuleNotFoundError, AttributeError) as exc:
-                raise ValueError(
+                raise exceptions.ModelLoadFailed(
                     "the bundled denoise model could not be located in the "
                     "installed wheel. Ensure the models/ directory was included "
-                    "during installation."
+                    "during installation.",
+                    _BUNDLED_DENOISE_MODEL,
                 ) from exc
 
         # Validate high-pass. Closed growable numeric cutoff selector mirroring
@@ -545,16 +565,18 @@ class Microphone:
             )
 
         # Validate AGC. The target is an integer dBFS level in [-40, -3]
-        # (typical -18); absence leaves it off. Mirrors the Vad threshold range
-        # check; the Rust core guards the same range as a backstop.
+        # (typical -18); absence leaves it off. The core names this failure, so
+        # the wrapper raises the core's class; the core guards the same range.
         if agc is not None and not -40 <= agc <= -3:
-            raise ValueError(f"agc must be in [-40, -3]; got {agc}")
+            raise exceptions.AgcTargetOutOfRange(f"agc must be in [-40, -3]; got {agc}")
 
         # Validate the limiter ceiling. A sample-peak ceiling in dBFS in
-        # [-3.0, 0.0] (typical -1.0); absence leaves it off. Mirrors the agc range
-        # check; the Rust core guards the same range as a backstop.
+        # [-3.0, 0.0] (typical -1.0); absence leaves it off. Mirrors the agc
+        # check: the core names this failure, so the wrapper raises its class.
         if limiter is not None and not -3.0 <= limiter <= 0.0:
-            raise ValueError(f"limiter must be in [-3.0, 0.0]; got {limiter}")
+            raise exceptions.LimiterCeilingOutOfRange(
+                f"limiter must be in [-3.0, 0.0]; got {limiter}"
+            )
 
         # Resolve the ORT dylib path via the four-arm priority order in
         # _ort_resolver. Consulted when an ONNX stage loads (Silero VAD or
@@ -1390,6 +1412,16 @@ class File:
         resolved_model_path: str | None = None
         if model_path is not None:
             resolved_model_path = str(Path(model_path))
+            if (
+                vad_enabled
+                and vad_mode == "silero"
+                and not Path(resolved_model_path).is_file()
+            ):
+                raise exceptions.VadModelLoadFailed(
+                    f"Silero VAD model not found at {resolved_model_path}. "
+                    "Ensure model_path points to an existing ONNX model file.",
+                    resolved_model_path,
+                )
         elif vad_enabled and vad_mode == "silero":
             try:
                 model_resource = (
@@ -1404,11 +1436,12 @@ class File:
                     )
                 resolved_model_path = str(model_resource)
             except (FileNotFoundError, ModuleNotFoundError, AttributeError) as exc:
-                raise ValueError(
+                raise exceptions.VadModelLoadFailed(
                     "model_path was not provided and the bundled Silero "
                     "model could not be located in the installed wheel. "
                     "Ensure the models/ directory was included during "
-                    "installation, or pass model_path explicitly."
+                    "installation, or pass model_path explicitly.",
+                    _BUNDLED_VAD_MODEL,
                 ) from exc
 
         resolved_denoise_model_path: str | None = None
@@ -1430,10 +1463,11 @@ class File:
                     )
                 resolved_denoise_model_path = str(denoise_resource)
             except (FileNotFoundError, ModuleNotFoundError, AttributeError) as exc:
-                raise ValueError(
+                raise exceptions.ModelLoadFailed(
                     "the bundled denoise model could not be located in the "
                     "installed wheel. Ensure the models/ directory was included "
-                    "during installation."
+                    "during installation.",
+                    _BUNDLED_DENOISE_MODEL,
                 ) from exc
 
         if highpass is not None and highpass not in _VALID_HIGHPASS:
@@ -1442,10 +1476,12 @@ class File:
             )
 
         if agc is not None and not -40 <= agc <= -3:
-            raise ValueError(f"agc must be in [-40, -3]; got {agc}")
+            raise exceptions.AgcTargetOutOfRange(f"agc must be in [-40, -3]; got {agc}")
 
         if limiter is not None and not -3.0 <= limiter <= 0.0:
-            raise ValueError(f"limiter must be in [-3.0, 0.0]; got {limiter}")
+            raise exceptions.LimiterCeilingOutOfRange(
+                f"limiter must be in [-3.0, 0.0]; got {limiter}"
+            )
 
         resolved_ort_path: str | None = None
         if (vad_enabled and vad_mode == "silero") or denoise is not None:

--- a/bindings/python/python/decibri/exceptions.py
+++ b/bindings/python/python/decibri/exceptions.py
@@ -4,6 +4,12 @@ This module is the public home for the decibri exception hierarchy. All
 classes are also re-exported at ``decibri.<X>`` for convenience; users
 may import from either path.
 
+decibri raises a DecibriError subclass whenever the core has a name for the
+failure, and a Python built-in when the failure is a wrapper-level argument
+shape the core never sees. An out-of-range agc target raises
+AgcTargetOutOfRange; a malformed vad, denoise or highpass value raises
+ValueError.
+
 43 instance classes plus 3 intermediate parent classes (DeviceError,
 OrtError, OrtPathError) for catch ergonomics, totaling 46 class
 definitions. Single-inheritance hierarchy per CPython convention.

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -889,16 +889,22 @@ impl MicrophoneBridge {
         }
 
         // AGC: thread the dBFS target to the core level-control engine. The
-        // wrapper performs the user-facing range check (a ValueError); the core
-        // guards the same range in validate() (the load-bearing backstop, raised
-        // as AgcTargetOutOfRange), so no inline check is needed here.
+        // wrapper performs the user-facing range check (an AgcTargetOutOfRange);
+        // the core guards the same range in validate() below, so no inline check
+        // is needed here.
         capture_config.agc = agc;
 
         // Limiter: thread the dBFS ceiling to the core limiter stage. The wrapper
-        // performs the user-facing range check (a ValueError); the core guards the
-        // same range in validate() (the load-bearing backstop, raised as
-        // LimiterCeilingOutOfRange), so no inline check is needed here.
+        // performs the user-facing range check (a LimiterCeilingOutOfRange); the
+        // core guards the same range in validate() below, so no inline check is
+        // needed here.
         capture_config.limiter = limiter;
+
+        // Value validation runs at construction: a bad sample rate, channel
+        // count, frame size, agc target or limiter ceiling is reported here,
+        // before any model is loaded or any device is touched. Microphone::new
+        // validates again at start().
+        capture_config.validate().map_err(|e| to_py_err(py, e))?;
 
         // VAD construction gate (Option (b)+(h)). The bridge constructs
         // SileroVad only if vad=True AND vad_mode=="silero". The vad_mode
@@ -1191,6 +1197,11 @@ impl SpeakerBridge {
         output_config.sample_rate = sample_rate;
         output_config.channels = channels;
         output_config.device = device_selector;
+
+        // Value validation runs at construction, mirroring MicrophoneBridge: a
+        // bad sample rate or channel count is reported here rather than at
+        // start(). Speaker::new validates again at start().
+        output_config.validate().map_err(|e| to_py_err(py, e))?;
 
         Ok(SpeakerBridge {
             output_config,

--- a/bindings/python/tests/test_agc.py
+++ b/bindings/python/tests/test_agc.py
@@ -6,9 +6,9 @@ rejection) is CI-safe and runs without audio hardware or ORT. The engine's
 temporal behaviour (cold start, convergence, gating) is covered by the core Rust
 tests; these cover the binding surface only.
 
-The agc target is an integer dBFS level in -40..-3 (typical -18). Unlike the
-closed-set highpass/denoise selectors, it is a numeric range, so an out-of-range
-value is a ``ValueError`` (a range violation) at the wrapper.
+The agc target is an integer dBFS level in -40..-3 (typical -18). The core names
+this failure, so an out-of-range value is an ``AgcTargetOutOfRange`` at the
+wrapper, catchable as ``DecibriError``.
 """
 
 from __future__ import annotations
@@ -44,25 +44,50 @@ def test_agc_range_edges_construct() -> None:
 
 
 def test_agc_out_of_range_raises() -> None:
-    """A target outside [-40, -3] is a clear ValueError, below and above."""
-    with pytest.raises(ValueError, match=r"agc must be in \[-40, -3\]"):
+    """A target outside [-40, -3] raises AgcTargetOutOfRange, below and above."""
+    with pytest.raises(
+        decibri_exc.AgcTargetOutOfRange, match=r"agc must be in \[-40, -3\]"
+    ):
         Microphone(agc=-100)
-    with pytest.raises(ValueError, match=r"agc must be in \[-40, -3\]"):
+    with pytest.raises(
+        decibri_exc.AgcTargetOutOfRange, match=r"agc must be in \[-40, -3\]"
+    ):
         Microphone(agc=0)
 
 
 def test_async_agc_out_of_range_raises() -> None:
-    with pytest.raises(ValueError, match=r"agc must be in \[-40, -3\]"):
+    with pytest.raises(
+        decibri_exc.AgcTargetOutOfRange, match=r"agc must be in \[-40, -3\]"
+    ):
         AsyncMicrophone(agc=-41)
 
 
-def test_agc_target_out_of_range_is_a_dedicated_exception_class() -> None:
-    """The core backstop has its own catchable class in the hierarchy.
+def test_agc_out_of_range_is_catchable_as_decibri_error() -> None:
+    """The wrapper's range check is catchable through the base class.
 
-    The wrapper raises a plain ``ValueError`` for the friendly path; a raw-bridge
-    consumer that bypasses the wrapper trips the core guard, surfaced as the
-    dedicated ``AgcTargetOutOfRange`` (a ``DecibriError`` subclass).
+    The core names this failure, so the wrapper raises the core's class rather
+    than a bare ``ValueError``: ``except DecibriError`` catches a bad agc target
+    the same way it catches a bad dtype.
     """
     assert issubclass(decibri_exc.AgcTargetOutOfRange, decibri_exc.DecibriError)
-    with pytest.raises(decibri_exc.AgcTargetOutOfRange):
-        raise decibri_exc.AgcTargetOutOfRange("agc target level must be between -40 and -3")
+    with pytest.raises(decibri_exc.DecibriError):
+        Microphone(agc=0)
+
+
+def test_agc_out_of_range_from_the_raw_bridge_raises_the_same_class() -> None:
+    """A raw-bridge consumer that bypasses the wrapper trips the core guard.
+
+    Same class, core message: the wrapper's earlier check does not change the
+    identity a bypassing caller sees.
+    """
+    from decibri import _decibri
+
+    with pytest.raises(decibri_exc.AgcTargetOutOfRange) as exc_info:
+        _decibri.MicrophoneBridge(
+            sample_rate=16000,
+            channels=1,
+            frames_per_buffer=1600,
+            format="int16",
+            agc=0,
+        )
+    assert str(exc_info.value) == "agc target level must be between -40 and -3"

--- a/bindings/python/tests/test_async.py
+++ b/bindings/python/tests/test_async.py
@@ -464,13 +464,13 @@ async def test_async_microphone_open_forwards_kwargs() -> None:
     """Kwargs passed to open() reach the underlying constructor."""
     mic = await AsyncMicrophone.open(
         sample_rate=24000,
-        channels=2,
+        channels=1,
         dtype="float32",
         frames_per_buffer=2400,
     )
     text = repr(mic)
     assert "sample_rate=24000" in text
-    assert "channels=2" in text
+    assert "channels=1" in text
     assert "dtype='float32'" in text
     assert "frames_per_buffer=2400" in text
 

--- a/bindings/python/tests/test_config.py
+++ b/bindings/python/tests/test_config.py
@@ -4,15 +4,16 @@ Tests Microphone constructor + start() argument validation with full message-tex
 equality per the hybrid policy (hard-freeze on InvalidArg-family). All tests
 exercise the path a user actually hits, not direct exception instantiation.
 
-Two validation layers:
+Two validation layers, both at construction:
 
 - Wrapper-layer validation in _classes.py (format string lookup): fires at
   Microphone.__init__ time. Message text is composed in Python with the
   offending value interpolated.
-- Rust-core validation in AudioCapture::new via config.validate(): fires at
-  Microphone.start() time, BEFORE any cpal device interaction. Runs in CI
-  without audio hardware. Message text from crates/decibri/src/error.rs
-  Display impls (static strings; no value interpolation).
+- Rust-core validation via config.validate() in the bridge constructor: fires
+  at Microphone.__init__ time as well, BEFORE any cpal device interaction.
+  Runs in CI without audio hardware. Message text from
+  crates/decibri/src/error.rs Display impls (static strings; no value
+  interpolation). Microphone.start() validates the same config again.
 
 Notes on PyO3 boundary:
 - sample_rate / frames_per_buffer are u32; channels is u16. Passing negative
@@ -20,7 +21,7 @@ Notes on PyO3 boundary:
   Rust validation. These cases are not reachable via the Python surface and
   are not part of the test matrix.
 - Positive out-of-range values pass through PyO3 cleanly and trigger
-  validation at .start() time.
+  validation at construction.
 
 VAD-specific validations (the Vad object's threshold range and holdoff_ms,
 the vad selector value) raise bare ValueError (not DecibriError subclasses)
@@ -36,6 +37,7 @@ from decibri import (
     InvalidFormat,
     MultichannelNotSupported,
     SampleRateOutOfRange,
+    Speaker,
 )
 
 
@@ -84,7 +86,7 @@ def test_invalid_format_wrapper(dtype_value: str, expected_msg: str) -> None:
 
 # ---------------------------------------------------------------------------
 # Bridge-layer validation: sample_rate / channels / frames_per_buffer
-# range checks fire at Microphone.start() via CaptureConfig::validate(). The
+# range checks fire at Microphone.__init__ via CaptureConfig::validate(). The
 # validate() call runs BEFORE cpal device interaction, so the test does NOT
 # need audio hardware. Messages from error.rs Display impls.
 # ---------------------------------------------------------------------------
@@ -100,18 +102,16 @@ def test_invalid_format_wrapper(dtype_value: str, expected_msg: str) -> None:
     ],
 )
 def test_invalid_sample_rate(sample_rate: int) -> None:
-    """Out-of-range sample_rate raises with the canonical Rust Display message at start()."""
-    d = Microphone(sample_rate=sample_rate)
+    """Out-of-range sample_rate raises the canonical Rust Display message at construction."""
     with pytest.raises(SampleRateOutOfRange) as exc_info:
-        d.start()
+        Microphone(sample_rate=sample_rate)
     assert str(exc_info.value) == "sample rate must be between 1000 and 384000"
 
 
 def test_zero_channels_is_out_of_range() -> None:
-    """A zero channel count raises the plain ChannelsOutOfRange at start()."""
-    d = Microphone(channels=0)
+    """A zero channel count raises the plain ChannelsOutOfRange at construction."""
     with pytest.raises(ChannelsOutOfRange) as exc_info:
-        d.start()
+        Microphone(channels=0)
     assert str(exc_info.value) == "channels must be between 1 and 32"
 
 
@@ -125,11 +125,10 @@ def test_zero_channels_is_out_of_range() -> None:
 )
 def test_multichannel_request_is_rejected(channels: int) -> None:
     """Capture is mono only: more than one channel raises MultichannelNotSupported
-    at start() (rejected, not silently downmixed) with the canonical Rust message.
+    at construction (rejected, not silently downmixed) with the canonical Rust message.
     """
-    d = Microphone(channels=channels)
     with pytest.raises(MultichannelNotSupported) as exc_info:
-        d.start()
+        Microphone(channels=channels)
     assert (
         str(exc_info.value)
         == "multichannel capture is not supported; channels must be 1 (mono)"
@@ -146,11 +145,51 @@ def test_multichannel_request_is_rejected(channels: int) -> None:
     ],
 )
 def test_invalid_frames_per_buffer(frames_per_buffer: int) -> None:
-    """Out-of-range frames_per_buffer raises with the canonical Display message at start()."""
-    d = Microphone(frames_per_buffer=frames_per_buffer)
+    """Out-of-range frames_per_buffer raises the canonical Display message at construction."""
     with pytest.raises(FramesPerBufferOutOfRange) as exc_info:
-        d.start()
+        Microphone(frames_per_buffer=frames_per_buffer)
     assert str(exc_info.value) == "frames per buffer must be between 64 and 65536"
+
+
+# ---------------------------------------------------------------------------
+# Speaker: the same bridge-layer validation, at Speaker.__init__. SpeakerConfig
+# validates sample_rate and channels only (playback accepts up to 32 channels,
+# so there is no multichannel rejection here). Hardware-free.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sample_rate",
+    [
+        pytest.param(0, id="speaker_sample_rate_zero"),
+        pytest.param(999, id="speaker_sample_rate_below_minimum"),
+        pytest.param(384001, id="speaker_sample_rate_above_maximum"),
+    ],
+)
+def test_speaker_invalid_sample_rate(sample_rate: int) -> None:
+    """Out-of-range sample_rate raises at Speaker construction, not at start()."""
+    with pytest.raises(SampleRateOutOfRange) as exc_info:
+        Speaker(sample_rate=sample_rate)
+    assert str(exc_info.value) == "sample rate must be between 1000 and 384000"
+
+
+@pytest.mark.parametrize(
+    "channels",
+    [
+        pytest.param(0, id="speaker_channels_zero"),
+        pytest.param(33, id="speaker_channels_above_maximum"),
+    ],
+)
+def test_speaker_invalid_channels(channels: int) -> None:
+    """Out-of-range channels raises at Speaker construction, not at start()."""
+    with pytest.raises(ChannelsOutOfRange) as exc_info:
+        Speaker(channels=channels)
+    assert str(exc_info.value) == "channels must be between 1 and 32"
+
+
+def test_speaker_stereo_constructs() -> None:
+    """Playback is not mono only: a stereo speaker still constructs."""
+    Speaker(sample_rate=24000, channels=2)
 
 
 # ---------------------------------------------------------------------------
@@ -174,3 +213,31 @@ def test_invalid_frames_per_buffer(frames_per_buffer: int) -> None:
 def test_boundary_values_construct_cleanly(kwargs: dict) -> None:
     """Values exactly at min/max boundaries construct without raising."""
     Microphone(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# The positive path: validating at construction does not obstruct a valid
+# configuration, which still constructs AND starts. Hardware-marked.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_audio_input
+def test_valid_config_still_starts() -> None:
+    """A valid capture config constructs and still opens a device at start()."""
+    d = Microphone(sample_rate=16000, channels=1, frames_per_buffer=512)
+    d.start()
+    try:
+        assert d.is_open is True
+    finally:
+        d.stop()
+
+
+@pytest.mark.requires_audio_output
+def test_valid_speaker_config_still_starts() -> None:
+    """A valid playback config constructs and still opens a device at start()."""
+    o = Speaker(sample_rate=16000, channels=1)
+    o.start()
+    try:
+        assert o.is_playing is True
+    finally:
+        o.stop()

--- a/bindings/python/tests/test_denoise.py
+++ b/bindings/python/tests/test_denoise.py
@@ -26,6 +26,26 @@ from decibri import AsyncMicrophone, Microphone, ModelLoadFailed
 # ---------------------------------------------------------------------------
 
 
+def test_missing_bundled_denoise_model_raises_the_typed_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unresolvable bundled model raises ModelLoadFailed, not ValueError."""
+    import importlib.resources
+
+    from decibri import DecibriError
+
+    def _unresolvable(package: str) -> object:
+        raise ModuleNotFoundError(package)
+
+    monkeypatch.setattr(importlib.resources, "files", _unresolvable)
+
+    with pytest.raises(ModelLoadFailed) as exc_info:
+        Microphone(denoise="fastenhancer-t")
+    err = exc_info.value
+    assert isinstance(err, DecibriError)
+    assert err.path == "decibri/models/fastenhancer_t.onnx"
+
+
 def test_denoise_constructs() -> None:
     """A valid model name constructs; the model loads later, at start()."""
     mic = Microphone(sample_rate=16000, channels=1, denoise="fastenhancer-t")

--- a/bindings/python/tests/test_file.py
+++ b/bindings/python/tests/test_file.py
@@ -184,6 +184,40 @@ def test_open_invalid_wav_raises(tmp_path: Path) -> None:
         File(path)
 
 
+def test_missing_model_path_raises_at_construction(tmp_path: Path) -> None:
+    """A model_path that does not exist fails at construction, not at read().
+
+    The File builds its detector on first read, so the path check is the only
+    thing standing between a typo and a failure several calls later. Needs
+    neither the golden fixture nor ORT.
+    """
+    from decibri import VadModelLoadFailed
+
+    missing = str(tmp_path / "no-such-decibri-model-7c5d.onnx")
+    with pytest.raises(VadModelLoadFailed) as exc_info:
+        File.buffer(
+            sine_samples(16000, 0.2),
+            input_rate=16000,
+            vad="silero",
+            model_path=missing,
+        )
+    err = exc_info.value
+    assert isinstance(err, DecibriError)
+    assert "no-such-decibri-model-7c5d.onnx" in err.path
+
+
+def test_missing_model_path_is_ignored_in_energy_mode(tmp_path: Path) -> None:
+    """The path is checked only where it is read: energy mode never loads it."""
+    missing = str(tmp_path / "no-such-decibri-model-2b8f.onnx")
+    file = File.buffer(
+        sine_samples(16000, 0.2),
+        input_rate=16000,
+        vad="energy",
+        model_path=missing,
+    )
+    assert file is not None
+
+
 def test_repr_shows_construction() -> None:
     file = File.buffer([0.0] * 1600, input_rate=16000)
     assert repr(file) == "File(sample_rate=16000, dtype='int16', vad=False)"

--- a/bindings/python/tests/test_limiter.py
+++ b/bindings/python/tests/test_limiter.py
@@ -7,8 +7,8 @@ behaviour (the absolute-ceiling guarantee, graceful shaping, release) is covered
 by the core Rust tests; these cover the binding surface only.
 
 The limiter ceiling is a float dBFS level in -3.0..0.0 (typical -1.0). Like the
-agc target it is a numeric range, so an out-of-range value is a ``ValueError`` (a
-range violation) at the wrapper.
+agc target the core names this failure, so an out-of-range value is a
+``LimiterCeilingOutOfRange`` at the wrapper, catchable as ``DecibriError``.
 """
 
 from __future__ import annotations
@@ -44,27 +44,50 @@ def test_limiter_range_edges_construct() -> None:
 
 
 def test_limiter_out_of_range_raises() -> None:
-    """A ceiling outside [-3.0, 0.0] is a clear ValueError, below and above."""
-    with pytest.raises(ValueError, match=r"limiter must be in \[-3.0, 0.0\]"):
+    """A ceiling outside [-3.0, 0.0] raises LimiterCeilingOutOfRange, below and above."""
+    with pytest.raises(
+        decibri_exc.LimiterCeilingOutOfRange, match=r"limiter must be in \[-3.0, 0.0\]"
+    ):
         Microphone(limiter=-5.0)
-    with pytest.raises(ValueError, match=r"limiter must be in \[-3.0, 0.0\]"):
+    with pytest.raises(
+        decibri_exc.LimiterCeilingOutOfRange, match=r"limiter must be in \[-3.0, 0.0\]"
+    ):
         Microphone(limiter=1.0)
 
 
 def test_async_limiter_out_of_range_raises() -> None:
-    with pytest.raises(ValueError, match=r"limiter must be in \[-3.0, 0.0\]"):
+    with pytest.raises(
+        decibri_exc.LimiterCeilingOutOfRange, match=r"limiter must be in \[-3.0, 0.0\]"
+    ):
         AsyncMicrophone(limiter=0.5)
 
 
-def test_limiter_ceiling_out_of_range_is_a_dedicated_exception_class() -> None:
-    """The core backstop has its own catchable class in the hierarchy.
+def test_limiter_out_of_range_is_catchable_as_decibri_error() -> None:
+    """The wrapper's range check is catchable through the base class.
 
-    The wrapper raises a plain ``ValueError`` for the friendly path; a raw-bridge
-    consumer that bypasses the wrapper trips the core guard, surfaced as the
-    dedicated ``LimiterCeilingOutOfRange`` (a ``DecibriError`` subclass).
+    The core names this failure, so the wrapper raises the core's class rather
+    than a bare ``ValueError``: ``except DecibriError`` catches a bad limiter
+    ceiling the same way it catches a bad dtype.
     """
     assert issubclass(decibri_exc.LimiterCeilingOutOfRange, decibri_exc.DecibriError)
-    with pytest.raises(decibri_exc.LimiterCeilingOutOfRange):
-        raise decibri_exc.LimiterCeilingOutOfRange(
-            "limiter ceiling must be between -3.0 and 0.0"
+    with pytest.raises(decibri_exc.DecibriError):
+        Microphone(limiter=1.0)
+
+
+def test_limiter_out_of_range_from_the_raw_bridge_raises_the_same_class() -> None:
+    """A raw-bridge consumer that bypasses the wrapper trips the core guard.
+
+    Same class, core message: the wrapper's earlier check does not change the
+    identity a bypassing caller sees.
+    """
+    from decibri import _decibri
+
+    with pytest.raises(decibri_exc.LimiterCeilingOutOfRange) as exc_info:
+        _decibri.MicrophoneBridge(
+            sample_rate=16000,
+            channels=1,
+            frames_per_buffer=1600,
+            format="int16",
+            limiter=1.0,
         )
+    assert str(exc_info.value) == "limiter ceiling must be between -3.0 and 0.0"

--- a/bindings/python/tests/test_microphone_properties.py
+++ b/bindings/python/tests/test_microphone_properties.py
@@ -16,10 +16,10 @@ Validation layers (mirrors test_config.py docstring):
 - Wrapper-layer validation in _classes.py: dtype string lookup at
   Microphone.__init__ time; raises InvalidFormat with an interpolated
   Python f-string message.
-- Bridge-layer validation in AudioCapture::new via CaptureConfig::validate:
-  fires at Microphone.start() time, BEFORE any cpal device interaction.
-  Runs in CI without audio hardware. Messages from error.rs Display impls
-  (static strings; no value interpolation).
+- Bridge-layer validation via CaptureConfig::validate in the bridge
+  constructor: fires at Microphone.__init__ time, BEFORE any cpal device
+  interaction. Runs in CI without audio hardware. Messages from error.rs
+  Display impls (static strings; no value interpolation).
 
 Hypothesis settings: max_examples=20, deadline=None per test. Total file
 runtime is bounded under 30 seconds on a typical CI runner; combined with
@@ -90,11 +90,8 @@ _invalid_dtype = st.text(min_size=0, max_size=32).filter(
 # ---------------------------------------------------------------------------
 # Section A: invalid inputs route through typed decibri exceptions.
 #
-# Validation point varies by argument:
-#   dtype             -> __init__ time (wrapper layer)
-#   sample_rate       -> .start() time (bridge layer)
-#   channels          -> .start() time (bridge layer)
-#   frames_per_buffer -> .start() time (bridge layer)
+# Every argument validates at __init__ time: dtype at the wrapper layer, the
+# rest at the bridge layer.
 #
 # All four exceptions are subclasses of DecibriError; passing the property
 # is equivalent to "no panic / abort / untyped exception under fuzz".
@@ -104,37 +101,33 @@ _invalid_dtype = st.text(min_size=0, max_size=32).filter(
 @given(sample_rate=_invalid_sample_rate)
 @settings(max_examples=20, deadline=None)
 def test_invalid_sample_rate_property(sample_rate: int) -> None:
-    """Any out-of-range sample_rate raises SampleRateOutOfRange at start()."""
-    mic = Microphone(sample_rate=sample_rate)
+    """Any out-of-range sample_rate raises SampleRateOutOfRange at construction."""
     with pytest.raises(SampleRateOutOfRange):
-        mic.start()
+        Microphone(sample_rate=sample_rate)
 
 
 @given(channels=_multichannel_channels)
 @settings(max_examples=20, deadline=None)
 def test_multichannel_channels_property(channels: int) -> None:
-    """Any channel count above 1 raises MultichannelNotSupported at start()
+    """Any channel count above 1 raises MultichannelNotSupported at construction
     (capture is mono only: the request is rejected, not silently downmixed).
     """
-    mic = Microphone(channels=channels)
     with pytest.raises(MultichannelNotSupported):
-        mic.start()
+        Microphone(channels=channels)
 
 
 def test_zero_channels_is_out_of_range() -> None:
-    """A zero channel count raises the plain ChannelsOutOfRange at start()."""
-    mic = Microphone(channels=0)
+    """A zero channel count raises the plain ChannelsOutOfRange at construction."""
     with pytest.raises(ChannelsOutOfRange):
-        mic.start()
+        Microphone(channels=0)
 
 
 @given(frames_per_buffer=_invalid_frames_per_buffer)
 @settings(max_examples=20, deadline=None)
 def test_invalid_frames_per_buffer_property(frames_per_buffer: int) -> None:
-    """Any out-of-range frames_per_buffer raises FramesPerBufferOutOfRange at start()."""
-    mic = Microphone(frames_per_buffer=frames_per_buffer)
+    """Any out-of-range frames_per_buffer raises FramesPerBufferOutOfRange at construction."""
     with pytest.raises(FramesPerBufferOutOfRange):
-        mic.start()
+        Microphone(frames_per_buffer=frames_per_buffer)
 
 
 @given(dtype=_invalid_dtype)

--- a/bindings/python/tests/test_repr.py
+++ b/bindings/python/tests/test_repr.py
@@ -38,14 +38,14 @@ def test_microphone_repr_shows_defaults_and_is_open() -> None:
 def test_microphone_repr_reflects_custom_params() -> None:
     mic = decibri.Microphone(
         sample_rate=24000,
-        channels=2,
+        channels=1,
         dtype="float32",
         frames_per_buffer=2400,
         vad="energy",
     )
     text = repr(mic)
     assert "sample_rate=24000" in text
-    assert "channels=2" in text
+    assert "channels=1" in text
     assert "dtype='float32'" in text
     assert "frames_per_buffer=2400" in text
     assert "vad='energy'" in text

--- a/bindings/python/tests/test_vad.py
+++ b/bindings/python/tests/test_vad.py
@@ -387,12 +387,11 @@ def test_vad_energy_mode_end_to_end() -> None:
         assert 0.0 <= d.vad_score <= 1.0
 
 
-@pytest.mark.requires_bundled_ort
 def test_silero_missing_model_path_raises_typed_error(tmp_path: Path) -> None:
     """A model_path that does not exist raises VadModelLoadFailed with .path.
 
-    No device is opened: the detector is built during construction, so this
-    needs ORT but no microphone.
+    The existence check runs at construction, before the model is loaded, so
+    this needs neither a microphone nor ORT.
     """
     from decibri import DecibriError, OrtError, VadModelLoadFailed
 
@@ -409,6 +408,64 @@ def test_silero_missing_model_path_raises_typed_error(tmp_path: Path) -> None:
     assert isinstance(err, OrtError)
     assert isinstance(err, DecibriError)
     assert "no-such-decibri-model-b8f2.onnx" in err.path
+
+
+def test_async_silero_missing_model_path_raises_typed_error(tmp_path: Path) -> None:
+    """AsyncMicrophone mirrors the sync existence check."""
+    from decibri import VadModelLoadFailed
+
+    missing = str(tmp_path / "no-such-decibri-model-c4a1.onnx")
+    with pytest.raises(VadModelLoadFailed) as exc_info:
+        AsyncMicrophone(vad="silero", model_path=missing)
+    assert "no-such-decibri-model-c4a1.onnx" in exc_info.value.path
+
+
+def test_missing_model_path_is_ignored_when_silero_is_not_selected(
+    tmp_path: Path,
+) -> None:
+    """The path is checked only where it is read: energy mode never loads it."""
+    missing = str(tmp_path / "no-such-decibri-model-9d3e.onnx")
+    assert Microphone(vad="energy", model_path=missing) is not None
+    assert Microphone(vad=False, model_path=missing) is not None
+
+
+def test_missing_bundled_vad_model_raises_the_typed_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unresolvable bundled model raises VadModelLoadFailed, not ValueError."""
+    import importlib.resources
+
+    from decibri import DecibriError, VadModelLoadFailed
+
+    def _unresolvable(package: str) -> object:
+        raise ModuleNotFoundError(package)
+
+    monkeypatch.setattr(importlib.resources, "files", _unresolvable)
+
+    with pytest.raises(VadModelLoadFailed) as exc_info:
+        Microphone(vad="silero")
+    err = exc_info.value
+    assert isinstance(err, DecibriError)
+    assert err.path == "decibri/models/silero_vad.onnx"
+
+
+def test_wrapper_only_options_still_raise_value_error() -> None:
+    """The other half of the rule: no core name means a Python built-in.
+
+    ``vad``, ``denoise`` and ``highpass`` shape errors have no core variant, so
+    they stay plain ``ValueError`` and are deliberately not DecibriError.
+    """
+    from decibri import DecibriError
+
+    for kwargs in (
+        {"vad": "maybe"},
+        {"vad": True},
+        {"denoise": "nope"},
+        {"highpass": 60},
+    ):
+        with pytest.raises(ValueError) as exc_info:
+            Microphone(**kwargs)  # type: ignore[arg-type]
+        assert not isinstance(exc_info.value, DecibriError)
 
 
 @pytest.mark.requires_audio_input


### PR DESCRIPTION
Python now validates option values at construction rather than at the operation that uses them, and raises the core's own exception class for every option the core also names.

**Validation timing**

- The capture and speaker config are validated in the bridge constructors, so a bad `sample_rate`, `frames_per_buffer` or `channels` raises at construction instead of at `start()`. The async bridges inherit this by delegation.
- A user-supplied `model_path` is checked for existence at construction in all three resolution blocks, so a `File` no longer defers the failure to the first `read()` or `analyze()`. The check runs when Silero VAD is selected, matching the node entry.

**Exception classes**

- A missing bundled model raises `VadModelLoadFailed` or `ModelLoadFailed` instead of `ValueError`.
- An out-of-range `agc` or `limiter` raises `AgcTargetOutOfRange` or `LimiterCeilingOutOfRange` instead of `ValueError`. Neither derives from `ValueError`, so `except ValueError` no longer catches them and `except DecibriError` now does.
- `dtype` keeps `InvalidFormat`. `vad`, `denoise`, `highpass` and the `vad=True` migration error keep `ValueError`, because the core has no name for them.
- The rule is stated in the `decibri.exceptions` module docstring.

**Scope**

- Python only. No change to `crates/decibri`, `npm/decibri` or `bindings/node`.
- No new public names. Every exception class raised here already existed and was already exported.

**Summary**
- validate the capture and speaker config in the bridge constructors in bindings/python/src/lib.rs, so a bad value raises at construction not at start
- check a user-supplied model path exists at construction in all three resolution blocks in bindings/python/python/decibri/
- raise VadModelLoadFailed and ModelLoadFailed for a missing bundled model instead of ValueError
- raise AgcTargetOutOfRange and LimiterCeilingOutOfRange for out-of-range agc and limiter values instead of ValueError, and state the rule in the module docstring
