### PR TITLE
fix(python): raise ImportError for ndarray output without numpy

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -27,6 +27,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - A `model_path` that does not exist is reported at construction. `File(..., vad='silero', model_path=...)` raises `VadModelLoadFailed` from the constructor instead of from the first `read()` or `analyze()`. The path is checked only where Silero VAD reads it, so `vad='energy'` and `vad=False` are unaffected.
 - A bundled model that cannot be located raises `VadModelLoadFailed` or `ModelLoadFailed`, where a builtin `ValueError` was raised before. Both derive from `DecibriError` and carry the model's packaged location in `path`. Code catching `ValueError` for a broken install catches `DecibriError` instead.
 
+### Fixed
+
+- Requesting ndarray output without numpy installed raises `ImportError` (install with `pip install decibri[numpy]`) from the constructor, on every surface accepting `as_ndarray=True`, where an uncatchable `pyo3_runtime.PanicException` was raised from the first `read()`. A plain `except Exception` now catches the failure.
+
 ## [0.7.2] - 2026-07-25
 
 ### Added

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -42,14 +42,14 @@ dependencies = [
     "typing-extensions>=4.15",
 ]
 
-# numpy is the optional ndarray-support extra. Users who want
-# `Decibri(numpy=True)` and `output.write(np_array)` install via
-# `pip install decibri[numpy]`. The Rust binary always includes the
-# rust-numpy code paths (compile-time gating adds CI complexity for
-# negligible binary-size savings); calling `numpy=True` without the
-# Python `numpy` package installed raises a clear ImportError at the
-# first PyArray construction. Lower bound 1.20 covers the abi3-py310
-# baseline and matches industry convention (sounddevice, polars).
+# numpy is the optional ndarray-support extra. Users who want ndarray
+# output (`as_ndarray=True`) or who want to pass an ndarray to playback
+# install via `pip install decibri[numpy]`. The Rust binary always
+# includes the rust-numpy code paths, so the extra is a Python
+# dependency only. Requesting ndarray output without the Python `numpy`
+# package installed raises ImportError at construction. Lower bound 1.20
+# covers the abi3-py310 baseline and matches industry convention
+# (sounddevice, polars).
 [project.optional-dependencies]
 numpy = ["numpy>=1.20"]
 

--- a/bindings/python/python/decibri/_async_classes.py
+++ b/bindings/python/python/decibri/_async_classes.py
@@ -64,6 +64,7 @@ from decibri._classes import (
     _BUNDLED_DENOISE_MODEL,
     _BUNDLED_VAD_MODEL,
     _DEFAULT_VAD_HOLDOFF_MS,
+    _require_numpy,
     _VadStateMachine,
     _VALID_DENOISE_MODELS,
     _VALID_FORMATS,
@@ -193,6 +194,12 @@ class AsyncMicrophone:
             raise exceptions.InvalidFormat(
                 f"dtype must be 'int16' or 'float32'; got {dtype!r}"
             )
+
+        # ndarray output requires numpy at read time; checked here, before
+        # the bridge is constructed, so a missing install raises a catchable
+        # ImportError from the constructor.
+        if as_ndarray:
+            _require_numpy()
 
         # Decompose ``vad`` into the bridge's (enabled, mode) split plus the
         # threshold/holdoff policy values. Mirrors Microphone exactly; see
@@ -466,9 +473,9 @@ class AsyncMicrophone:
         thread on the Rust side runs to completion; its result (if any) is
         dropped. The bridge state remains consistent for subsequent reads.
 
-        Raises ``ImportError`` with a clear actionable message if
-        ``as_ndarray=True`` is set but ``numpy`` is not installed (i.e.
-        the user did not run ``pip install decibri[numpy]``).
+        ``as_ndarray=True`` requires the optional ``numpy`` extra; a
+        missing numpy raises ``ImportError`` at construction (install
+        with ``pip install decibri[numpy]``).
         """
         try:
             chunk = await self._bridge.read(timeout_ms=timeout_ms)

--- a/bindings/python/python/decibri/_classes.py
+++ b/bindings/python/python/decibri/_classes.py
@@ -276,6 +276,22 @@ _BUNDLED_VAD_MODEL = "decibri/models/silero_vad.onnx"
 _BUNDLED_DENOISE_MODEL = "decibri/models/fastenhancer_t.onnx"
 
 
+def _require_numpy() -> None:
+    """Raise ``ImportError`` when numpy is not installed.
+
+    Called wherever ``as_ndarray=True`` is accepted, before the bridge is
+    constructed, so a missing numpy surfaces as a normal, catchable
+    ``ImportError`` instead of a failure from inside the extension. The
+    message matches the read-path guard's message exactly.
+    """
+    try:
+        import numpy  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "numpy is not installed. Install with: pip install decibri[numpy]"
+        ) from exc
+
+
 class Microphone:
     """Audio capture with VAD policy.
 
@@ -431,6 +447,12 @@ class Microphone:
             raise exceptions.InvalidFormat(
                 f"dtype must be 'int16' or 'float32'; got {dtype!r}"
             )
+
+        # ndarray output requires numpy at read time; checked here, before
+        # the bridge is constructed, so a missing install raises a catchable
+        # ImportError from the constructor.
+        if as_ndarray:
+            _require_numpy()
 
         # Decompose ``vad`` into the bridge's (enabled, mode) split plus the
         # threshold/holdoff policy values. ``vad`` accepts False (disabled;
@@ -727,10 +749,9 @@ class Microphone:
         so the returned chunk is not inspected for VAD and the return type
         (bytes vs ndarray) does not affect it.
 
-        Raises ``ImportError`` with a clear actionable message if
-        ``as_ndarray=True`` is set but the optional ``numpy`` extra is
-        not installed (i.e. the user did not run
-        ``pip install decibri[numpy]``).
+        ``as_ndarray=True`` requires the optional ``numpy`` extra; a
+        missing numpy raises ``ImportError`` at construction (install
+        with ``pip install decibri[numpy]``).
         """
         try:
             chunk = self._bridge.read(timeout_ms=timeout_ms)
@@ -1375,6 +1396,12 @@ class File:
             raise exceptions.InvalidFormat(
                 f"dtype must be 'int16' or 'float32'; got {dtype!r}"
             )
+
+        # ndarray output requires numpy at read time; checked here, before
+        # the bridge is constructed, so a missing install raises a catchable
+        # ImportError from the constructor.
+        if as_ndarray:
+            _require_numpy()
 
         vad_enabled: bool
         vad_mode: str

--- a/bindings/python/tests/test_numpy.py
+++ b/bindings/python/tests/test_numpy.py
@@ -3,7 +3,8 @@
 Covers: construction with as_ndarray=True (no NotImplementedError),
 bytes-mode regression (default), ndarray return on read, dtype/shape
 correctness, ndarray-accept on write, dtype mismatch rejection, async
-parallel, and the 5-test smoke baseline still passing.
+parallel, the missing-numpy construction guard (absence simulated via
+``sys.modules``), and the 5-test smoke baseline still passing.
 
 By convention, every async test has explicit
 ``@pytest.mark.asyncio``. Hardware-gated tests use the existing
@@ -16,10 +17,15 @@ assertions on synthetic data) don't need hardware markers.
 
 from __future__ import annotations
 
+import struct
+import sys
+import wave
+from pathlib import Path
+
 import numpy as np
 import pytest
 
-from decibri import AsyncMicrophone, AsyncSpeaker, Microphone, Speaker
+from decibri import AsyncFile, AsyncMicrophone, AsyncSpeaker, File, Microphone, Speaker
 
 
 # ---------------------------------------------------------------------------
@@ -173,3 +179,174 @@ async def test_async_write_accepts_ndarray() -> None:
     async with AsyncSpeaker(dtype="int16") as o:
         await o.write(samples)
         await o.drain()
+
+
+# ---------------------------------------------------------------------------
+# Missing-numpy guard (no hardware needed)
+#
+# Absence is simulated per test with a ``None`` entry in ``sys.modules``:
+# any ``import numpy`` then raises ImportError while the module object
+# already imported above (the ``np`` global) stays usable, and pytest's
+# ``monkeypatch`` restores the real entry on teardown, so no state
+# outlives the test. Mirrors the bundled-model tests, which simulate
+# their failure by monkeypatching the resource lookup.
+# ---------------------------------------------------------------------------
+
+_MISSING_NUMPY_MESSAGE = (
+    "numpy is not installed. Install with: pip install decibri[numpy]"
+)
+
+
+def _block_numpy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``import numpy`` raise ImportError for the current test."""
+    monkeypatch.setitem(sys.modules, "numpy", None)
+
+
+def _write_wav(path: Path, n_samples: int = 8000) -> None:
+    """Write a small silent mono 16-bit PCM WAV via the standard library."""
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(16000)
+        w.writeframes(struct.pack(f"<{n_samples}h", *([0] * n_samples)))
+
+
+def test_missing_numpy_microphone_raises_importerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``Microphone(as_ndarray=True)`` without numpy raises ``ImportError``."""
+    _block_numpy(monkeypatch)
+    with pytest.raises(ImportError) as excinfo:
+        Microphone(as_ndarray=True, vad=False)
+    assert str(excinfo.value) == _MISSING_NUMPY_MESSAGE
+
+
+def test_missing_numpy_is_caught_by_except_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The missing-numpy failure is caught by a plain ``except Exception``."""
+    _block_numpy(monkeypatch)
+    try:
+        Microphone(as_ndarray=True, vad=False)
+    except Exception as exc:
+        assert isinstance(exc, ImportError)
+        assert str(exc) == _MISSING_NUMPY_MESSAGE
+    else:
+        pytest.fail("Microphone(as_ndarray=True) did not raise without numpy")
+
+
+def test_missing_numpy_async_microphone_raises_importerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``AsyncMicrophone(as_ndarray=True)`` without numpy raises ``ImportError``."""
+    _block_numpy(monkeypatch)
+    with pytest.raises(ImportError) as excinfo:
+        AsyncMicrophone(as_ndarray=True, vad=False)
+    assert str(excinfo.value) == _MISSING_NUMPY_MESSAGE
+
+
+@pytest.mark.asyncio
+async def test_missing_numpy_async_microphone_open_raises_importerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``await AsyncMicrophone.open(as_ndarray=True)`` raises ``ImportError``."""
+    _block_numpy(monkeypatch)
+    with pytest.raises(ImportError) as excinfo:
+        await AsyncMicrophone.open(as_ndarray=True, vad=False)
+    assert str(excinfo.value) == _MISSING_NUMPY_MESSAGE
+
+
+def test_missing_numpy_file_surfaces_raise_importerror(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``File(path)``, ``File.open`` and ``File.buffer`` all raise the guard."""
+    _block_numpy(monkeypatch)
+    path = tmp_path / "clip.wav"
+    _write_wav(path)
+    with pytest.raises(ImportError) as excinfo:
+        File(path, as_ndarray=True)
+    assert str(excinfo.value) == _MISSING_NUMPY_MESSAGE
+    with pytest.raises(ImportError) as excinfo:
+        File.open(path, as_ndarray=True)
+    assert str(excinfo.value) == _MISSING_NUMPY_MESSAGE
+    with pytest.raises(ImportError) as excinfo:
+        File.buffer([0.0] * 1600, input_rate=16000, as_ndarray=True)
+    assert str(excinfo.value) == _MISSING_NUMPY_MESSAGE
+
+
+@pytest.mark.asyncio
+async def test_missing_numpy_async_file_surfaces_raise_importerror(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``AsyncFile(path)``, ``AsyncFile.open`` and ``AsyncFile.buffer`` raise."""
+    _block_numpy(monkeypatch)
+    path = tmp_path / "clip.wav"
+    _write_wav(path)
+    with pytest.raises(ImportError) as excinfo:
+        AsyncFile(path, as_ndarray=True)
+    assert str(excinfo.value) == _MISSING_NUMPY_MESSAGE
+    with pytest.raises(ImportError) as excinfo:
+        await AsyncFile.open(path, as_ndarray=True)
+    assert str(excinfo.value) == _MISSING_NUMPY_MESSAGE
+    with pytest.raises(ImportError) as excinfo:
+        await AsyncFile.buffer([0.0] * 1600, input_rate=16000, as_ndarray=True)
+    assert str(excinfo.value) == _MISSING_NUMPY_MESSAGE
+
+
+def test_missing_numpy_default_bytes_mode_unaffected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``as_ndarray=False`` constructs and reads bytes without numpy."""
+    _block_numpy(monkeypatch)
+    assert Microphone(vad=False) is not None
+    path = tmp_path / "clip.wav"
+    _write_wav(path)
+    chunk = File(path).read()
+    assert isinstance(chunk, bytes)
+    buffered = File.buffer([0.0] * 1600, input_rate=16000).read()
+    assert isinstance(buffered, bytes)
+
+
+# ---------------------------------------------------------------------------
+# With numpy present, the guarded surfaces still work (regression for the
+# guard sitting in front of a working path). File reads need no hardware.
+# ---------------------------------------------------------------------------
+
+
+def test_file_read_returns_ndarray_with_numpy_present(tmp_path: Path) -> None:
+    """``File(path, as_ndarray=True).read()`` returns an int16 ndarray."""
+    path = tmp_path / "clip.wav"
+    _write_wav(path)
+    for file in (File(path, as_ndarray=True), File.open(path, as_ndarray=True)):
+        chunk = file.read()
+        assert isinstance(chunk, np.ndarray)
+        assert chunk.dtype == np.int16
+
+
+def test_file_buffer_read_returns_ndarray_with_numpy_present() -> None:
+    """``File.buffer(..., as_ndarray=True).read()`` returns an ndarray."""
+    chunk = File.buffer([0.0] * 1600, input_rate=16000, as_ndarray=True).read()
+    assert isinstance(chunk, np.ndarray)
+
+
+@pytest.mark.asyncio
+async def test_async_file_read_returns_ndarray_with_numpy_present(
+    tmp_path: Path,
+) -> None:
+    """Every ``AsyncFile`` constructor still yields ndarray reads."""
+    path = tmp_path / "clip.wav"
+    _write_wav(path)
+    for f in (
+        AsyncFile(path, as_ndarray=True),
+        await AsyncFile.open(path, as_ndarray=True),
+        await AsyncFile.buffer([0.0] * 1600, input_rate=16000, as_ndarray=True),
+    ):
+        chunk = await f.read()
+        assert isinstance(chunk, np.ndarray)
+
+
+@pytest.mark.asyncio
+async def test_async_microphone_open_constructs_with_numpy_present() -> None:
+    """``await AsyncMicrophone.open(as_ndarray=True)`` constructs cleanly."""
+    mic = await AsyncMicrophone.open(as_ndarray=True, vad=False)
+    assert mic is not None

--- a/bindings/python/tests/test_wheel_smoke.py
+++ b/bindings/python/tests/test_wheel_smoke.py
@@ -76,14 +76,30 @@ def test_async_construct() -> None:
 
 
 def test_as_ndarray_construct() -> None:
-    """Microphone(as_ndarray=True) constructs cleanly (verifies rust-numpy bundling).
+    """Microphone(as_ndarray=True) constructs with numpy, or raises without it.
 
-    Construction only; no actual read. The as_ndarray=True flag exercises
-    the rust-numpy code path's presence in the wheel; calling read()
-    would also exercise it but requires audio hardware.
+    Construction only; no actual read. With numpy installed the
+    constructor succeeds; without it (the wheel-install venv, which
+    carries no numpy) the constructor raises the guard's ``ImportError``,
+    so the production install surface verifies the failure is a normal
+    catchable error.
     """
-    d = decibri.Microphone(as_ndarray=True)
-    assert d is not None
+    try:
+        import numpy  # noqa: F401
+
+        numpy_available = True
+    except ImportError:
+        numpy_available = False
+
+    if numpy_available:
+        d = decibri.Microphone(as_ndarray=True)
+        assert d is not None
+    else:
+        with pytest.raises(ImportError) as excinfo:
+            decibri.Microphone(as_ndarray=True)
+        assert str(excinfo.value) == (
+            "numpy is not installed. Install with: pip install decibri[numpy]"
+        )
 
 
 def test_wheel_size_within_budget() -> None:


### PR DESCRIPTION
Requesting ndarray output with numpy absent raised `pyo3_runtime.PanicException`, which derives from `BaseException` rather than `Exception`, so a caller's `except Exception` could not catch it.

**What was wrong**

- The wrapper already carried `ImportError` guards for this case, but they sat around the bridge read calls and a panic can never match them, so the handlers were dead.
- The panic came from rust-numpy's lazy array-API initialisation, reached from the bridge read paths. The bridge constructors only stored the flag, so the failure fired at the first read rather than at construction.
- `AsyncMicrophone.read()` was the exception, surfacing it as a catchable `RustPanic` carrying the message "rust future panicked: unknown error".

**What changes**

- A check runs at construction, on every surface accepting `as_ndarray`, before anything crosses into the extension. Nine public surfaces funnel into three roots and all three are guarded.
- The failure is now `ImportError`, catchable by `except Exception`, naming `pip install decibri[numpy]`.
- It raises at construction, where it previously crashed at the first read.
- The wheel-install CI job runs in a venv without numpy, so its ndarray smoke test now asserts the guard rather than a bare construction. That job becomes a real no-numpy acceptance test.