### PR TITLE
chore: ONNX feature guard, WAV validation, and changelog label fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,11 +89,11 @@ jobs:
       #     and doctests under that feature selection.
       #   - The ORT-backed cells run `cargo check --all-targets`, which
       #     type-checks every test target without linking or downloading ONNX
-      #     Runtime. Their tests cannot execute here: `default` pins
-      #     ort-load-dynamic and no ORT dylib is resolvable on a runner, while
-      #     `vad` and `no-vad-full` select no ORT distribution mode, so their
-      #     test binaries do not link. The maximal feature set's tests run in
-      #     the Rust Tests job via the cargo test-decibri alias
+      #     Runtime. All three pin ort-load-dynamic (`vad` and `no-vad-full`
+      #     explicitly, which the distribution-mode guard in lib.rs requires),
+      #     so they compile; their tests cannot execute here because no ORT
+      #     dylib is resolvable on a runner. The maximal feature set's tests
+      #     run in the Rust Tests job via the cargo test-decibri alias
       #     (ort-download-binaries).
       #
       # Exclusions, by design:
@@ -112,8 +112,8 @@ jobs:
           - { name: capture, command: "test", flags: "--no-default-features --features capture" }
           - { name: playback, command: "test", flags: "--no-default-features --features playback" }
           - { name: capture+playback, command: "test", flags: "--no-default-features --features capture,playback" }
-          - { name: vad, command: "check --all-targets", flags: "--no-default-features --features vad" }
-          - { name: no-vad-full, command: "check --all-targets", flags: "--no-default-features --features capture,playback,denoise,gain" }
+          - { name: vad, command: "check --all-targets", flags: "--no-default-features --features vad,ort-load-dynamic" }
+          - { name: no-vad-full, command: "check --all-targets", flags: "--no-default-features --features capture,playback,denoise,gain,ort-load-dynamic" }
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -26,6 +26,7 @@ For other decibri packages, see:
 
 - `File::open` opens WAV files using the WAVE_FORMAT_EXTENSIBLE container when their SubFormat GUID names 16-bit PCM or 32-bit IEEE float; they were rejected as an unsupported encoding.
 - `File::open` opens WAV files whose `data` chunk precedes their format chunk; they were rejected as missing the format chunk.
+- Building with `vad` or `denoise` and no ONNX Runtime distribution mode fails at compile time with a message naming the two modes (`ort-load-dynamic`, `ort-download-binaries`), instead of at link with an unresolved `OrtGetApiBase` symbol.
 
 ## [5.2.1] - 2026-07-25
 

--- a/crates/decibri/src/file.rs
+++ b/crates/decibri/src/file.rs
@@ -856,10 +856,11 @@ fn parse_wav(bytes: &[u8]) -> Result<WavSource, DecibriError> {
     }
 
     // Walk the chunk list for `fmt ` and `data`, taking the first of each;
-    // RIFF fixes neither their order nor their count. The walk ends once
-    // both are found, so bytes past that point are not examined, exactly as
-    // before for the conventional order. Chunk bodies are padded to an even
-    // byte count in the file.
+    // RIFF fixes neither their order nor their count. Every `fmt ` chunk the
+    // walk meets is validated, and only the first is recorded. The walk ends
+    // once both are found, so bytes past that point are not examined, exactly
+    // as before for the conventional order. Chunk bodies are padded to an
+    // even byte count in the file.
     let mut fmt: Option<(usize, usize)> = None; // body offset, size
     let mut data: Option<(usize, usize)> = None; // body offset, size
     let mut offset = 12usize;
@@ -870,11 +871,13 @@ fn parse_wav(bytes: &[u8]) -> Result<WavSource, DecibriError> {
         if body + size > bytes.len() {
             return Err(invalid("chunk extends past end of file"));
         }
-        if id == b"fmt " && fmt.is_none() {
+        if id == b"fmt " {
             if size < 16 {
                 return Err(invalid("fmt chunk too short"));
             }
-            fmt = Some((body, size));
+            if fmt.is_none() {
+                fmt = Some((body, size));
+            }
         } else if id == b"data" && data.is_none() {
             data = Some((body, size));
         }
@@ -1332,6 +1335,31 @@ mod tests {
         assert_eq!(parsed.samples, expected.samples);
         assert_eq!(parsed.sample_rate, 16000);
         assert_eq!(parsed.channels, 1);
+    }
+
+    /// A malformed duplicate `fmt ` chunk is rejected even though a valid
+    /// first `fmt ` chunk wins: every `fmt ` chunk the walk meets is
+    /// validated, not only the recorded one.
+    #[test]
+    fn short_duplicate_fmt_chunk_is_rejected() {
+        let samples = sine(16000, 0.1);
+        let conventional = wav_bytes(1, 1, 16000, &samples);
+        // Splice a too-short `fmt ` chunk between the valid `fmt ` chunk
+        // (bytes 12..36) and the `data` chunk (bytes 36..), so the walk
+        // meets it before both chunks are found.
+        let mut doubled = conventional[0..36].to_vec();
+        doubled.extend_from_slice(b"fmt ");
+        doubled.extend_from_slice(&8u32.to_le_bytes());
+        doubled.extend_from_slice(&[0u8; 8]);
+        doubled.extend_from_slice(&conventional[36..]);
+
+        let err = parse_wav(&doubled)
+            .err()
+            .expect("a too-short duplicate fmt chunk should be rejected");
+        assert!(matches!(
+            err,
+            DecibriError::WavInvalid { reason } if reason == "fmt chunk too short"
+        ));
     }
 
     /// Bytes after the last chunk the parse needs are not examined: a file

--- a/crates/decibri/src/lib.rs
+++ b/crates/decibri/src/lib.rs
@@ -162,6 +162,17 @@ compile_error!(
      if you want `ort-download-binaries`, disable default features first."
 );
 
+#[cfg(all(
+    any(feature = "vad", feature = "denoise"),
+    not(feature = "ort-load-dynamic"),
+    not(feature = "ort-download-binaries")
+))]
+compile_error!(
+    "features `vad` and `denoise` require an ONNX Runtime distribution mode; \
+     enable exactly one of `ort-load-dynamic` or `ort-download-binaries`. \
+     The default feature set enables `ort-load-dynamic`."
+);
+
 pub mod error;
 pub mod sample;
 

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -6,8 +6,8 @@ Changes to the decibri npm package, published to npmjs.com. Tags use the `npm-v*
 
 For other decibri packages, see:
 
-- Rust crate: [crates/decibri/CHANGELOG.md](../../crates/decibri/CHANGELOG.md)
-- Python wheel: [bindings/python/CHANGELOG.md](../../bindings/python/CHANGELOG.md)
+- Rust core: [crates/decibri/CHANGELOG.md](../../crates/decibri/CHANGELOG.md)
+- Python package: [bindings/python/CHANGELOG.md](../../bindings/python/CHANGELOG.md)
 
 ## [Unreleased]
 


### PR DESCRIPTION
Four changes:

**ONNX Runtime distribution guard**

- `vad` and `denoise` each pull `ort` but neither selects a distribution mode, so building with `--no-default-features --features vad` failed at link with an unresolved `OrtGetApiBase` and no indication of the cause.
- That combination now fails at compile time with a message naming both distribution modes and which one the default feature set enables.
- Nothing that built before stops building. The combination has never linked.

**Feature matrix**

- Two cells selected a feature that pulls `ort` with no distribution mode, which is what the guard now rejects, so both cells select `ort-load-dynamic`. It resolves at runtime, so a check-only cell compiles without fetching anything.
- The job comment is corrected to match.

**WAV reader**

- The chunk walk validates every `fmt ` chunk it meets and records the first, so a malformed duplicate is rejected rather than skipped. This restores strictness that was relaxed as a side effect of an unreleased change, so nothing user-facing has moved.

**Documentation**

- Two link labels in the npm changelog header.