### PR TITLE
fix(ci): cover test targets in every feature combination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,16 +74,27 @@ jobs:
         run: cargo test -p decibri --no-default-features --features capture,playback,vad,denoise,gain,ort-load-dynamic --test vad_ort_load_failure
 
   feature-combinations:
-    name: Feature Combinations
+    name: Feature Combinations (${{ matrix.name }})
     runs-on: ubuntu-latest
     needs: lint
     strategy:
       fail-fast: false
-      # `cargo check` each meaningful feature selection so a future change that
-      # breaks a feature gate (a module, a re-export, or a DecibriError variant
-      # that fails to compile under some combination) is caught. `check` is used
-      # rather than `build` because the goal is gate breakage, not artifacts, and
-      # it neither links nor downloads ONNX Runtime.
+      # Each meaningful feature selection is exercised so a change that breaks
+      # a feature gate (a module, a re-export, or a DecibriError variant that
+      # fails to compile under some combination) is caught, and so the test
+      # targets stay compilable, and where possible green, under every
+      # combination. Each cell carries its own command:
+      #   - The cells with no ONNX Runtime dependency (capture, playback,
+      #     capture+playback) run `cargo test`: lib tests, integration tests,
+      #     and doctests under that feature selection.
+      #   - The ORT-backed cells run `cargo check --all-targets`, which
+      #     type-checks every test target without linking or downloading ONNX
+      #     Runtime. Their tests cannot execute here: `default` pins
+      #     ort-load-dynamic and no ORT dylib is resolvable on a runner, while
+      #     `vad` and `no-vad-full` select no ORT distribution mode, so their
+      #     test binaries do not link. The maximal feature set's tests run in
+      #     the Rust Tests job via the cargo test-decibri alias
+      #     (ort-download-binaries).
       #
       # Exclusions, by design:
       #   - The execution-provider features (coreml, cuda, directml, rocm) are
@@ -94,16 +105,15 @@ jobs:
       #     ort-download-binaries) are mutually exclusive (compile_error! in
       #     lib.rs), so there is no single "all features" build. The `default`
       #     entry below is the maximal CI-compilable set (it pins
-      #     ort-load-dynamic); ort-download-binaries is already exercised by the
-      #     Rust Tests job via the cargo test-decibri alias.
+      #     ort-load-dynamic).
       matrix:
         include:
-          - { name: default, flags: "" }
-          - { name: capture, flags: "--no-default-features --features capture" }
-          - { name: playback, flags: "--no-default-features --features playback" }
-          - { name: capture+playback, flags: "--no-default-features --features capture,playback" }
-          - { name: vad, flags: "--no-default-features --features vad" }
-          - { name: no-vad-full, flags: "--no-default-features --features capture,playback,denoise,gain" }
+          - { name: default, command: "check --all-targets", flags: "" }
+          - { name: capture, command: "test", flags: "--no-default-features --features capture" }
+          - { name: playback, command: "test", flags: "--no-default-features --features playback" }
+          - { name: capture+playback, command: "test", flags: "--no-default-features --features capture,playback" }
+          - { name: vad, command: "check --all-targets", flags: "--no-default-features --features vad" }
+          - { name: no-vad-full, command: "check --all-targets", flags: "--no-default-features --features capture,playback,denoise,gain" }
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -111,8 +121,8 @@ jobs:
         with:
           shared-key: "rust"
       - run: sudo apt-get update && sudo apt-get install -y libasound2-dev
-      - name: cargo check (${{ matrix.name }})
-        run: cargo check -p decibri ${{ matrix.flags }}
+      - name: cargo ${{ matrix.command }} (${{ matrix.name }})
+        run: cargo ${{ matrix.command }} -p decibri ${{ matrix.flags }}
 
   test-node:
     name: Node.js Tests

--- a/crates/decibri/src/lib.rs
+++ b/crates/decibri/src/lib.rs
@@ -48,7 +48,11 @@
 //! timeout while the stream is still open, and
 //! `Err(DecibriError::MicrophoneStreamClosed)` once the stream ends.
 //!
-//! ```no_run
+// The example uses Microphone and SileroVad, so it is a compilable doctest
+// only when both `capture` and `vad` are enabled; other feature selections
+// render it as a plain text block instead of compiling it.
+#![cfg_attr(all(feature = "capture", feature = "vad"), doc = "```no_run")]
+#![cfg_attr(not(all(feature = "capture", feature = "vad")), doc = "```text")]
 //! use std::time::Duration;
 //! use decibri::{Microphone, MicrophoneConfig, SileroVad, VadConfig, DecibriError};
 //!

--- a/crates/decibri/src/microphone.rs
+++ b/crates/decibri/src/microphone.rs
@@ -1861,6 +1861,11 @@ mod tests {
     /// on the tap does not. This is the energy-mode analogue of
     /// `test_vad_input_returns_pre_transform_signal`, asserted through the RMS
     /// the bindings now compute in native.
+    ///
+    /// Needs the `gain` feature: with it compiled out the AGC transform is
+    /// inert, the delivered level equals the pre-transform level, and the
+    /// divergence assertion cannot hold.
+    #[cfg(feature = "gain")]
     #[test]
     fn test_energy_score_invariant_to_transform() {
         // A quiet sine: AGC boosts it well above its input level, so the


### PR DESCRIPTION
The feature matrix ran `cargo check` without `--all-targets`, so no test target was ever built under any feature combination, and nothing was ever run.

What changes

- Each matrix cell now carries its own command alongside its flags, so what a cell does is readable from its row.
- `capture`, `playback` and `capture+playback` run `cargo test`, which covers lib tests, integration tests and doctests under that selection. Plain, not `--all-targets`, which would exclude doctests.
- `default`, `vad` and `no-vad-full` run `cargo check --all-targets`, which type-checks every test target. Their tests cannot execute on a runner: `default` pins `ort-load-dynamic` and no ONNX Runtime dylib is resolvable, while `vad` and `no-vad-full` select no distribution mode, so their test binaries do not link. The maximal feature set's tests run in the Rust Tests job.
- The job name is set explicitly, so the six checks read `(default)`, `(capture)`, `(playback)`, `(capture+playback)`, `(vad)` and `(no-vad-full)`.

Two failures the change exposes, both fixed by gating rather than by weakening what they assert:

- The energy-score invariance test is gated on `gain`. Without it the AGC transform is inert, so the delivered level equals the pre-transform level and a divergence assertion cannot hold.
- The crate-level doc example is gated on `capture` and `vad`, the features it imports. Where either is absent the block renders as text rather than being collected as a doctest. It is not marked `ignore`, so it still runs in the default build and on docs.rs.

Both were confirmed to still run under the default feature set after gating, rather than inferred from the cells going green.