### PR TITLE
chore(release): 5.5.0 (crate), 5.3.0 (npm), and 0.8.0 (python)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "decibri"
-version = "5.4.1"
+version = "5.5.0"
 dependencies = [
  "cpal",
  "crossbeam-channel",
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "decibri-node"
-version = "5.4.1"
+version = "5.5.0"
 dependencies = [
  "decibri",
  "napi",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "decibri-python"
-version = "5.4.1"
+version = "5.5.0"
 dependencies = [
  "decibri",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "5.4.1"
+version = "5.5.0"
 edition = "2021"
 # MSRV empirically verified 2026-04-22: rustc 1.88 is the minimum version
 # that compiles the workspace. Floors: ort 2.0.0-rc.12 declares

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -8,7 +8,7 @@ For Rust core (`crates/decibri`) and npm package (`npm/decibri`) changes, see [t
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.0] - 2026-07-31
 
 ### Added
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "decibri"
-version = "0.7.5"
+version = "0.8.0"
 description = "Cross-platform audio capture, playback, and voice activity detection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/python/python/decibri/__init__.py
+++ b/bindings/python/python/decibri/__init__.py
@@ -78,7 +78,7 @@ from decibri.exceptions import (
     WavInvalid,
 )
 
-__version__ = "0.7.5"
+__version__ = "0.8.0"
 
 
 def input_devices() -> list[MicrophoneInfo]:

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -19,7 +19,7 @@ import decibri
 
 
 def test_package_imports() -> None:
-    assert decibri.__version__ == "0.7.5"
+    assert decibri.__version__ == "0.8.0"
     # The bridges are hidden behind the private _decibri module. They are
     # NOT accessible at decibri.<X> top level (sync or async). The async
     # pair was never accessible at the top level; the sync pair
@@ -57,7 +57,7 @@ def test_version_decibri_matches_rust_core() -> None:
     # Literal equality is intentional. When the Rust workspace bumps past
     # 4.0.0 this assertion breaks deliberately, to force a conscious update of
     # the Python expectation alongside the Rust version bump.
-    assert _decibri.MicrophoneBridge.version().decibri == "5.4.1"
+    assert _decibri.MicrophoneBridge.version().decibri == "5.5.0"
 
 
 def test_version_audio_backend_matches_cpal() -> None:
@@ -73,7 +73,7 @@ def test_version_info_fields() -> None:
     from decibri import _decibri
 
     info = _decibri.MicrophoneBridge.version()
-    assert info.decibri == "5.4.1"
+    assert info.decibri == "5.5.0"
     assert info.audio_backend == "cpal 0.17"
     # binding is derived from the [project] version in pyproject.toml by
     # bindings/python/build.rs, and the installed distribution's metadata

--- a/bindings/python/tests/test_wheel_smoke.py
+++ b/bindings/python/tests/test_wheel_smoke.py
@@ -29,7 +29,7 @@ def test_import_decibri() -> None:
     """The package imports successfully from the installed wheel."""
     assert decibri is not None
     assert hasattr(decibri, "__version__")
-    assert decibri.__version__ == "0.7.5"
+    assert decibri.__version__ == "0.8.0"
 
 
 def test_construct_decibri_default() -> None:

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -68,7 +68,7 @@ wheels = [
 
 [[package]]
 name = "decibri"
-version = "0.7.5"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions" },

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -9,7 +9,7 @@ For other decibri packages, see:
 - npm package: [npm/decibri/CHANGELOG.md](../../npm/decibri/CHANGELOG.md)
 - Python package: [bindings/python/CHANGELOG.md](../../bindings/python/CHANGELOG.md)
 
-## [Unreleased]
+## [5.5.0] - 2026-07-31
 
 ### Added
 

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -9,7 +9,7 @@ For other decibri packages, see:
 - Rust core: [crates/decibri/CHANGELOG.md](../../crates/decibri/CHANGELOG.md)
 - Python package: [bindings/python/CHANGELOG.md](../../bindings/python/CHANGELOG.md)
 
-## [Unreleased]
+## [5.3.0] - 2026-07-31
 
 ### Added
 

--- a/npm/decibri/examples/decibri.browser.js
+++ b/npm/decibri/examples/decibri.browser.js
@@ -70,7 +70,7 @@ var decibri = (function() {
 	var require_decibri_browser = /* @__PURE__ */ __commonJSMin(((exports, module) => {
 		const { Emitter } = require_emitter();
 		const { WORKLET_SOURCE } = require_worklet_inline();
-		const VERSION = "5.2.5";
+		const VERSION = "5.3.0";
 		/**
 		* Browser microphone capture.
 		*

--- a/npm/decibri/package.json
+++ b/npm/decibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decibri",
-  "version": "5.2.5",
+  "version": "5.3.0",
   "description": "Cross-platform audio capture, playback, and processing for Node.js and browsers",
   "main": "src/decibri.js",
   "types": "src/decibri.d.ts",
@@ -72,10 +72,10 @@
     "MIGRATION.md"
   ],
   "optionalDependencies": {
-    "@decibri/decibri-win32-x64-msvc": "5.2.5",
-    "@decibri/decibri-darwin-arm64": "5.2.5",
-    "@decibri/decibri-linux-x64-gnu": "5.2.5",
-    "@decibri/decibri-linux-arm64-gnu": "5.2.5"
+    "@decibri/decibri-win32-x64-msvc": "5.3.0",
+    "@decibri/decibri-darwin-arm64": "5.3.0",
+    "@decibri/decibri-linux-x64-gnu": "5.3.0",
+    "@decibri/decibri-linux-arm64-gnu": "5.3.0"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.7.0"

--- a/npm/decibri/src/browser/decibri-browser.js
+++ b/npm/decibri/src/browser/decibri-browser.js
@@ -6,7 +6,7 @@ const { WORKLET_SOURCE } = require('./worklet-inline.js');
 // Browser build version. Keep in sync with package.json on each release; the
 // browser bundle cannot read package.json at runtime the way the Node wrapper
 // does, so this is a maintained constant.
-const VERSION = '5.2.5';
+const VERSION = '5.3.0';
 
 /**
  * Browser microphone capture.

--- a/npm/platform-darwin-arm64/package.json
+++ b/npm/platform-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-darwin-arm64",
-  "version": "5.2.5",
+  "version": "5.3.0",
   "os": ["darwin"],
   "cpu": ["arm64"],
   "main": "decibri.darwin-arm64.node",

--- a/npm/platform-linux-arm64-gnu/package.json
+++ b/npm/platform-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-arm64-gnu",
-  "version": "5.2.5",
+  "version": "5.3.0",
   "os": ["linux"],
   "cpu": ["arm64"],
   "main": "decibri.linux-arm64-gnu.node",

--- a/npm/platform-linux-x64-gnu/package.json
+++ b/npm/platform-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-linux-x64-gnu",
-  "version": "5.2.5",
+  "version": "5.3.0",
   "os": ["linux"],
   "cpu": ["x64"],
   "main": "decibri.linux-x64-gnu.node",

--- a/npm/platform-win32-x64-msvc/package.json
+++ b/npm/platform-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decibri/decibri-win32-x64-msvc",
-  "version": "5.2.5",
+  "version": "5.3.0",
   "os": ["win32"],
   "cpu": ["x64"],
   "main": "decibri.win32-x64-msvc.node",


### PR DESCRIPTION
Bump the Rust workspace from 5.4.1 to 5.5.0, the npm package from 5.2.5 to 5.3.0, and the Python package from 0.7.5 to 0.8.0. Every version site moves with its own artifact: the workspace manifest and lockfile, the npm package manifest with its four platform pins and manifests and the browser version with its regenerated bundle, and the Python project metadata, version mirror, lockfile, and version assertions. All three take a minor, since each gained public surface. The binding version site in the Python bridge is derived from pyproject.toml and is not edited.