### PR TITLE
feat(node): add File rate getters and align the browser entry

### DIFF
--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -14,8 +14,12 @@ For other decibri packages, see:
 ### Added
 
 - `underrunCount`: a read-only accessor on `Speaker` exposing the core stream's silence-fill counter, in samples. 0 while the producer keeps the queue fed; a rising value means playback is papering over gaps with silence.
+- `File.sampleRate` and `File.inputRate`: read-only accessors reporting the rate every delivered chunk carries and the source's own rate, taken from the WAV header or from the `inputRate` passed to `File.buffer`. They differ when the source was resampled, which is the only way a caller learns that it was. Both read for the life of the `File`, including after the source is consumed or closed.
 
 ### Changed
+
+- **The browser build rejects a non-numeric `vad` `threshold` or `holdoffMs`, which it accepted before.** A string, or any other non-number, was stored as given; every later score comparison against it evaluated false, so the detector never fired and nothing reported why. A non-numeric `holdoffMs` reached the silence timer directly. Both now raise a `TypeError`, with the Node build's messages: `vad threshold must be a number` and `vad holdoffMs must be a number`.
+- **The browser build raises `RangeError` where it raised `TypeError` for an out-of-range `threshold`, `holdoffMs` and `sampleRate`, and carries the Node build's messages.** The messages are now `vad threshold must be between 0 and 1`, `vad holdoffMs must be non-negative` and `sample rate must be between 1000 and 384000`; they previously read `threshold must be between 0 and 1, got <value>`, `holdoffMs must be >= 0, got <value>` and `sample rate must be between 1000 and 384000, got <value>`. Code that catches `TypeError` for these three options, or that matches the old message text, needs updating.
 
 - Every error that reaches a consumer is a `DecibriError` carrying a `code`. The `Microphone` `'error'` event and the `Speaker` `write()` and `end()` paths previously delivered the raw native error, which reported `name: 'Error'` and the native status string `'GenericFailure'` in `code` for a permission denial, a device loss and a failed open alike, and did not satisfy `instanceof DecibriError`.
 - A playback device that fails mid-stream is reported as `code: 'DEVICE_FAILED'` on the `Speaker` `'error'` event, or as a rejection from `writeAsync()` and `drainAsync()`, instead of the generic closed-stream error. It surfaces on the next write or drain, so a producer that has stopped writing is not told; `isPlaying` goes false immediately either way.

--- a/npm/decibri/examples/decibri.browser.js
+++ b/npm/decibri/examples/decibri.browser.js
@@ -108,11 +108,13 @@ var decibri = (function() {
 					if (vad.model !== "energy") throw new TypeError(`Invalid vad model: ${JSON.stringify(vad.model)}. Expected 'energy'.`);
 					this._vad = true;
 					if (vad.threshold !== void 0) {
-						if (vad.threshold < 0 || vad.threshold > 1) throw new TypeError(`threshold must be between 0 and 1, got ${vad.threshold}`);
+						if (typeof vad.threshold !== "number" || Number.isNaN(vad.threshold)) throw new TypeError("vad threshold must be a number");
+						if (vad.threshold < 0 || vad.threshold > 1) throw new RangeError("vad threshold must be between 0 and 1");
 						vadThreshold = vad.threshold;
 					}
 					if (vad.holdoffMs !== void 0) {
-						if (vad.holdoffMs < 0) throw new TypeError(`holdoffMs must be >= 0, got ${vad.holdoffMs}`);
+						if (typeof vad.holdoffMs !== "number" || Number.isNaN(vad.holdoffMs)) throw new TypeError("vad holdoffMs must be a number");
+						if (vad.holdoffMs < 0) throw new RangeError("vad holdoffMs must be non-negative");
 						vadHoldoff = vad.holdoffMs;
 					}
 				} else throw new TypeError(`Invalid vad value: ${JSON.stringify(vad)}. Expected false, 'energy', or a config object { model, threshold, holdoffMs }.`);
@@ -129,7 +131,7 @@ var decibri = (function() {
 				this._echoCancellation = options.echoCancellation ?? true;
 				this._noiseSuppression = options.noiseSuppression ?? true;
 				this._workletUrl = options.workletUrl;
-				if (this._sampleRate < 1e3 || this._sampleRate > 384e3) throw new TypeError(`sample rate must be between 1000 and 384000, got ${this._sampleRate}`);
+				if (this._sampleRate < 1e3 || this._sampleRate > 384e3) throw new RangeError("sample rate must be between 1000 and 384000");
 				if (this._channels < 1 || this._channels > 32) throw new TypeError(`channels must be between 1 and 32, got ${this._channels}`);
 				if (this._framesPerBuffer < 64 || this._framesPerBuffer > 65536) throw new TypeError(`frames per buffer must be between 64 and 65536, got ${this._framesPerBuffer}`);
 				if (this._dtype !== "int16" && this._dtype !== "float32") throw new TypeError("dtype must be 'int16' or 'float32'");

--- a/npm/decibri/src/browser/decibri-browser.js
+++ b/npm/decibri/src/browser/decibri-browser.js
@@ -62,15 +62,23 @@ class Microphone extends Emitter {
         throw new TypeError(`Invalid vad model: ${JSON.stringify(vad.model)}. Expected 'energy'.`);
       }
       this._vad = true;
+      // The guards, the error classes and the messages are the node entry's,
+      // so the same option value is rejected the same way in both runtimes.
       if (vad.threshold !== undefined) {
+        if (typeof vad.threshold !== 'number' || Number.isNaN(vad.threshold)) {
+          throw new TypeError('vad threshold must be a number');
+        }
         if (vad.threshold < 0 || vad.threshold > 1) {
-          throw new TypeError(`threshold must be between 0 and 1, got ${vad.threshold}`);
+          throw new RangeError('vad threshold must be between 0 and 1');
         }
         vadThreshold = vad.threshold;
       }
       if (vad.holdoffMs !== undefined) {
+        if (typeof vad.holdoffMs !== 'number' || Number.isNaN(vad.holdoffMs)) {
+          throw new TypeError('vad holdoffMs must be a number');
+        }
         if (vad.holdoffMs < 0) {
-          throw new TypeError(`holdoffMs must be >= 0, got ${vad.holdoffMs}`);
+          throw new RangeError('vad holdoffMs must be non-negative');
         }
         vadHoldoff = vad.holdoffMs;
       }
@@ -95,7 +103,7 @@ class Microphone extends Emitter {
 
     // ── Validate ──────────────────────────────────────────────────────────
     if (this._sampleRate < 1000 || this._sampleRate > 384000) {
-      throw new TypeError(`sample rate must be between 1000 and 384000, got ${this._sampleRate}`);
+      throw new RangeError('sample rate must be between 1000 and 384000');
     }
     if (this._channels < 1 || this._channels > 32) {
       throw new TypeError(`channels must be between 1 and 32, got ${this._channels}`);

--- a/npm/decibri/src/browser/decibri-output-browser.js
+++ b/npm/decibri/src/browser/decibri-output-browser.js
@@ -100,7 +100,7 @@ class Speaker {
     this._dtype = options.dtype ?? 'int16';
     this._workletUrl = options.workletUrl;
 
-    // ── Validate (mirrors the browser Microphone error style: TypeError) ────
+    // ── Validate ──────────────────────────────────────────────────────────
     if (this._sampleRate < 1000 || this._sampleRate > 384000) {
       throw new TypeError(`sample rate must be between 1000 and 384000, got ${this._sampleRate}`);
     }

--- a/npm/decibri/src/decibri.d.ts
+++ b/npm/decibri/src/decibri.d.ts
@@ -473,6 +473,19 @@ export declare class File extends Readable {
   readonly vadScore: number;
 
   /**
+   * The rate every delivered chunk carries: the `sampleRate` option, or
+   * 16000 when it was not given.
+   */
+  readonly sampleRate: number;
+
+  /**
+   * The source's own rate, taken from the WAV header or from the
+   * `inputRate` passed to `File.buffer`. Differs from `sampleRate` when the
+   * source was resampled.
+   */
+  readonly inputRate: number;
+
+  /**
    * Analyze the whole recording for speech, off the event loop. Resolves to
    * a `VadReport` with per-window `scores` and merged speech `segments`,
    * all in seconds of file time. Consumes the source (a `File` is a single

--- a/npm/decibri/src/decibri.js
+++ b/npm/decibri/src/decibri.js
@@ -995,6 +995,27 @@ class File extends Readable {
   }
 
   /**
+   * The rate every delivered chunk carries: the `sampleRate` option, or 16000
+   * when it was not given. Readable for the life of the File, including after
+   * the source is consumed or closed.
+   * @returns {number}
+   */
+  get sampleRate() {
+    return this._native.sampleRate;
+  }
+
+  /**
+   * The source's own rate, taken from the WAV header or from the `inputRate`
+   * passed to `File.buffer`. Differs from `sampleRate` when the source was
+   * resampled. Readable for the life of the File, including after the source
+   * is consumed or closed.
+   * @returns {number}
+   */
+  get inputRate() {
+    return this._native.inputRate;
+  }
+
+  /**
    * Analyze the whole recording for speech. Runs the recording once through
    * the conditioning pass off the event loop and resolves to a `VadReport`:
    * per-window `scores` (`{ start, end, vadScore, isSpeech }`) and merged

--- a/tests/browser/decibri-browser.test.js
+++ b/tests/browser/decibri-browser.test.js
@@ -87,6 +87,16 @@ const { Microphone } = await import('../../npm/decibri/src/browser/decibri-brows
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+/** The error a call throws, so its class and message can both be asserted. */
+function thrownBy(fn) {
+  try {
+    fn();
+  } catch (err) {
+    return err;
+  }
+  throw new Error('expected the call to throw');
+}
+
 function resetMocks() {
   vi.clearAllMocks();
   mockPortOnMessage.onmessage = null;
@@ -126,8 +136,13 @@ describe('Microphone constructor', () => {
 
 describe('Microphone constructor validation', () => {
   it('throws on invalid sampleRate', () => {
-    expect(() => new Microphone({ sampleRate: 0 })).toThrow('sample rate');
-    expect(() => new Microphone({ sampleRate: 500000 })).toThrow('sample rate');
+    // Out of range is a RangeError carrying the node entry's message, so the
+    // same value is rejected identically in both runtimes.
+    for (const sampleRate of [0, 500000]) {
+      const err = thrownBy(() => new Microphone({ sampleRate }));
+      expect(err).toBeInstanceOf(RangeError);
+      expect(err.message).toBe('sample rate must be between 1000 and 384000');
+    }
   });
 
   it('throws on invalid framesPerBuffer', () => {
@@ -141,12 +156,35 @@ describe('Microphone constructor validation', () => {
   });
 
   it('throws on invalid vad threshold', () => {
-    expect(() => new Microphone({ vad: { model: 'energy', threshold: -1 } })).toThrow('threshold');
-    expect(() => new Microphone({ vad: { model: 'energy', threshold: 2 } })).toThrow('threshold');
+    for (const threshold of [-1, 2]) {
+      const err = thrownBy(() => new Microphone({ vad: { model: 'energy', threshold } }));
+      expect(err).toBeInstanceOf(RangeError);
+      expect(err.message).toBe('vad threshold must be between 0 and 1');
+    }
+  });
+
+  it('throws on a non-numeric vad threshold', () => {
+    // A string threshold compares false against every score, so accepting it
+    // leaves the detector permanently quiet with nothing reported.
+    for (const threshold of ['high', NaN, null, {}]) {
+      const err = thrownBy(() => new Microphone({ vad: { model: 'energy', threshold } }));
+      expect(err).toBeInstanceOf(TypeError);
+      expect(err.message).toBe('vad threshold must be a number');
+    }
   });
 
   it('throws on invalid vad holdoffMs', () => {
-    expect(() => new Microphone({ vad: { model: 'energy', holdoffMs: -100 } })).toThrow('holdoffMs');
+    const err = thrownBy(() => new Microphone({ vad: { model: 'energy', holdoffMs: -100 } }));
+    expect(err).toBeInstanceOf(RangeError);
+    expect(err.message).toBe('vad holdoffMs must be non-negative');
+  });
+
+  it('throws on a non-numeric vad holdoffMs', () => {
+    for (const holdoffMs of ['300', NaN, null, {}]) {
+      const err = thrownBy(() => new Microphone({ vad: { model: 'energy', holdoffMs } }));
+      expect(err).toBeInstanceOf(TypeError);
+      expect(err.message).toBe('vad holdoffMs must be a number');
+    }
   });
 
   it('throws on an unknown vad model', () => {

--- a/tests/test-ci.js
+++ b/tests/test-ci.js
@@ -641,6 +641,94 @@ console.log('--- Group 7c: typed model, resampler, and enumeration failures ---'
 console.log('  Group 7c done\n');
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// Group 7d: the browser entry rejects the same input the same way
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// One package, one option name, one documented meaning: a value the node entry
+// refuses has to be refused by the browser entry with the same class and the
+// same message. Asserted against both entries in one place so the two cannot
+// drift apart silently. The browser module is plain JS and touches no browser
+// global before start(), so its constructor runs under plain Node here.
+
+console.log('--- Group 7d: browser and node entry validation parity ---');
+
+const { Microphone: BrowserMicrophone } = require(
+  path.join(__dirname, '..', 'npm', 'decibri', 'src', 'browser', 'decibri-browser.js')
+);
+
+const parityCases = [
+  {
+    label: "vad threshold 'high'",
+    options: { vad: { model: 'energy', threshold: 'high' } },
+    type: TypeError,
+    message: 'vad threshold must be a number',
+  },
+  {
+    label: 'vad threshold NaN',
+    options: { vad: { model: 'energy', threshold: NaN } },
+    type: TypeError,
+    message: 'vad threshold must be a number',
+  },
+  {
+    label: 'vad threshold 5',
+    options: { vad: { model: 'energy', threshold: 5 } },
+    type: RangeError,
+    message: 'vad threshold must be between 0 and 1',
+  },
+  {
+    label: "vad holdoffMs '300'",
+    options: { vad: { model: 'energy', holdoffMs: '300' } },
+    type: TypeError,
+    message: 'vad holdoffMs must be a number',
+  },
+  {
+    label: 'vad holdoffMs -1',
+    options: { vad: { model: 'energy', holdoffMs: -1 } },
+    type: RangeError,
+    message: 'vad holdoffMs must be non-negative',
+  },
+  {
+    label: 'sampleRate 0',
+    options: { sampleRate: 0 },
+    type: RangeError,
+    message: 'sample rate must be between 1000 and 384000',
+  },
+  {
+    label: 'sampleRate 500000',
+    options: { sampleRate: 500000 },
+    type: RangeError,
+    message: 'sample rate must be between 1000 and 384000',
+  },
+];
+
+for (const { label, options, type, message } of parityCases) {
+  const thrown = {};
+  for (const [entry, Ctor] of [['node', Microphone], ['browser', BrowserMicrophone]]) {
+    try {
+      new Ctor(options);
+      console.log(`  FAIL: ${entry} entry accepted ${label}`);
+      failed++;
+    } catch (e) {
+      thrown[entry] = e;
+      assert(e instanceof type, `${entry} entry rejects ${label} with a ${type.name}`);
+      assert(e.message === message, `${entry} entry message for ${label} is "${message}" (got "${e.message}")`);
+    }
+  }
+  if (thrown.node && thrown.browser) {
+    assert(
+      thrown.node.constructor === thrown.browser.constructor,
+      `both entries throw the same class for ${label} (${thrown.node.constructor.name} / ${thrown.browser.constructor.name})`
+    );
+    assert(
+      thrown.node.message === thrown.browser.message,
+      `both entries throw the same message for ${label}`
+    );
+  }
+}
+
+console.log('  Group 7d done\n');
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // Group 8: Denoise option (deterministic, no hardware required)
 // ═══════════════════════════════════════════════════════════════════════════════
 //

--- a/tests/test-file.js
+++ b/tests/test-file.js
@@ -126,6 +126,42 @@ async function fileTests(h) {
   const mean = sum / (conditioned.length / 2) / 32768;
   assert(Math.abs(mean) < 0.05, `dcRemoval conditions the delivered audio (mean ${mean.toFixed(3)})`);
 
+  console.log('File: rate getters');
+
+  // sampleRate is the rate every delivered chunk carries; inputRate is the
+  // source's own rate. They match when nothing was resampled.
+  const rateDefault = new File(wavPath);
+  assert(rateDefault.sampleRate === 16000, `sampleRate defaults to 16000 (got ${rateDefault.sampleRate})`);
+  assert(rateDefault.inputRate === 16000, `inputRate reads the WAV header (got ${rateDefault.inputRate})`);
+  rateDefault.close();
+
+  // A WAV read at a different engine rate: the two getters disagree, which is
+  // the only way a caller learns the source was resampled.
+  const wav48Path = path.join(tmp, 'clip-48k.wav');
+  writeWav(wav48Path, sineSamples(48000, 0.25), 48000);
+  const rateResampled = await File.open(wav48Path, { sampleRate: 16000 });
+  assert(rateResampled.sampleRate === 16000, `sampleRate reports the engine rate (got ${rateResampled.sampleRate})`);
+  assert(rateResampled.inputRate === 48000, `inputRate reports the source rate (got ${rateResampled.inputRate})`);
+
+  // Both survive a full pass and a close, the same as vadScore: the File keeps
+  // answering what it was configured with after the source is gone.
+  await readAll(rateResampled);
+  assert(
+    rateResampled.sampleRate === 16000 && rateResampled.inputRate === 48000,
+    'the rate getters still read after the source is consumed'
+  );
+  rateResampled.close();
+  assert(
+    rateResampled.sampleRate === 16000 && rateResampled.inputRate === 48000,
+    'the rate getters still read after close()'
+  );
+
+  // The buffer path reports the explicit inputRate it was given.
+  const rateBuffered = File.buffer(sineSamples(44100, 0.1), { inputRate: 44100, sampleRate: 22050 });
+  assert(rateBuffered.sampleRate === 22050, `buffer sampleRate is the requested rate (got ${rateBuffered.sampleRate})`);
+  assert(rateBuffered.inputRate === 44100, `buffer inputRate is the declared rate (got ${rateBuffered.inputRate})`);
+  rateBuffered.close();
+
   console.log('File: buffer input enforcement');
 
   // A raw Buffer of bytes is ambiguous and rejected; so is anything that is


### PR DESCRIPTION
Closes two gaps in the Node surface: two missing getters, and a browser entry that disagreed with the node entry.

**File rate getters**

- `File.sampleRate` returns the engine rate and `File.inputRate` returns the source rate, both forwarding the native handle. `inputRate` is the only way a caller learns whether the source was resampled, since the WAV header is parsed internally and discarded.
- Scoped to `File`. `Microphone` exposes no rate getter, so this adds no new asymmetry.

**Browser entry**

- A non-numeric `vad` `threshold` or `holdoffMs` was accepted silently. With a string threshold both range comparisons were false, the value was stored, and the detector never fired with nothing reporting why. Both now raise `TypeError`, as the node entry already did.
- An out-of-range `threshold`, `holdoffMs` or `sampleRate` raised `TypeError` and now raises `RangeError`, matching the node entry.
- The four messages are now the node entry's messages. Parity between the two entries is asserted input by input in the CI suite.

**Scope**

- npm package only. No change to `crates/decibri` and no Python change.
- New public names: `File.sampleRate` and `File.inputRate`.