### PR TITLE
fix(capture): keep the echo canceller's far-end stream level with the capture

### DIFF
--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -14,13 +14,16 @@ For other decibri packages, see:
 ### Added
 
 - `aec` feature, on by default: acoustic echo cancellation on the capture path. `MicrophoneConfig::aec` names the canceller model, with `aec_tail_ms`, `aec_suppression` and `aec_reference_sample_rate` for the rest. The stage runs last in the normalize segment, on the mono signal at the target rate and before the pre-transform detector tap, so a detector reads the echo-removed signal.
-- `MicrophoneStream::push_aec_reference`, which queues the far-end audio the canceller cancels against. Mono `f32` at `aec_reference_sample_rate`, in played order. It never blocks and never fails; samples that do not fit the bounded queue are discarded from the newest end and counted by `MicrophoneStream::aec_reference_dropped`. decibri converts the reference to the capture rate when the declared rate differs.
+- `MicrophoneStream::push_aec_reference`, which queues the far-end audio the canceller cancels against. Mono `f32` at `aec_reference_sample_rate`, in played order. It never blocks and never fails; samples that do not fit the bounded queue are discarded from the newest end and counted by `MicrophoneStream::aec_reference_dropped`. decibri converts the reference to the capture rate when the declared rate differs. Silence between what is played need not be pushed: decibri keeps the far-end stream level with the capture, so a caller that stops pushing between utterances keeps cancelling.
+- `MicrophoneStream::aec_reference_silence`, the count of far-end samples decibri supplied in the caller's place, at the capture sample rate. A stream where it tracks the whole length never had a reference pushed to it.
 - `MicrophoneStream::aec_metrics`, the canceller's transport and cancellation metrics.
 - `AecMetrics`, `AecModel` and `Suppression` re-exported from `decibri-aec`.
 - `DecibriError::AecSampleRateUnsupported`, reported when echo cancellation is enabled with a capture sample rate outside 8000 to 48000, which is narrower than the range `sample_rate` otherwise accepts.
 - `DecibriError::AecConfigInvalid`, reported when the echo canceller rejects its configuration. The message forwards the canceller's own text.
 
 With no reference pushed, an echo-cancelling capture delivers the captured audio unchanged.
+
+The reference queue holds two seconds at the declared reference rate, so a whole synthesized utterance handed over in one call is held whole. A push past the bound costs the cancellation of the discarded span alone: the time it occupied is represented as silence, so the canceller keeps its alignment for the rest of the stream.
 
 ## [5.4.1] - 2026-07-28
 

--- a/crates/decibri/src/microphone.rs
+++ b/crates/decibri/src/microphone.rs
@@ -340,25 +340,37 @@ const VAD_TAP_BOUND_SECS: usize = 2;
 /// Memory bound for the far-end echo-cancellation reference queue, in seconds of
 /// audio at the declared reference rate. The caller pushes played audio into the
 /// queue with [`MicrophoneStream::push_aec_reference`] and the canceller drains
-/// everything queued at the head of each block, so the queue only ever holds
-/// what was pushed since the previous block: one second is an order of magnitude
-/// above the interval between blocks at every buffer size the configuration
-/// accepts.
+/// everything queued at the head of each block, so a caller feeding in step with
+/// the capture never fills more than one block of it.
 ///
-/// The bound is also what caps how far the far-end feed can run ahead of the
-/// capture in one drain. The canceller learns the lead its caller keeps and
-/// re-anchors when the lead steps outside it, and it holds several seconds of
-/// far-end history to serve that lead from, so a queue that stays well inside
-/// that depth keeps the lead a small, steady figure rather than one that jumps by
-/// the length of whatever the caller handed over. A caller that pushes a whole
-/// synthesized utterance in one call therefore has samples discarded and counted
-/// by [`MicrophoneStream::aec_reference_dropped`]; the reference is pushed as it
-/// is played, not as it is produced.
+/// What the bound is sized for is the caller who does not feed in step: one that
+/// hands over a whole synthesized utterance in a single call. The queue holds
+/// that push whole up to this many seconds, and the canceller then reads it as
+/// the capture catches up.
 ///
-/// At 16 kHz the queue holds 16000 samples, 64 KB; at 48 kHz, 48000 samples,
-/// 192 KB.
+/// The size comes from the canceller's own limit on how far the far-end feed may
+/// run ahead of the capture. It serves a lead out of its far-end history, which
+/// spans its echo-delay window plus its adaptive tail plus a fixed slack; past
+/// that depth the lead is unservable, the canceller re-anchors onto a frontier
+/// the capture has not reached, and cancellation stops for the rest of the
+/// stream. The shallowest history any configuration decibri accepts can produce
+/// is 4266 ms (the canceller's 250 ms echo-delay window, the shortest tail
+/// [`MicrophoneConfig::aec_tail_ms`] accepts, and four seconds of slack).
+/// Measured against that configuration, a lead of 4000 ms still cancels intact,
+/// 4200 ms begins to starve, and 4400 ms is the unservable cliff. Two seconds is
+/// half the shallowest depth, so one push of the full bound cannot approach the
+/// cliff even when the previous one has not yet been consumed.
+///
+/// A push larger than the bound is truncated at its newest end and the discarded
+/// samples are counted by [`MicrophoneStream::aec_reference_dropped`]. The time
+/// they occupied is still represented: the drain supplies silence for every
+/// near-end sample the caller did not cover, so the cost is the cancellation of
+/// the discarded span alone.
+///
+/// At 16 kHz the queue holds 32000 samples, 128 KB; at 48 kHz, 96000 samples,
+/// 384 KB.
 #[cfg(all(feature = "capture", feature = "aec"))]
-pub(crate) const AEC_REFERENCE_BOUND_SECS: usize = 1;
+pub(crate) const AEC_REFERENCE_BOUND_SECS: usize = 2;
 
 /// An open capture stream you pull [`AudioChunk`]s from.
 ///
@@ -900,17 +912,24 @@ impl MicrophoneStream {
     /// `reference` is mono `f32` at
     /// [`MicrophoneConfig::aec_reference_sample_rate`] (the capture
     /// [`sample_rate`](MicrophoneConfig::sample_rate) when that is unset), in
-    /// played order and including any silence the renderer inserted: the
-    /// canceller aligns it against the captured signal, so a gap that is not
-    /// represented moves the alignment. Push it as it is played, not as it is
-    /// produced.
+    /// played order. Push it as it is played, not as it is produced: the
+    /// canceller aligns it against the captured signal, so a caller running
+    /// further ahead of the capture than the canceller can search cancels
+    /// nothing.
+    ///
+    /// Silence between what is played need not be pushed. A caller that stops
+    /// pushing has said that nothing is playing, and decibri supplies the
+    /// silence that means, counted by
+    /// [`aec_reference_silence`](Self::aec_reference_silence). Pushing the
+    /// silence explicitly is equivalent, not better.
     ///
     /// Never blocks on the canceller and never fails, so it may be called from a
     /// renderer callback or a socket handler. The queue is bounded (see
     /// `AEC_REFERENCE_BOUND_SECS`); samples that do not fit are discarded from
     /// the newest end and counted by
     /// [`aec_reference_dropped`](Self::aec_reference_dropped), leaving what
-    /// remains a contiguous run in played order.
+    /// remains a contiguous run in played order and the time the discarded
+    /// samples occupied represented as silence.
     ///
     /// A no-op on a stream with echo cancellation off.
     ///
@@ -925,10 +944,16 @@ impl MicrophoneStream {
     }
 
     /// Total number of far-end reference samples discarded because the queue was
-    /// full. Stays 0 while the reference is pushed as it plays; a rising count
-    /// means reference audio arrived faster than the capture consumed it and the
-    /// canceller has a hole in its far-end timeline. 0 on a stream with echo
+    /// full, at the declared reference rate. Stays 0 while the reference is
+    /// pushed as it plays; a rising count means a single push exceeded the
+    /// queue's bound, so that much of the played signal never reached the
+    /// canceller and the echo of it cannot be removed. 0 on a stream with echo
     /// cancellation off.
+    ///
+    /// The span the discarded samples occupied is still represented, as silence,
+    /// so the canceller's alignment survives a discard rather than being moved
+    /// by it: what a rising count costs is the cancellation of that span, not of
+    /// the rest of the stream.
     ///
     /// Distinct from [`AecMetrics::reference_dropped`](decibri_aec::AecMetrics::reference_dropped),
     /// which counts what the canceller's own far-end history overwrote after this
@@ -940,6 +965,29 @@ impl MicrophoneStream {
             .map_or(0, |queue| queue.dropped())
     }
 
+    /// Total number of far-end reference samples decibri supplied as silence
+    /// because the caller had pushed none for them, at the capture
+    /// [`sample_rate`](Self::sample_rate). 0 on a stream with echo cancellation
+    /// off.
+    ///
+    /// An accounting figure, not a fault. The canceller reads one far-end sample
+    /// for every near-end sample it cancels, and while nothing is playing the
+    /// far end is silence, so a stream with occasional playback spends most of
+    /// its length here. What it makes visible is the caller: a count that tracks
+    /// the whole length of the stream means nothing was ever pushed, and a count
+    /// that climbs while the caller believes it is playing means the reference
+    /// is not reaching this stream.
+    ///
+    /// Read with [`AecMetrics::reference_starved`](decibri_aec::AecMetrics::reference_starved),
+    /// which counts near-end samples the canceller could find no far-end sample
+    /// for at all. That one stays at 0 while this one carries the shortfall.
+    #[cfg(feature = "aec")]
+    pub fn aec_reference_silence(&self) -> u64 {
+        self.aec_reference
+            .as_ref()
+            .map_or(0, |queue| queue.silence())
+    }
+
     /// The echo canceller's transport and cancellation metrics, or `None` on a
     /// stream with echo cancellation off.
     ///
@@ -948,6 +996,14 @@ impl MicrophoneStream {
     /// reference: none was pushed, it is not at the declared rate, or it is not
     /// the signal that produced the echo. `reference_reanchors` climbing is the
     /// canceller recovering its alignment after a break in either stream.
+    ///
+    /// `reference_starved` reports near-end samples the canceller could find no
+    /// far-end sample for. decibri keeps the far-end stream level with the
+    /// capture, so this stays at 0 on a stream whose caller simply stops
+    /// pushing; the shortfall is reported by
+    /// [`aec_reference_silence`](Self::aec_reference_silence) instead. A
+    /// non-zero count here means the caller ran further ahead of the capture
+    /// than the canceller's far-end history reaches.
     ///
     /// # Thread safety
     /// Takes the capture chain's lock, which the chain holds for the duration of
@@ -2776,9 +2832,10 @@ mod tests {
     }
 
     /// The stream's push method reaches the queue the chain's canceller drains,
-    /// the discard count is reachable from the stream, and the canceller's metrics
-    /// are too. Regression: a push that lands in a queue nothing reads, and a
-    /// discard count or a metrics read with no path out to a consumer.
+    /// the discard and substituted-silence counts are reachable from the stream,
+    /// and the canceller's metrics are too. Regression: a push that lands in a
+    /// queue nothing reads, and a discard count, a silence count, or a metrics
+    /// read with no path out to a consumer.
     #[cfg(feature = "aec")]
     #[test]
     fn the_stream_reaches_the_reference_queue_and_the_metrics() {
@@ -2816,17 +2873,38 @@ mod tests {
             "the samples past the queue's bound are counted through the stream"
         );
 
+        assert_eq!(
+            stream.aec_reference_silence(),
+            0,
+            "a stream that has processed no capture has substituted no silence"
+        );
+        let mut buf = VecDeque::new();
+        stream
+            .ingest(&mut buf, make_native_chunk(vec![0.1; 320]))
+            .expect("the chain conditions one block");
+        assert_eq!(
+            stream.aec_reference_silence(),
+            320 - 4,
+            "the drain covers the near-end samples the four queued reference \
+             samples did not"
+        );
+
         let metrics = stream.aec_metrics().expect("the stream reports metrics");
         assert_eq!(
             metrics.reference_reanchors, 0,
-            "a stream that processed nothing has re-anchored nothing"
+            "a stream that processed one block has re-anchored nothing"
+        );
+        assert_eq!(
+            metrics.reference_starved, 0,
+            "a far end kept level with the capture starves nothing"
         );
 
         // A stream with echo cancellation off answers without a queue: the push is
-        // a no-op, the count is zero, and there are no metrics.
+        // a no-op, both counts are zero, and there are no metrics.
         let (plain, _sender, _running) = test_stream_with(None, 1);
         plain.push_aec_reference(&[0.1, 0.2]);
         assert_eq!(plain.aec_reference_dropped(), 0);
+        assert_eq!(plain.aec_reference_silence(), 0);
         assert!(plain.aec_metrics().is_none());
     }
 }

--- a/crates/decibri/src/stage.rs
+++ b/crates/decibri/src/stage.rs
@@ -159,6 +159,12 @@ impl Stage for ResampleStage {
 /// ([`MicrophoneStream::overrun_count`](crate::microphone::MicrophoneStream::overrun_count)),
 /// so a stall that truncates one stream truncates the other at the same point in
 /// the timeline instead of moving them apart.
+///
+/// The samples a truncation discards are lost, but the TIME they occupied is
+/// not: the drain keeps the far-end stream level with the capture by supplying
+/// silence for every near-end sample the caller did not cover (see
+/// [`AecStage::fill_reference_to`]), so a discarded span costs the cancellation
+/// of that span alone rather than moving every later sample off its alignment.
 #[cfg(feature = "aec")]
 pub(crate) struct AecReferenceRing {
     /// Samples pushed and not yet drained, in played order. Never longer than
@@ -171,6 +177,11 @@ pub(crate) struct AecReferenceRing {
     /// Samples discarded because the queue was full, read via
     /// [`dropped`](Self::dropped).
     dropped: AtomicU64,
+    /// Samples of silence the drain supplied in the caller's place, at the
+    /// capture target rate, read via [`silence`](Self::silence). Recorded here
+    /// rather than on the stage so the accessor reaches it without taking the
+    /// capture chain's lock, as [`dropped`](Self::dropped) does.
+    silence: AtomicU64,
 }
 
 #[cfg(feature = "aec")]
@@ -181,6 +192,7 @@ impl AecReferenceRing {
             queued: Mutex::new(Vec::with_capacity(capacity)),
             capacity,
             dropped: AtomicU64::new(0),
+            silence: AtomicU64::new(0),
         }
     }
 
@@ -218,6 +230,18 @@ impl AecReferenceRing {
     /// queue.
     pub(crate) fn dropped(&self) -> u64 {
         self.dropped.load(Ordering::Relaxed)
+    }
+
+    /// Record `count` far-end samples the drain supplied as silence because the
+    /// caller had pushed none for them.
+    fn record_silence(&self, count: u64) {
+        self.silence.fetch_add(count, Ordering::Relaxed);
+    }
+
+    /// Samples of silence the drain supplied in the caller's place, at the
+    /// capture target rate, for the lifetime of the queue.
+    pub(crate) fn silence(&self) -> u64 {
+        self.silence.load(Ordering::Relaxed)
     }
 }
 
@@ -257,6 +281,13 @@ pub(crate) struct AecSettings {
 /// the caller had pushed by the time that block ran. The engine re-blocks
 /// internally, so a call may append fewer or more samples than it consumed and
 /// the totals balance after [`flush`](Stage::flush).
+///
+/// The drain then tops the far-end stream up with silence to the near-end
+/// frontier, so the two streams advance together whatever the caller does. That
+/// is the played signal, not a substitute for it: while nothing is playing the
+/// far end IS silence, and a caller who pushes nothing is saying so. Without the
+/// top-up a caller who pauses leaves the far-end frontier permanently behind the
+/// capture, which the engine can only read as a reference that never arrives.
 #[cfg(feature = "aec")]
 struct AecStage {
     /// The canceller, constructed at the capture target rate.
@@ -274,6 +305,17 @@ struct AecStage {
     reference_resampler: Option<PolyphaseResampler>,
     /// The drained reference at the target rate, when a resampler runs.
     resampled: Vec<f32>,
+    /// Zeros handed to the engine when the caller's reference falls short of the
+    /// capture. Reused across blocks; one block's worth is its high-water mark,
+    /// because [`fill_reference_to`](Self::fill_reference_to) restores the
+    /// far-ahead-of-near invariant every block and so never has more than one
+    /// block to make up.
+    silence: Vec<f32>,
+    /// Far-end samples handed to the engine, at the capture target rate. Held
+    /// against `near_seen` to size the silence top-up.
+    far_fed: u64,
+    /// Near-end samples handed to the engine, at the capture target rate.
+    near_seen: u64,
     /// Whether any near-end sample has reached [`process`](Stage::process). A
     /// stage that received none holds no framing carry, so it emits nothing at
     /// [`flush`](Stage::flush) rather than a tail assembled out of nothing.
@@ -331,6 +373,9 @@ impl AecStage {
             drained: Vec::new(),
             reference_resampler,
             resampled: Vec::new(),
+            silence: Vec::new(),
+            far_fed: 0,
+            near_seen: 0,
             received_near: false,
         })
     }
@@ -347,10 +392,43 @@ impl AecStage {
                 self.resampled.clear();
                 resampler.process(&self.drained, &mut self.resampled)?;
                 self.aec.feed_reference(&self.resampled);
+                self.far_fed += self.resampled.len() as u64;
             }
-            None => self.aec.feed_reference(&self.drained),
+            None => {
+                self.aec.feed_reference(&self.drained);
+                self.far_fed += self.drained.len() as u64;
+            }
         }
         Ok(())
+    }
+
+    /// Feed silence until the far-end stream reaches `near_frontier`, the
+    /// near-end sample count this block ends at.
+    ///
+    /// The engine reads one far-end sample for every near-end sample it cancels,
+    /// and takes the far-end frontier as the caller's statement of what has
+    /// played. A caller who pushes nothing has stated that nothing played, and
+    /// the far-end signal for that span is zero, so the engine is handed exactly
+    /// that. A caller feeding in step covers every sample itself and nothing is
+    /// added; a caller who pushed AHEAD of the capture stays ahead, because the
+    /// top-up only ever makes up a shortfall and never advances the frontier
+    /// past what the caller established.
+    ///
+    /// The shortfall is at most one block: the invariant this restores holds
+    /// entering the call, so the far end can only have fallen behind by the
+    /// near-end samples added since.
+    fn fill_reference_to(&mut self, near_frontier: u64) {
+        let fill = near_frontier.saturating_sub(self.far_fed);
+        if fill == 0 {
+            return;
+        }
+        let fill = fill as usize;
+        if self.silence.len() < fill {
+            self.silence.resize(fill, 0.0);
+        }
+        self.aec.feed_reference(&self.silence[..fill]);
+        self.far_fed += fill as u64;
+        self.reference.record_silence(fill as u64);
     }
 }
 
@@ -358,8 +436,11 @@ impl AecStage {
 impl Stage for AecStage {
     fn process(&mut self, input: &[f32], out: &mut Vec<f32>) -> Result<(), DecibriError> {
         // The reference goes in first, so the far-end frontier this block is
-        // cancelled against is everything the caller had pushed by now.
+        // cancelled against is everything the caller had pushed by now, and the
+        // top-up then covers whatever of this block the caller left uncovered.
         self.feed_reference()?;
+        self.fill_reference_to(self.near_seen + input.len() as u64);
+        self.near_seen += input.len() as u64;
         if !input.is_empty() {
             self.received_near = true;
         }
@@ -3232,6 +3313,250 @@ mod tests {
         assert!(
             removed >= 20.0,
             "a reference declared at another rate must be converted and cancel (removed {removed:.1} dB)"
+        );
+    }
+
+    /// A caller that stops pushing while nothing is playing keeps cancelling
+    /// afterwards, at the level it reached before the pause.
+    ///
+    /// The far end goes silent for three seconds in the middle of the stream and
+    /// the caller pushes nothing across it, which is what a synthesis pipeline
+    /// that stops between utterances does. Regression: a drain that hands the
+    /// engine nothing when the queue is empty, which leaves the far-end frontier
+    /// permanently behind the capture. Measured against that regression, the
+    /// stream below starves 190,416 of its 256,000 near-end samples and delivers
+    /// -0.01 dB after the pause instead of the level asserted here, and it never
+    /// recovers for the rest of the call.
+    #[cfg(feature = "aec")]
+    #[test]
+    fn aec_cancels_after_the_caller_stops_pushing() {
+        const RATE: usize = 16_000;
+        const DELAY: usize = 400;
+        const ECHO_GAIN: f32 = 0.25;
+        const SECONDS: usize = 12;
+        const PAUSE_AT: usize = 4;
+        const PAUSE: usize = 3;
+
+        // The far end is silent across the pause either way. The two runs differ
+        // only in whether the caller pushes that silence itself or stops pushing
+        // and leaves decibri to supply it, which is the whole of the change.
+        let mut far = far_noise(SECONDS * RATE);
+        for sample in far[PAUSE_AT * RATE..(PAUSE_AT + PAUSE) * RATE].iter_mut() {
+            *sample = 0.0;
+        }
+        let mut near = vec![0.0f32; far.len()];
+        for i in DELAY..near.len() {
+            near[i] = ECHO_GAIN * far[i - DELAY];
+        }
+
+        let run = |push_the_silence: bool| {
+            let queue = Arc::new(AecReferenceRing::new(2 * RATE));
+            let mut chain = aec_chain(1, RATE as u32, RATE as u32, false, &queue, RATE as u32);
+            let mut out = Vec::new();
+            for (block, piece) in near.chunks(320).enumerate() {
+                let at = block * 320;
+                let paused = at >= PAUSE_AT * RATE && at < (PAUSE_AT + PAUSE) * RATE;
+                if push_the_silence || !paused {
+                    queue.push(&far[at..at + piece.len()]);
+                }
+                out.extend_from_slice(chain.run(piece).expect("run"));
+            }
+            chain.flush(&mut out).expect("flush");
+            (out, chain.aec_metrics().expect("metrics"), queue.silence())
+        };
+
+        let (pushed, _, pushed_silence) = run(true);
+        let (unpushed, metrics, silence) = run(false);
+
+        // The engine is handed the same far-end samples in the same order at the
+        // same points in the capture, so the two streams are the same stream.
+        assert_eq!(
+            unpushed, pushed,
+            "a caller that stops pushing must get what a caller pushing the \
+             silence itself gets"
+        );
+
+        let window = (SECONDS - 1) * RATE..(SECONDS - 1) * RATE + RATE / 2;
+        let removed = rms_db(&near[window.clone()]) - rms_db(&unpushed[window]);
+        assert!(
+            removed >= 30.0,
+            "the canceller must still remove at least 30 dB after a pause \
+             (removed {removed:.1} dB)"
+        );
+
+        // The far end was kept level with the capture across the pause, so the
+        // engine found a far-end sample for every near-end sample and needed no
+        // re-anchor to recover an alignment it never lost.
+        assert_eq!(
+            metrics.reference_starved, 0,
+            "a paused caller must not starve the canceller"
+        );
+        assert_eq!(
+            metrics.reference_reanchors, 0,
+            "a paused caller must not force the canceller to re-anchor"
+        );
+        assert_eq!(
+            silence,
+            (PAUSE * RATE) as u64,
+            "the silence decibri supplied is exactly the span the caller did not"
+        );
+        assert_eq!(
+            pushed_silence, 0,
+            "a caller pushing every block leaves nothing for decibri to supply"
+        );
+    }
+
+    /// A caller that hands over a whole utterance in a single call, larger than
+    /// the queue's previous one-second bound, locks and cancels.
+    ///
+    /// The push is 1.5 seconds, made once the stream is already running, which is
+    /// where a talk-back application's first playback falls. Regression: a bound
+    /// that truncates an ordinary utterance push, and an alignment that is built
+    /// against a far-end frontier the caller was not asked to keep level.
+    /// Measured against that regression this stream never locks at all:
+    /// `delay_samples` stays `None` for its whole length.
+    #[cfg(feature = "aec")]
+    #[test]
+    fn aec_locks_on_a_reference_handed_over_a_whole_utterance_at_a_time() {
+        const RATE: usize = 16_000;
+        const DELAY: usize = 400;
+        const ECHO_GAIN: f32 = 0.25;
+        const SECONDS: usize = 12;
+        // 1.5 s: larger than the one second the queue used to hold, and inside
+        // the two seconds it holds now.
+        const UTTERANCE: usize = 24_000;
+
+        let mut far = far_noise(SECONDS * RATE);
+        // Nothing plays for the first second, so the first push lands on a stream
+        // that has already anchored.
+        for sample in far[..RATE].iter_mut() {
+            *sample = 0.0;
+        }
+        let mut near = vec![0.0f32; far.len()];
+        for i in DELAY..near.len() {
+            near[i] = ECHO_GAIN * far[i - DELAY];
+        }
+
+        let queue = Arc::new(AecReferenceRing::new(2 * RATE));
+        let mut chain = aec_chain(1, RATE as u32, RATE as u32, false, &queue, RATE as u32);
+        let mut out = Vec::new();
+        // Each utterance is handed over in one call the moment the previous one
+        // has finished playing, so the far-end frontier and the capture time of
+        // the push are the same figure.
+        let mut frontier = RATE;
+        for (block, piece) in near.chunks(320).enumerate() {
+            if block * 320 >= frontier && frontier < far.len() {
+                let end = (frontier + UTTERANCE).min(far.len());
+                queue.push(&far[frontier..end]);
+                frontier = end;
+            }
+            out.extend_from_slice(chain.run(piece).expect("run"));
+        }
+        chain.flush(&mut out).expect("flush");
+
+        assert_eq!(
+            queue.dropped(),
+            0,
+            "an utterance-sized push must fit the queue whole"
+        );
+        let metrics = chain.aec_metrics().expect("a canceller reports metrics");
+        assert!(
+            metrics.delay_samples.is_some(),
+            "a caller that pushes an utterance at a time must still lock"
+        );
+        assert_eq!(
+            metrics.reference_starved, 0,
+            "a push the queue held whole starves nothing"
+        );
+
+        let window = (SECONDS - 1) * RATE..(SECONDS - 1) * RATE + RATE / 2;
+        let removed = rms_db(&near[window.clone()]) - rms_db(&out[window]);
+        assert!(
+            removed >= 30.0,
+            "an utterance-at-a-time caller must still cancel (removed {removed:.1} dB)"
+        );
+    }
+
+    /// A push larger than the queue can hold costs the cancellation of the span
+    /// it discarded and nothing else.
+    ///
+    /// The discarded samples are counted, and the span they occupied is handed to
+    /// the engine as silence, so every later sample keeps the alignment it had.
+    /// Regression: a discard that shortens the far-end timeline instead of
+    /// blanking part of it, which moves every sample after it and ends
+    /// cancellation for the rest of the call rather than for the discarded span.
+    #[cfg(feature = "aec")]
+    #[test]
+    fn an_oversized_reference_push_costs_only_the_span_it_discarded() {
+        const RATE: usize = 16_000;
+        const DELAY: usize = 400;
+        const ECHO_GAIN: f32 = 0.25;
+        const SECONDS: usize = 12;
+        const CAPACITY: usize = 2 * RATE;
+        // Three seconds handed over at once against a two-second queue, so one
+        // second of every push is discarded.
+        const UTTERANCE: usize = 3 * RATE;
+
+        let mut far = far_noise(SECONDS * RATE);
+        for sample in far[..RATE].iter_mut() {
+            *sample = 0.0;
+        }
+        let mut near = vec![0.0f32; far.len()];
+        for i in DELAY..near.len() {
+            near[i] = ECHO_GAIN * far[i - DELAY];
+        }
+
+        let queue = Arc::new(AecReferenceRing::new(CAPACITY));
+        let mut chain = aec_chain(1, RATE as u32, RATE as u32, false, &queue, RATE as u32);
+        let mut out = Vec::new();
+        let mut frontier = RATE;
+        for (block, piece) in near.chunks(320).enumerate() {
+            if block * 320 >= frontier && frontier < far.len() {
+                let end = (frontier + UTTERANCE).min(far.len());
+                queue.push(&far[frontier..end]);
+                frontier = end;
+            }
+            out.extend_from_slice(chain.run(piece).expect("run"));
+        }
+        chain.flush(&mut out).expect("flush");
+
+        // Pushes land at 1 s, 4 s, 7 s and 10 s. The first three hand over three
+        // seconds each, of which the queue keeps two, so each discards one
+        // second; the fourth has only the stream's last two seconds left to push
+        // and fits whole.
+        assert_eq!(
+            queue.dropped(),
+            3 * (UTTERANCE - CAPACITY) as u64,
+            "the samples past the bound are counted"
+        );
+        let metrics = chain.aec_metrics().expect("a canceller reports metrics");
+        assert!(
+            metrics.delay_samples.is_some(),
+            "a discard must not cost the canceller its lock"
+        );
+        assert_eq!(
+            metrics.reference_starved, 0,
+            "the discarded span is handed over as silence, so nothing starves"
+        );
+
+        // Inside the second push's kept span (4 s to 6 s), converged and with the
+        // reference intact.
+        let kept = 5 * RATE..5 * RATE + RATE / 2;
+        let removed = rms_db(&near[kept.clone()]) - rms_db(&out[kept]);
+        assert!(
+            removed >= 30.0,
+            "the span the queue held must still cancel (removed {removed:.1} dB)"
+        );
+
+        // Inside the same push's discarded span (6 s to 7 s), where the engine was
+        // handed silence and there is nothing to cancel against. Pinned so the
+        // cost of a discard stays bounded to the span it discarded rather than
+        // being assumed to be.
+        let discarded = 6 * RATE + RATE / 4..6 * RATE + RATE * 3 / 4;
+        let unremoved = rms_db(&near[discarded.clone()]) - rms_db(&out[discarded]);
+        assert!(
+            unremoved.abs() < 3.0,
+            "the discarded span passes through (level moved {unremoved:.1} dB)"
         );
     }
 


### PR DESCRIPTION
Core only. Neither binding exposes AEC yet.

Two measured failures in the reference path, both with one cause: the far-end stream is a timeline, and decibri was letting it lose time.

- A caller who pushed nothing during pauses starved the canceller permanently. Cancellation stopped after the first pause and never returned, with the audio itself intact.
- A push larger than the reference bound was discarded and the stream never locked at all.

What changes

- The drain supplies silence for every near-end sample the caller did not cover. If nothing is playing, silence is the played signal, so this is the correct far-end value rather than a substitute for one.
- The reference bound grows from one second to two, derived from the canceller's measured servable history depth.
- A truncated push now loses content but not time, so the cost is confined to the discarded span instead of the whole call.

Measured

- Pause case: 190,416 of 256,000 samples starved becomes 0, and ERLE after the pause goes from -0.01 dB to 177.1 dB.
- Oversized push: the stream now locks, at 1904 samples.
- Output for a stream with no reference is bit-identical to AEC disabled, unchanged from the previous commit. A caller who stops pushing now gets a stream bit-identical to one who pushes the silence themselves.

Diagnostics

- reference_starved no longer reports the ordinary case, so decibri counts substituted silence separately. reference_starved now reports only a caller running past the canceller's history depth.