### PR TITLE
fix(python): reject multichannel and non-float buffers, correct the docs

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -8,6 +8,14 @@ For Rust core (`crates/decibri`) and npm package (`npm/decibri`) changes, see [t
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`File.buffer` and `AsyncFile.buffer` reject a numpy array that is not one channel.** An interleaved multichannel array was accepted and its channels were spliced into a single channel, so an `(800, 2)` stereo array became 1600 mono samples: twice the expected duration, pitched down, with the two channels alternating sample by sample. Nothing indicated it. An array with more than one axis longer than 1 now raises `ValueError`; select a single channel or mix down to mono before passing it. A mono array carrying a redundant axis, `(N, 1)` or `(1, N)`, is still accepted and delivers exactly the samples the equivalent 1-D array delivers.
+- **`File.buffer` and `AsyncFile.buffer` reject a numpy array whose dtype is not floating-point.** An `int16` array of PCM was cast value for value, delivering samples around 32768 times full scale. A non-floating dtype now raises `ValueError`; convert with `samples.astype(numpy.float32)`, scaling integer PCM into `[-1.0, 1.0]` first. A `float64` array is unaffected and still narrows to `float32`, matching a list of Python floats.
+- `Microphone.read`, `AsyncMicrophone.read` and `record_to_file` no longer document a multichannel result. Capture is mono, so an `as_ndarray=True` read returns a 1-D array and `channels` accepts only 1. `File.buffer` documents what it accepts, and `File` documents that a multichannel WAV is downmixed to mono.
+
 ## [0.7.4] - 2026-07-28
 
 ### Added

--- a/bindings/python/python/decibri/__init__.py
+++ b/bindings/python/python/decibri/__init__.py
@@ -128,7 +128,9 @@ def record_to_file(
     sample_rate : int, optional
         Capture sample rate in Hz. Default 16000.
     channels : int, optional
-        Number of input channels. Default 1 (mono).
+        Number of input channels. Capture is mono, so 1 (the default) is
+        the only accepted value; a higher value raises
+        ``MultichannelNotSupported``.
     device : int | str | None, optional
         Input device selector. ``None`` (default) uses the system
         default input. Pass an integer index from ``input_devices()``

--- a/bindings/python/python/decibri/_async_classes.py
+++ b/bindings/python/python/decibri/_async_classes.py
@@ -452,10 +452,9 @@ class AsyncMicrophone:
 
         Return type:
         - When ``as_ndarray=False`` (default), returns ``bytes``.
-        - When ``as_ndarray=True``, returns a ``numpy.ndarray`` with
-          dtype matching the configured ``dtype`` and shape matching
-          the channel count (1-D mono, 2-D ``(N, channels)``
-          multi-channel).
+        - When ``as_ndarray=True``, returns a 1-D ``numpy.ndarray`` with
+          dtype matching the configured ``dtype``. Capture is mono, so
+          the array is always 1-D.
 
         Use ``read_with_metadata()`` to receive a typed ``Chunk`` with
         ``.data``, ``.timestamp``, ``.sequence``, ``.is_speaking``, and

--- a/bindings/python/python/decibri/_classes.py
+++ b/bindings/python/python/decibri/_classes.py
@@ -732,10 +732,9 @@ class Microphone:
 
         Return type:
         - When ``as_ndarray=False`` (default), returns ``bytes``.
-        - When ``as_ndarray=True``, returns a ``numpy.ndarray`` with
+        - When ``as_ndarray=True``, returns a 1-D ``numpy.ndarray`` with
           dtype matching the configured ``dtype`` (np.int16 or
-          np.float32) and shape matching the channel count (1-D for
-          mono, 2-D ``(N, channels)`` for multi-channel).
+          np.float32). Capture is mono, so the array is always 1-D.
 
         Use ``read_with_metadata()`` to receive a typed ``Chunk`` with
         ``.data``, ``.timestamp``, ``.sequence``, ``.is_speaking``, and
@@ -1297,7 +1296,8 @@ class File:
     ) -> None:
         """Open a WAV file as an offline source.
 
-        The input rate and channel count come from the WAV header;
+        The input rate and channel count come from the WAV header; a
+        multichannel file is downmixed, so the delivered stream is mono.
         ``sample_rate`` is the target output rate, the same meaning it has
         on ``Microphone``. Supports 16-bit PCM and 32-bit float WAV files;
         other formats are handled elsewhere, keeping this path
@@ -1351,10 +1351,14 @@ class File:
     ) -> "File":
         """Wrap in-memory samples as an offline source.
 
-        ``samples`` is a list of floats or a numpy ndarray of f32 mono
-        samples in ``[-1.0, 1.0]``. Raw samples carry no header, so
-        ``input_rate`` (their native rate) is required; ``sample_rate``
-        stays the target output rate.
+        ``samples`` is a list of floats or a numpy ndarray of mono
+        samples in ``[-1.0, 1.0]``. An ndarray must be one channel with a
+        floating dtype: a redundant axis (``(N, 1)`` or ``(1, N)``) is
+        accepted, an array with more than one axis longer than 1 raises
+        ``ValueError``, and a non-floating dtype (int16 PCM, for example)
+        raises ``ValueError`` rather than being cast. Raw samples carry no
+        header, so ``input_rate`` (their native rate) is required;
+        ``sample_rate`` stays the target output rate.
         """
         self = object.__new__(cls)
         self._init_common(
@@ -1555,6 +1559,22 @@ class File:
                 if not isinstance(samples, np.ndarray):
                     raise TypeError(
                         "samples must be a list of floats or a numpy ndarray"
+                    )
+                # One channel means at most one axis longer than 1: a
+                # redundant axis squeezes away without reordering, while a
+                # second long axis carries channels the C-order flatten
+                # below would splice into the sample stream.
+                if sum(1 for length in samples.shape if length > 1) > 1:
+                    raise ValueError(
+                        "samples must be one channel; got an array of shape "
+                        f"{samples.shape}. Select a single channel or mix "
+                        "down to mono before passing it."
+                    )
+                if not np.issubdtype(samples.dtype, np.floating):
+                    raise ValueError(
+                        f"samples must have a floating dtype; got {samples.dtype}. "
+                        "Convert with samples.astype(numpy.float32), scaling "
+                        "integer PCM to [-1.0, 1.0]."
                     )
                 samples = np.ascontiguousarray(samples, dtype=np.float32).tobytes()
             self._bridge = _decibri.FileBridge.buffer(

--- a/bindings/python/tests/test_file.py
+++ b/bindings/python/tests/test_file.py
@@ -19,6 +19,7 @@ import math
 import struct
 import wave
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -170,6 +171,103 @@ def test_buffer_rejects_other_types() -> None:
     """Anything but a list of floats or an ndarray is rejected clearly."""
     with pytest.raises(TypeError, match="list of floats or a numpy ndarray"):
         File.buffer("not samples", input_rate=16000)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# buffer: one channel, floating dtype
+#
+# Every rejection below is paired with a control asserting the accepted form
+# of the same input still works, so a guard that rejected everything would
+# fail the module rather than pass it.
+# ---------------------------------------------------------------------------
+
+
+def buffer_f32(samples: Any) -> bytes:
+    """Read a buffer source back as raw f32 bytes: no resample, no chain."""
+    return read_all(
+        File.buffer(samples, input_rate=16000, sample_rate=16000, dtype="float32")
+    )
+
+
+def test_buffer_1d_delivers_the_samples_it_was_given() -> None:
+    """The intended 1-D form round-trips sample for sample."""
+    np = pytest.importorskip("numpy")
+    mono = np.asarray(sine_samples(16000, 0.05), dtype=np.float32)
+    assert buffer_f32(mono) == mono.tobytes()
+
+
+def test_buffer_rejects_multichannel_array() -> None:
+    """An interleaved stereo array is rejected, not spliced into one channel."""
+    np = pytest.importorskip("numpy")
+    mono = np.asarray(sine_samples(16000, 0.05), dtype=np.float32)
+    stereo = np.stack([mono, mono + 0.25], axis=1)
+    assert stereo.shape == (800, 2)
+
+    with pytest.raises(ValueError, match=r"must be one channel.*\(800, 2\)"):
+        File.buffer(stereo, input_rate=16000)
+
+    # Control: one channel of that same array is accepted, and delivers that
+    # channel's samples rather than the interleaved pair.
+    assert buffer_f32(stereo[:, 0]) == mono.tobytes()
+
+
+def test_buffer_rejects_more_than_two_dimensions() -> None:
+    """A second axis longer than 1 is rejected whatever the rank."""
+    np = pytest.importorskip("numpy")
+    mono = np.asarray(sine_samples(16000, 0.05), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="must be one channel"):
+        File.buffer(mono.reshape(2, 20, 20), input_rate=16000)
+
+    # Control: the same 800 samples as one channel are accepted.
+    assert buffer_f32(mono) == mono.tobytes()
+
+
+def test_buffer_accepts_redundant_axis_unchanged() -> None:
+    """(N, 1) and (1, N) are one channel and deliver the 1-D samples exactly.
+
+    Several audio libraries return a mono recording with a redundant axis.
+    Asserting equality (not just the sample count) catches a squeeze that
+    reordered the samples.
+    """
+    np = pytest.importorskip("numpy")
+    mono = np.asarray(sine_samples(16000, 0.05), dtype=np.float32)
+    expected = mono.tobytes()
+
+    assert buffer_f32(mono.reshape(-1, 1)) == expected
+    assert buffer_f32(mono.reshape(1, -1)) == expected
+
+
+def test_buffer_accepts_non_contiguous_view() -> None:
+    """A strided view is copied, not read across the gaps between elements."""
+    np = pytest.importorskip("numpy")
+    mono = np.asarray(sine_samples(16000, 0.05), dtype=np.float32)
+    right = mono + 0.25
+    channel = np.stack([mono, right], axis=1)[:, 1]
+    assert not channel.flags["C_CONTIGUOUS"]
+
+    assert buffer_f32(channel) == right.tobytes()
+
+
+def test_buffer_rejects_non_floating_dtype() -> None:
+    """Integer PCM is rejected rather than cast to a full-scale float."""
+    np = pytest.importorskip("numpy")
+    mono = np.asarray(sine_samples(16000, 0.05), dtype=np.float32)
+    pcm = (mono * 32767.0).astype(np.int16)
+
+    with pytest.raises(ValueError, match="floating dtype; got int16"):
+        File.buffer(pcm, input_rate=16000)
+
+    # Control: the same audio scaled back into range is accepted.
+    scaled = pcm.astype(np.float32) / 32768.0
+    assert buffer_f32(scaled) == scaled.tobytes()
+
+
+def test_buffer_accepts_float64_like_a_list_of_floats() -> None:
+    """float64 narrows to f32, matching what a list of Python floats does."""
+    np = pytest.importorskip("numpy")
+    values = sine_samples(16000, 0.05)
+    assert buffer_f32(np.asarray(values, dtype=np.float64)) == buffer_f32(values)
 
 
 def test_open_missing_file_raises() -> None:

--- a/bindings/python/tests/test_repr.py
+++ b/bindings/python/tests/test_repr.py
@@ -121,3 +121,34 @@ def test_async_speaker_repr_shows_defaults_and_is_playing() -> None:
     assert "channels=1" in text
     assert "dtype='int16'" in text
     assert "is_playing=False" in text
+
+
+# ---------------------------------------------------------------------------
+# Extension classes: module path
+#
+# A pyclass declared without a module attribute reports ``builtins`` in its
+# repr and pickles against the wrong path. Every class the extension exports
+# carries it, so the check is a sweep rather than a spot check.
+# ---------------------------------------------------------------------------
+
+
+def test_extension_classes_report_their_module() -> None:
+    from decibri import _decibri
+
+    exported = [
+        getattr(_decibri, name)
+        for name in _decibri.__all__
+        if isinstance(getattr(_decibri, name), type)
+    ]
+    assert len(exported) == 8
+    for cls in exported:
+        assert cls.__module__ == "decibri._decibri", cls.__name__
+
+
+def test_file_bridge_repr_reports_its_module() -> None:
+    """The bridge instance repr names the extension module, not builtins."""
+    file = decibri.File.buffer([0.0] * 16, input_rate=16000)
+    try:
+        assert repr(file._bridge).startswith("<decibri._decibri.FileBridge object")
+    finally:
+        file.close()


### PR DESCRIPTION
`File.buffer` accepted arrays it could not interpret and reinterpreted them silently. Two forms, both delivering wrong audio with no diagnostic.

**Issue**

- A multichannel array was flattened, so an (800, 2) interleaved stereo array delivered 1600 samples read as one channel at double the true rate. A three-dimensional array was flattened the same way.
- Any non-floating dtype was cast value for value, so an int16 PCM array delivered samples roughly 32768 times full scale.
- Neither reached anything that could notice. The wrapper flattens to bytes before the core is called, so rank and dtype are gone by then.

**What changes**

- A buffer must be unambiguously one channel of floating point samples. The rule is at most one axis longer than one, so it is rank-independent rather than a shape match.
- A mono array with a redundant axis, (N, 1) or (1, N), is still accepted and delivers identical samples. A float64 array is still accepted, since it carries the same values at the same scale.
- A rejected integer array names the dtype and says how to convert it.

**Scope**

- Python only. `AsyncFile.buffer` delegates to the same path and is covered.
- `Speaker.write` takes arrays through a separate, already stricter path and is unchanged. Its multichannel acceptance is correct, since Speaker genuinely supports more than one channel.
- The Node binding has no equivalent hole. `Float32Array` rejects every other input type, and a subarray view reads correctly.

**Documentation**

- Four sites described a delivered array as two-dimensional, which capture has not produced since 5.0.
- `File.buffer` now states what it accepts, and `File` states that a multichannel WAV is downmixed. Those two differ deliberately: a WAV header states its channel count, a bare array's shape does not.