### PR TITLE
fix(denoise): stop emitting a tail from a stage that received no audio

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - The resample stage no longer contributes a tail at close when it processed no audio. A capture that ends before a single buffer arrives, and a `File` over an empty source, each returned that tail as a short run of silence when the input rate and the requested `sample_rate` differed.
+- The denoise stage no longer contributes a tail at close when it processed no audio. With `denoise` set, a capture that ends before a single buffer arrives, and a `File` over an empty source, each returned 512 samples of silence (32 ms at 16 kHz) that the stream never captured, indistinguishable to a consumer from recorded audio.
 - A conditioned capture no longer returns audio after the stream has closed. A capture whose device rate differed from the requested `sample_rate`, or that had an enhancement step enabled, could return a final burst of samples that do not follow the recording, at up to full scale, when capture ended on a device error or on `stop()`. An unconditioned capture is unaffected.
 
 ## [0.7.3] - 2026-07-27

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -23,6 +23,7 @@ For other decibri packages, see:
 ### Fixed
 
 - The resample stage no longer contributes a tail at close when it processed no audio. A `Microphone` capture that ends before a single buffer arrives, and a `File` over an empty source, each delivered that tail as a short run of silence when the input rate and the requested rate differed.
+- The denoise stage no longer contributes a tail at close when it processed no audio. With denoise enabled, a `Microphone` capture that ends before a single buffer arrives, and a `File` over an empty source, each delivered 512 samples of silence (32 ms at 16 kHz) that the stream never captured, indistinguishable to a consumer from recorded audio.
 - A conditioned capture no longer delivers audio after the stream has closed. A `Microphone` capture whose device rate differed from the requested rate, or that had an enhancement step enabled, could end with a burst of samples that do not follow the recording, at up to full scale, when the stream closed on a device or driver failure or on `stop()`. An unconditioned capture is unaffected.
 
 ## [5.3.0] - 2026-07-27

--- a/crates/decibri/src/denoise.rs
+++ b/crates/decibri/src/denoise.rs
@@ -15,9 +15,10 @@
 //! the three updated caches. Frames advance by the hop (256), so consecutive
 //! windows overlap by 512 - 256 = 256 samples, and the caches must be fed back
 //! each call. The stream is left-padded by one (window - hop) = 256-sample
-//! half-window of zeros (the [`accumulator`](Denoise::accumulator) is seeded with
-//! 256 zeros) so the first analysis window is `[zeros(256), samples(256)]`, which
-//! matches how the upstream streaming export initialises its internal buffer. The
+//! half-window of zeros (the [`accumulator`](Denoise::accumulator) takes 256 zeros
+//! when its first sample arrives) so the first analysis window is
+//! `[zeros(256), samples(256)]`, which matches how the upstream streaming export
+//! initialises its internal buffer. The
 //! model therefore introduces 256 samples of algorithmic latency (the output hop
 //! lags its input by window - hop); the capture chain accounts for that latency
 //! as a tap lead, not here.
@@ -56,16 +57,23 @@ const CACHE_REC_LEN: usize = 16 * 20;
 /// Length-changing and latency-introducing: each [`process`](Stage::process)
 /// emits whole 256-sample hops as enough input accumulates, buffering the
 /// remainder, so its output count trails its input by the framing latency until
-/// [`flush`](Stage::flush) drains the tail at close. It runs in the `transform`
-/// segment after the VAD tap, so that latency surfaces as a bounded tap lead and
-/// never reaches the detector.
+/// [`flush`](Stage::flush) drains the tail at close. The tail exists to frame the
+/// audio the stage received, so a stage that received none emits nothing at
+/// flush. It runs in the `transform` segment after the VAD tap, so that latency
+/// surfaces as a bounded tap lead and never reaches the detector.
 pub(crate) struct Denoise {
     /// The model behind the shared ONNX session seam. Loaded from a caller-
     /// supplied path; the crate embeds no model bytes.
     session: Box<dyn OnnxSession>,
-    /// Pending samples not yet consumed by a frame. Seeded with `WINDOW - HOP`
-    /// zeros (the left-pad half-window); each frame consumes `HOP` from the front
-    /// and retains the `WINDOW - HOP`-sample overlap for the next window.
+    /// Pending samples not yet consumed by a frame. Empty until the stage
+    /// receives its first sample, when [`process`](Stage::process) seeds it with
+    /// `WINDOW - HOP` zeros (the left-pad half-window); each frame then consumes
+    /// `HOP` from the front and retains the `WINDOW - HOP`-sample overlap for the
+    /// next window, so once seeded it never empties again until
+    /// [`flush`](Stage::flush) clears it.
+    ///
+    /// Invariant, which [`flush`](Stage::flush) reads: an empty accumulator means
+    /// the stage holds no audio to frame, so it has nothing to drain.
     accumulator: Vec<f32>,
     /// The model's overlap-add tail buffer (`cache_*_0`), carried across calls.
     cache0: Vec<f32>,
@@ -108,9 +116,9 @@ impl Denoise {
 
         Ok(Self {
             session,
-            // Left-pad the stream by one half-window of zeros so the first
-            // analysis window is `[zeros(256), first 256 samples]`.
-            accumulator: vec![0.0; WINDOW - HOP],
+            // Empty until the first sample arrives; `process` lays down the
+            // left-pad half-window then.
+            accumulator: Vec::new(),
             cache0: vec![0.0; CACHE0_LEN],
             cache1: vec![0.0; CACHE_REC_LEN],
             cache2: vec![0.0; CACHE_REC_LEN],
@@ -187,11 +195,29 @@ impl Denoise {
 
 impl Stage for Denoise {
     fn process(&mut self, input: &[f32], out: &mut Vec<f32>) -> Result<(), DecibriError> {
+        if input.is_empty() {
+            return Ok(());
+        }
+        if self.accumulator.is_empty() {
+            // Left-pad the stream by one half-window of zeros so the first
+            // analysis window is `[zeros(256), first 256 samples]`. Laid down on
+            // the first sample rather than at construction, so an accumulator
+            // that is still empty means the stage has received no audio.
+            self.accumulator.resize(WINDOW - HOP, 0.0);
+        }
         self.accumulator.extend_from_slice(input);
         self.drain_ready(out)
     }
 
     fn flush(&mut self, out: &mut Vec<f32>) -> Result<(), DecibriError> {
+        // The tail drains the audio still inside the model's framing, so a stage
+        // holding none contributes nothing. An empty accumulator means either no
+        // sample ever arrived or the tail has already been drained; both emit
+        // nothing here.
+        if self.accumulator.is_empty() {
+            return Ok(());
+        }
+
         // Pad the stream out by one full window of zeros (the upstream offline
         // recipe right-pads by n_fft) so the leftover real samples and the
         // model's overlap-add tail are pushed out as final hops, then drain.
@@ -199,10 +225,10 @@ impl Stage for Denoise {
         self.accumulator.resize(padded_len, 0.0);
         self.drain_ready(out)?;
 
-        // Leave the stage reusable: re-seed the left-pad half-window and zero the
-        // streaming caches, so a subsequent stream starts clean.
+        // Leave the stage reusable: drop the pending samples and zero the
+        // streaming caches, so a subsequent stream starts clean and lays down its
+        // own left-pad on its first sample.
         self.accumulator.clear();
-        self.accumulator.resize(WINDOW - HOP, 0.0);
         self.cache0.fill(0.0);
         self.cache1.fill(0.0);
         self.cache2.fill(0.0);
@@ -308,8 +334,8 @@ mod tests {
         let mut stage = Denoise::new(DenoiseModel::FastEnhancerT, &model_path(), None)
             .expect("bundled FastEnhancer-T model loads");
 
-        // Caches start zeroed and the accumulator carries the left-pad.
-        assert_eq!(stage.accumulator.len(), WINDOW - HOP);
+        // Caches start zeroed and the accumulator is empty until fed.
+        assert!(stage.accumulator.is_empty());
         assert!(stage.cache0.iter().all(|&v| v == 0.0));
 
         let input = noisy(4096);
@@ -363,9 +389,67 @@ mod tests {
             "process + flush deliver at least the whole input"
         );
 
-        // Reusable: caches re-zeroed, accumulator re-seeded with the left-pad.
+        // Reusable: caches re-zeroed, accumulator cleared so the next stream lays
+        // down its own left-pad.
         assert!(stage.cache0.iter().all(|&v| v == 0.0), "caches re-zeroed");
-        assert_eq!(stage.accumulator.len(), WINDOW - HOP, "left-pad re-seeded");
+        assert!(stage.accumulator.is_empty(), "pending samples cleared");
+    }
+
+    /// A stage that received no audio emits nothing at flush: the padding exists
+    /// to frame audio the stage holds, and it holds none. Absolute expectation,
+    /// so a tail of any length fails.
+    #[test]
+    fn unfed_flush_emits_nothing() {
+        let mut stage = Denoise::new(DenoiseModel::FastEnhancerT, &model_path(), None)
+            .expect("bundled FastEnhancer-T model loads");
+
+        let mut tail = Vec::new();
+        stage.flush(&mut tail).expect("flush runs unfed");
+        assert_eq!(
+            tail.len(),
+            0,
+            "an unfed stage emitted {} samples it never received",
+            tail.len()
+        );
+
+        // An empty block is not audio either, and neither is a repeated flush.
+        stage.process(&[], &mut tail).expect("empty block runs");
+        stage.flush(&mut tail).expect("second flush runs");
+        assert_eq!(
+            tail.len(),
+            0,
+            "an empty block still leaves nothing to drain"
+        );
+    }
+
+    /// The regression the gate guards: a stage fed even a fraction of one
+    /// analysis frame still drains that audio at flush. `process` emits nothing
+    /// for 100 samples (well under the 512-sample window), so every delivered
+    /// sample comes from the flush, and the count is exactly the whole hops the
+    /// padded stream forms.
+    #[test]
+    fn a_stage_fed_a_little_audio_still_drains_its_tail() {
+        let mut stage = Denoise::new(DenoiseModel::FastEnhancerT, &model_path(), None)
+            .expect("bundled FastEnhancer-T model loads");
+
+        let mut processed = Vec::new();
+        stage.process(&noisy(100), &mut processed).expect("process");
+        assert_eq!(
+            processed.len(),
+            0,
+            "100 samples do not fill the 512-sample analysis window"
+        );
+
+        let mut tail = Vec::new();
+        stage.flush(&mut tail).expect("flush drains the tail");
+        // Left-pad (256) + 100 real + one window of padding (512) = 868 samples,
+        // which yields floor((868 - 512) / 256) + 1 = 2 whole hops of 256.
+        assert_eq!(tail.len(), 2 * HOP, "the real tail is drained in full");
+        assert!(tail.iter().all(|s| s.is_finite()), "the tail is finite");
+        assert!(
+            tail.iter().any(|&s| s != 0.0),
+            "the tail carries the audio the stage received"
+        );
     }
 
     /// A nonexistent model path surfaces the model-agnostic `ModelLoadFailed`,

--- a/crates/decibri/src/file.rs
+++ b/crates/decibri/src/file.rs
@@ -1133,6 +1133,52 @@ mod tests {
         );
     }
 
+    /// An empty source with denoise enabled delivers no samples either: the
+    /// close-path flush of a chain that processed nothing appends nothing, so a
+    /// recording that held no audio yields none.
+    #[cfg(feature = "denoise")]
+    #[test]
+    fn empty_buffer_with_denoise_delivers_nothing() {
+        let config = FileConfig {
+            denoise: Some(DenoiseModel::FastEnhancerT),
+            denoise_model_path: Some(denoise_model_path()),
+            ..FileConfig::default()
+        };
+        let file = File::buffer(Vec::new(), 16000, config).unwrap();
+        assert_eq!(
+            collect(file).len(),
+            0,
+            "an unfed denoise chain contributes no samples at close"
+        );
+    }
+
+    /// A source holding a fraction of one analysis frame still comes back out:
+    /// 100 samples produce no output through the framing, so every delivered
+    /// sample arrives via the close-path flush. The regression that the unfed
+    /// gate must not break, on the `File` path.
+    #[cfg(feature = "denoise")]
+    #[test]
+    fn short_buffer_with_denoise_still_delivers_its_tail() {
+        let config = FileConfig {
+            denoise: Some(DenoiseModel::FastEnhancerT),
+            denoise_model_path: Some(denoise_model_path()),
+            ..FileConfig::default()
+        };
+        // 100 samples at 16 kHz: well under the 512-sample analysis window.
+        let source: Vec<f32> = (0..100)
+            .map(|i| 0.5 * (2.0 * std::f32::consts::PI * 440.0 * i as f32 / 16_000.0).sin())
+            .collect();
+        let file = File::buffer(source, 16000, config).unwrap();
+        let out = collect(file);
+        // Left-pad (256) + 100 real + one window of padding (512) = 868 samples,
+        // which yields two whole 256-sample hops.
+        assert_eq!(out.len(), 512, "the real tail is delivered in full");
+        assert!(
+            out.iter().any(|&s| s != 0.0),
+            "the delivered tail carries the audio the source held"
+        );
+    }
+
     // ── Constructor and parse errors ─────────────────────────────────────
 
     /// A missing file reports the typed read failure with its path.
@@ -1516,7 +1562,7 @@ mod tests {
             .join("silero_vad.onnx")
     }
 
-    #[cfg(all(feature = "vad", feature = "denoise"))]
+    #[cfg(feature = "denoise")]
     fn denoise_model_path() -> PathBuf {
         let manifest_dir = env!("CARGO_MANIFEST_DIR");
         Path::new(manifest_dir)

--- a/crates/decibri/src/microphone.rs
+++ b/crates/decibri/src/microphone.rs
@@ -2418,6 +2418,82 @@ mod tests {
         );
     }
 
+    /// A denoise-enabled capture that closes before a single buffer arrives
+    /// delivers nothing and reports closed: the close-path flush of a chain that
+    /// received no audio contributes no samples, so a consumer is never handed
+    /// audio the stream did not capture.
+    #[cfg(feature = "denoise")]
+    #[test]
+    fn a_capture_closed_before_any_buffer_delivers_nothing() {
+        let (stream, _sender, running) = test_stream_with(Some(denoise_stage()), 1);
+        running.store(false, Ordering::Relaxed);
+
+        let delivered = drain_try(&stream, 320);
+        assert!(
+            stream.chain_flushed.load(Ordering::Relaxed),
+            "the read reached the close-path flush"
+        );
+        assert_eq!(
+            delivered.len(),
+            0,
+            "a capture that received no buffer delivered {} samples",
+            delivered.len()
+        );
+        assert!(matches!(
+            stream.next_chunk(320, Some(Duration::from_millis(60))),
+            Err(DecibriError::MicrophoneStreamClosed)
+        ));
+    }
+
+    /// A denoise-enabled capture that received even a fraction of one analysis
+    /// frame still delivers that audio at close. The regression the unfed gate
+    /// must not break: 100 samples form no frame, so the whole delivery is the
+    /// flushed tail.
+    #[cfg(feature = "denoise")]
+    #[test]
+    fn a_capture_fed_a_little_audio_still_delivers_its_tail() {
+        let block: Vec<f32> = (0..100).map(|n| (n as f32 * 0.05).sin()).collect();
+
+        let (stream, sender, running) = test_stream_with(Some(denoise_stage()), 1);
+        sender.send(make_native_chunk(block)).unwrap();
+        running.store(false, Ordering::Relaxed);
+
+        let delivered = drain_try(&stream, 320);
+        // Left-pad (256) + 100 real + one window of padding (512) = 868 samples,
+        // which yields two whole 256-sample hops.
+        assert_eq!(delivered.len(), 512, "the real tail is delivered in full");
+        assert!(
+            delivered.iter().any(|&s| s != 0.0),
+            "the delivered tail carries the audio the stream captured"
+        );
+    }
+
+    /// A mono 16 kHz chain whose only stage is denoise, so the `transform`
+    /// segment is exercised with an empty `normalize`.
+    #[cfg(feature = "denoise")]
+    fn denoise_stage() -> CaptureStage {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("models")
+            .join("fastenhancer_t.onnx");
+        build_capture_stage(
+            1,
+            1,
+            16_000,
+            16_000,
+            Transforms {
+                dc_removal: false,
+                denoise: Some((DenoiseModel::FastEnhancerT, path.as_path(), None)),
+                highpass: None,
+                agc: None,
+                limiter: None,
+            },
+        )
+        .unwrap()
+        .expect("mono 16 kHz denoise chain")
+    }
+
     /// A stream opened, fed while running, and closed normally is unaffected: the
     /// close check that now runs before the drain does not disturb delivery of
     /// buffers that arrive while the stream is open, and the full delivered stream

--- a/crates/decibri/src/stage.rs
+++ b/crates/decibri/src/stage.rs
@@ -1523,6 +1523,85 @@ mod tests {
         );
     }
 
+    /// A denoise chain that processed nothing drains nothing: closing a stream
+    /// that captured no audio appends no samples, rather than the framing padding
+    /// pushed through an empty model. The absolute expectation is zero, on the
+    /// transform-only chain and on one carrying a `normalize` segment too.
+    #[cfg(feature = "denoise")]
+    #[test]
+    fn unfed_denoise_chain_flush_appends_nothing() {
+        let path = denoise_model_path();
+        let model = DenoiseModel::FastEnhancerT;
+
+        for (channels, native_rate, dc_removal, label) in [
+            (1u16, 16_000u32, false, "denoise only"),
+            (2, 48_000, true, "downmix + resample + dc + denoise"),
+        ] {
+            let mut chain = build_capture_stage(
+                channels,
+                1,
+                native_rate,
+                16_000,
+                Transforms {
+                    dc_removal,
+                    denoise: Some((model, path.as_path(), None)),
+                    highpass: None,
+                    agc: None,
+                    limiter: None,
+                },
+            )
+            .unwrap()
+            .expect("denoise chain");
+
+            let mut tail = Vec::new();
+            chain.flush(&mut tail).expect("flush runs unfed");
+            assert_eq!(
+                tail.len(),
+                0,
+                "{label}: an unfed chain delivered {} samples it never received",
+                tail.len()
+            );
+        }
+    }
+
+    /// A denoise chain fed even a fraction of one analysis frame still delivers
+    /// that audio at close. This is the regression the unfed gate must not break:
+    /// 100 samples produce no output through `run`, so the whole delivery comes
+    /// from the flush.
+    #[cfg(feature = "denoise")]
+    #[test]
+    fn barely_fed_denoise_chain_still_drains_its_tail() {
+        let path = denoise_model_path();
+        let mut chain = build_capture_stage(
+            1,
+            1,
+            16_000,
+            16_000,
+            Transforms {
+                dc_removal: false,
+                denoise: Some((DenoiseModel::FastEnhancerT, path.as_path(), None)),
+                highpass: None,
+                agc: None,
+                limiter: None,
+            },
+        )
+        .unwrap()
+        .expect("denoise chain");
+
+        let out = chain.run(&mono_signal(100)).expect("run").to_vec();
+        assert_eq!(out.len(), 0, "100 samples do not fill one analysis window");
+
+        let mut tail = Vec::new();
+        chain.flush(&mut tail).expect("flush drains the tail");
+        // Left-pad (256) + 100 real + one window of padding (512) = 868 samples,
+        // which yields two whole 256-sample hops.
+        assert_eq!(tail.len(), 512, "the real tail is delivered in full");
+        assert!(
+            tail.iter().any(|&s| s != 0.0),
+            "the tail carries the audio the chain received"
+        );
+    }
+
     /// With denoise in the transform segment, the pre-transform tap LEADS the
     /// delivered enhanced output. The tap is the post-normalize signal at real-
     /// time rate (equal to the mono input length here); the delivered output is

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -23,6 +23,7 @@ For other decibri packages, see:
 ### Fixed
 
 - The resample stage no longer contributes a tail at close when it processed no audio. A capture that ends before a single buffer arrives, and a `File` over an empty source, each emitted that tail as a short run of silent `data` when the input rate and the requested `sampleRate` differed.
+- The denoise stage no longer contributes a tail at close when it processed no audio. With `denoise` set, a capture that ends before a single buffer arrives, and a `File` over an empty source, each emitted 512 samples of silence (32 ms at 16 kHz) that the stream never captured, indistinguishable in a `data` event from recorded audio.
 - A conditioned capture no longer emits `data` after the stream has closed. A capture whose device rate differed from the requested `sampleRate`, or that had an enhancement step enabled, could emit a final burst of samples that do not follow the recording, at up to full scale, when capture ended on a device error or on `stop()`. An unconditioned capture is unaffected.
 
 ## [5.2.3] - 2026-07-27


### PR DESCRIPTION
A stream that captured no audio still delivered 512 samples at close when denoise was enabled.

**Issue**

- The denoise stage laid down its left-pad half-window at construction and padded it out at flush, so the drain ran whether or not the stage had ever received a sample.
- The samples reached the consumer on both the capture path and the `File` path, in the delivered audio rather than the detector feed, where nothing distinguishes them from recorded silence.
- They are identically zero, so 32 ms of fabricated quiet at 16 kHz rather than invented signal. A second flush emitted another 512.

**What changes**

- The left-pad moves from construction to the first sample, so an empty accumulator means the stage holds no audio to frame, and flush returns early on that condition. No new state was added; the accumulator already carried the fact.
- Flush clears rather than re-seeds, so a repeated flush emits nothing.
- A stream that received any audio drains its real tail unchanged, bit for bit.

**Scope**

- Denoise is the only affected stage. Every other stage keeps the trait default no-op at flush, and the resample stage was fixed upstream in decibri-resampler 0.3.0.

**Tests**

- Four never-fed and four barely-fed cases at the stage, chain, capture and `File` levels. With the guard disabled all four never-fed cases fail and all four barely-fed cases still pass.
- The denoise regression golden and all eight other anchors are unmoved.