### PR TITLE
chore(ci): gate on cargo-deny and lint test code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,50 @@ jobs:
         with:
           shared-key: "rust"
       - run: sudo apt-get update && sudo apt-get install -y libasound2-dev
-      - run: cargo clippy --workspace -- -D warnings
+      # --all-targets lints the test targets as well as the library. The
+      # published crate ships src/ including its test modules, and the sdist
+      # ships bindings/python/tests/, so a lint in test code is a lint in what
+      # a consumer downloads. Without this flag the test targets are never
+      # linted here.
+      - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo fmt --all -- --check
+
+  deny:
+    name: Dependency Policy
+    runs-on: ubuntu-latest
+    # This job reads the dependency graph and the lockfile. It writes nothing
+    # and needs no token beyond source access.
+    permissions:
+      contents: read
+    # Deliberately not gated on `lint`. It compiles nothing and finishes in
+    # seconds, so running it in parallel puts a licence or advisory failure in
+    # front of a reviewer at the same time as a formatting one.
+    steps:
+      # Third-party actions are pinned to immutable commits with a version
+      # comment, per the action pin policy documented in python-ci.yml: a
+      # floating major tag can be repointed by whoever controls the action.
+      # dtolnay/rust-toolchain is that policy's documented exception and keeps
+      # its rolling form. The other jobs in this workflow still use floating
+      # tags; converting them is separate work.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+        with:
+          # Distinct from the "rust" key the compiling jobs share. This job
+          # builds nothing and only needs the registry warm, so it neither
+          # depends on nor overwrites their target/ cache.
+          shared-key: "rust-deny"
+      - uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
+        with:
+          # Pinned exactly. cargo-deny's config semantics change between minor
+          # versions, so an unpinned upgrade can silently change what
+          # deny.toml means.
+          tool: cargo-deny@0.20.2
+      # All four checks: advisories, licenses, bans, sources. deny.toml holds
+      # the policy and the reasoning for each setting. The four cost under two
+      # seconds once warm; the advisory database adds about eight seconds and
+      # 2 MB on a cold runner, which is too small to be worth caching.
+      - run: cargo deny check
 
   audit:
     name: Security Audit

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -4,6 +4,12 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
+# Never published to crates.io. napi builds this crate and npm distributes the
+# result, so the unversioned path dependency on decibri below is the only
+# resolution that ever runs. This line pairs with `allow-wildcard-paths` in
+# deny.toml, which exempts an unversioned path dependency only for a crate that
+# is never published. Removing it fails cargo-deny's `bans` check.
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -4,6 +4,12 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
+# Never published to crates.io. maturin builds this crate and PyPI distributes
+# the result, so the unversioned path dependency on decibri below is the only
+# resolution that ever runs. This line pairs with `allow-wildcard-paths` in
+# deny.toml, which exempts an unversioned path dependency only for a crate that
+# is never published. Removing it fails cargo-deny's `bans` check.
+publish = false
 
 [lib]
 # Python extension module. `name = "_decibri"` makes cargo output

--- a/crates/decibri/src/stage.rs
+++ b/crates/decibri/src/stage.rs
@@ -3671,7 +3671,7 @@ mod tests {
             let mut out = Vec::new();
             for (block, piece) in near.chunks(320).enumerate() {
                 let at = block * 320;
-                let paused = at >= PAUSE_AT * RATE && at < (PAUSE_AT + PAUSE) * RATE;
+                let paused = (PAUSE_AT * RATE..(PAUSE_AT + PAUSE) * RATE).contains(&at);
                 if push_the_silence || !paused {
                     queue.push(&far[at..at + piece.len()]);
                 }

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,102 @@
+# cargo-deny policy for decibri.
+#
+# Four checks are enforced on every push and pull request by the `deny` job in
+# .github/workflows/ci.yml: advisories, licenses, bans, sources. All four are
+# enforcing. There are no ignore entries, no licence exceptions, no
+# clarifications and no skip entries. A dependency that would need one is a
+# dependency to reconsider, not a line to add here.
+#
+# A clarification asserts what someone else's licence means, so it is a
+# maintainer decision rather than a build fix. If a crate's licence cannot be
+# read, raise it rather than writing a `[[licenses.clarify]]` entry.
+#
+# Written against cargo-deny 0.20.2. The tool's config semantics change
+# between minor versions.
+
+[graph]
+# The four targets decibri publishes for. They are the build matrices of
+# .github/workflows/publish-npm.yml and .github/workflows/publish-pypi.yml,
+# and they must stay in step with both.
+#
+# Restricting the graph is what lets `multiple-versions = "deny"` below hold
+# with no skip entries. The duplicate versions in the lockfile (thiserror 1.x,
+# windows-sys 0.45) enter through cpal's Android branch, which none of these
+# four targets compiles, so they are absent from everything decibri ships.
+targets = [
+    "x86_64-pc-windows-msvc",
+    "aarch64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+]
+
+# Check every optional feature, not just the default selection. vad, denoise,
+# aec and capture each pull dependencies the default set does not, and an
+# unchecked feature is an unchecked dependency.
+all-features = true
+
+[advisories]
+# A yanked crate in the lockfile fails the build rather than warning.
+yanked = "deny"
+
+# The widest unmaintained scope: report an unmaintained crate anywhere in the
+# graph, not only among the workspace's own dependencies. A transitive
+# unmaintained crate ships in exactly the same binary as a direct one.
+unmaintained = "all"
+
+[licenses]
+# Permissive licences only. A crate whose licence expression cannot be
+# satisfied by an entry in this list fails the check.
+#
+# LGPL is deliberately absent, and its absence is the copyleft gate. Nothing
+# the four targets above resolve carries a copyleft arm today, so the gate is
+# forward-looking: a dependency that can only be satisfied under LGPL, GPL,
+# AGPL or MPL fails this check and reaches a person, rather than arriving with
+# a routine version bump. Widening `targets` reaches code these four do not, so
+# a change there is also a change to what this list has to cover.
+#
+# Nothing is added to this list to make a build pass. Each entry is a licence
+# decibri is willing to redistribute under, in a product with a paid
+# component.
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "Unicode-3.0",
+    "Unlicense",
+    "CDLA-Permissive-2.0",
+]
+
+# The list above is what decibri accepts, not an inventory of what the graph
+# currently contains, so an entry matching nothing is not a defect. Under the
+# four shipped targets BSD-3-Clause matches nothing today: it reaches the
+# lockfile only through num_enum under cpal's Android backend. Left at the
+# default this reports a warning on every green run.
+unused-allowed-license = "allow"
+
+[bans]
+# Exactly one version of each crate across the four shipped targets. A second
+# version entering the graph changes what ships, so it fails rather than warns.
+multiple-versions = "deny"
+
+# No dependency may carry a `*` version requirement.
+#
+# The two settings below work as a pair, and both are load-bearing.
+# bindings/node and bindings/python depend on decibri by path with no version
+# component; cargo-deny reads that as a wildcard for any crate bound for
+# crates.io, because publishing strips the path and leaves the requirement
+# unbounded. `allow-wildcard-paths` exempts an unversioned path dependency, but
+# only for a crate that is never published, which is why both bindings carry
+# `publish = false`. Removing either the setting below or `publish = false`
+# from either binding fails this check.
+wildcards = "deny"
+allow-wildcard-paths = true
+
+[sources]
+# crates.io is the only source. A git dependency or an alternative registry
+# fails the check.
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
Adds a licence and dependency gate, and closes a gap where CI did not lint test code.

cargo-deny

- `deny.toml` sets an explicit licence allowlist. Anything not on it fails, which is what makes copyleft a build failure rather than a discovery.
- Duplicate versions, wildcard requirements and non-crates.io sources all deny. The graph is scoped to the four shipped target triples, which is what makes the duplicate check achievable rather than something to soften.
- All four checks run on every pull request. Warm cost is 2.6 seconds; the advisory database on a cold runner adds 7.84 seconds and 2.2 MB, which is too small to justify caching.
- The gate is proven to fail: a crate carrying MPL-2.0 is rejected with its licence, its dependency path, and a Copyleft label.

publish = false

- Both bindings set it, and `deny.toml` sets `allow-wildcard-paths`. Both are required for the internal path dependencies to pass, and each fails without the other. Neither binding is published to crates.io.

Clippy

- The CI clippy step gains `--all-targets`. It previously did not lint test code, which ships: `tests/` is not packaged, but inline `#[cfg(test)]` modules in `src/` are.
- It catches one lint, a manual range comparison in `stage.rs`, which is rewritten. Nothing else fires.
