### PR TITLE
chore(python): derive the binding version from pyproject.toml

### DIFF
--- a/bindings/python/build.rs
+++ b/bindings/python/build.rs
@@ -1,0 +1,125 @@
+//! Build script: reads the project version from `pyproject.toml` and exposes
+//! it to crate code via the `DECIBRI_PYTHON_VERSION` environment variable.
+//!
+//! `pyproject.toml` is the single source of truth for the package version.
+//! `VersionInfo.binding` in `lib.rs` reads the emitted value, so the two never
+//! drift.
+//!
+//! # Locating pyproject.toml
+//!
+//! Two build layouts put the file in different places relative to this crate's
+//! manifest, so both are searched in order:
+//!
+//! 1. `CARGO_MANIFEST_DIR/pyproject.toml`, the in-repo layout, where the file
+//!    sits beside `bindings/python/Cargo.toml`.
+//! 2. `CARGO_MANIFEST_DIR/../../pyproject.toml`, the source-distribution
+//!    layout, where maturin packs `pyproject.toml` at the archive root and the
+//!    crate keeps its `bindings/python/` path.
+//!
+//! Exactly one `pyproject.toml` is tracked, so the two paths never both
+//! resolve within a single build.
+//!
+//! # Parsing
+//!
+//! The parse is anchored to the `[project]` table and to the `version` key
+//! within it. `pyproject.toml` holds other keys that a looser search matches:
+//! `python_version` under `[tool.mypy]`, `requires-python` under `[project]`,
+//! and the version constraints inside dependency specifiers.
+//!
+//! Every failure is a build failure. No candidate path readable, no match, or
+//! more than one match all panic with a message naming the cause. There is no
+//! default and no fallback value: a wrong version reported silently is worse
+//! than a build that stops.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn main() {
+    let manifest_dir = PathBuf::from(
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set by cargo"),
+    );
+
+    let mut candidates = vec![manifest_dir.join("pyproject.toml")];
+    if let Some(sdist_root) = manifest_dir.parent().and_then(|p| p.parent()) {
+        candidates.push(sdist_root.join("pyproject.toml"));
+    }
+
+    println!("cargo:rerun-if-changed=build.rs");
+    for candidate in &candidates {
+        println!("cargo:rerun-if-changed={}", candidate.display());
+    }
+
+    let (path, content) = candidates
+        .iter()
+        .find_map(|c| fs::read_to_string(c).ok().map(|content| (c, content)))
+        .unwrap_or_else(|| {
+            panic!(
+                "decibri-python build.rs: no readable pyproject.toml at any of {:?}",
+                candidates
+            )
+        });
+
+    let version = match project_versions(&content).as_slice() {
+        [v] => v.clone(),
+        [] => panic!(
+            "decibri-python build.rs: no `version` key found in the [project] table of {}",
+            path.display()
+        ),
+        found => panic!(
+            "decibri-python build.rs: found {} `version` keys in the [project] table of {}: {:?}; \
+             exactly one is required",
+            found.len(),
+            path.display(),
+            found
+        ),
+    };
+
+    println!("cargo:rustc-env=DECIBRI_PYTHON_VERSION={version}");
+}
+
+/// Collect every `version = "..."` value declared directly in the `[project]`
+/// table.
+///
+/// Sub-tables such as `[project.urls]` and `[project.optional-dependencies]`
+/// are separate tables and are not searched. Values inside multi-line arrays
+/// (`classifiers`, `authors`, `dependencies`) carry no bare `version` key, so
+/// the key-equality check excludes them.
+///
+/// Returns every match rather than the first, so the caller can reject an
+/// ambiguous file instead of guessing.
+fn project_versions(content: &str) -> Vec<String> {
+    let mut versions = Vec::new();
+    let mut in_project = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            in_project = trimmed == "[project]";
+            continue;
+        }
+        if !in_project {
+            continue;
+        }
+
+        let Some((key, value)) = trimmed.split_once('=') else {
+            continue;
+        };
+        if key.trim() != "version" {
+            continue;
+        }
+        if let Some(v) = quoted_value(value) {
+            versions.push(v);
+        }
+    }
+
+    versions
+}
+
+/// Extract the contents of the first double-quoted string in a TOML value,
+/// tolerating surrounding whitespace and a trailing comment.
+fn quoted_value(value: &str) -> Option<String> {
+    let after_quote = value.trim_start().strip_prefix('"')?;
+    let (inner, _) = after_quote.split_once('"')?;
+    Some(inner.to_string())
+}

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -322,6 +322,8 @@ fn parse_sample_format(s: &str) -> Result<BindingSampleFormat, CoreDecibriError>
 // ---------------------------------------------------------------------------
 // VersionInfo: surfaces decibri Rust core version, cpal version, and binding
 // version via three string fields. Constructed by MicrophoneBridge::version().
+// The binding version comes from the `[project]` version in pyproject.toml,
+// read at compile time by build.rs.
 // ---------------------------------------------------------------------------
 
 #[pyclass(module = "decibri._decibri", frozen)]
@@ -348,7 +350,7 @@ fn build_version_info() -> VersionInfo {
     VersionInfo {
         decibri: env!("CARGO_PKG_VERSION").to_string(),
         audio_backend: format!("cpal {}", CPAL_VERSION),
-        binding: "0.7.4".to_string(),
+        binding: env!("DECIBRI_PYTHON_VERSION").to_string(),
     }
 }
 

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -11,6 +11,7 @@ test_exceptions, test_error_messages, and test_lifecycle.
 """
 
 import ast
+import importlib.metadata
 import importlib.resources
 from pathlib import Path
 
@@ -74,7 +75,12 @@ def test_version_info_fields() -> None:
     info = _decibri.MicrophoneBridge.version()
     assert info.decibri == "5.4.0"
     assert info.audio_backend == "cpal 0.17"
-    assert info.binding == "0.7.4"
+    # binding is derived from the [project] version in pyproject.toml by
+    # bindings/python/build.rs, and the installed distribution's metadata
+    # version comes from that same key via maturin. Comparing the two checks
+    # the derived value against its source rather than against a literal that
+    # has to be hand-edited at every release.
+    assert info.binding == importlib.metadata.version("decibri")
 
 
 def test_version_info_is_frozen() -> None:


### PR DESCRIPTION
The Python binding reported its own version from a string literal that had to be edited by hand at every release, alongside three other sites carrying the same number.

**Issue**

- `bindings/python/build.rs` reads the version from the `[project]` table of `pyproject.toml` and emits it at compile time. The key match is anchored to that table and compared for equality, so neither `python_version` nor a dependency constraint can be picked up.
- Every failure path fails the build. No readable file, no match, or more than one match each stop the build with a message naming which it was. There is no fallback value, because a fallback is a hardcoded version that fires when nobody is looking.
- The reported value is unchanged and byte-identical.
- No new dependency. The manifest and lockfile are untouched.

**Testing**

- The version assertion now compares the reported binding version against the installed package metadata rather than a literal. A literal there would test whether someone edited the test file; the comparison tests the derived value against the source maturin recorded independently from the same key.
- The rerun trigger is verified in both directions, so a `pyproject.toml` change is picked up rather than going stale.
- The crate builds from inside an extracted sdist, where `pyproject.toml` sits at the archive root rather than beside the manifest.