### PR TITLE
chore(ci): pin every action and scope workflow permissions

### DIFF
--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -5,16 +5,23 @@ on:
     - cron: "0 22 * * 0"  # Monday 8:00 AM AEST (Sunday 10 PM UTC)
   workflow_dispatch:
 
+# Read-only at the workflow level. `issues: write` is granted per job, to the
+# three jobs that open a drift issue, so any job added later starts with no
+# write access.
 permissions:
-  issues: write
   contents: read
 
 jobs:
   check-cpal:
     name: Check cpal
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo generate-lockfile
 
@@ -46,16 +53,21 @@ jobs:
         if: steps.pinned.outputs.version != steps.latest.outputs.version
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Both versions come from network output (`cargo search` against
+          # crates.io and the lockfile), so they reach the shell as quoted
+          # variables rather than being expanded into the script text.
+          PINNED: ${{ steps.pinned.outputs.version }}
+          LATEST: ${{ steps.latest.outputs.version }}
         run: |
           COUNT=$(gh issue list --label "dependency-update" --state open --search "cpal" --json number --jq 'length')
           if [ "$COUNT" = "0" ]; then
             gh issue create \
-              --title "cpal ${{ steps.latest.outputs.version }} available (pinned: ${{ steps.pinned.outputs.version }})" \
+              --title "cpal ${LATEST} available (pinned: ${PINNED})" \
               --label "dependency-update" \
               --body "A new version of **cpal** is available on crates.io.
 
-          **Pinned:** ${{ steps.pinned.outputs.version }}
-          **Latest:** ${{ steps.latest.outputs.version }}
+          **Pinned:** ${PINNED}
+          **Latest:** ${LATEST}
 
           **Changelog:** https://github.com/RustAudio/cpal/releases
 
@@ -65,8 +77,13 @@ jobs:
   check-ort:
     name: Check ort
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo generate-lockfile
 
@@ -96,16 +113,20 @@ jobs:
         if: steps.pinned.outputs.version != steps.latest.outputs.version
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # See the cpal job: network-derived values are passed as variables,
+          # not expanded into the script text.
+          PINNED: ${{ steps.pinned.outputs.version }}
+          LATEST: ${{ steps.latest.outputs.version }}
         run: |
           COUNT=$(gh issue list --label "dependency-update" --state open --search "ort" --json number --jq 'length')
           if [ "$COUNT" = "0" ]; then
             gh issue create \
-              --title "ort ${{ steps.latest.outputs.version }} available (pinned: ${{ steps.pinned.outputs.version }})" \
+              --title "ort ${LATEST} available (pinned: ${PINNED})" \
               --label "dependency-update" \
               --body "A new version of **ort** is available on crates.io.
 
-          **Pinned:** ${{ steps.pinned.outputs.version }}
-          **Latest:** ${{ steps.latest.outputs.version }}
+          **Pinned:** ${PINNED}
+          **Latest:** ${LATEST}
 
           **Changelog:** https://github.com/pykeio/ort/releases
 
@@ -115,11 +136,15 @@ jobs:
   check-onnxruntime:
     name: Check ONNX Runtime upstream
     runs-on: ubuntu-latest
-    # No per-job `permissions` block: inherits file-level
-    # `issues: write, contents: read` declared at top of this workflow
-    # (same pattern as the existing check-cpal and check-ort jobs).
+    # Same per-job grant as check-cpal and check-ort: this job creates the
+    # label and opens the drift issue.
+    permissions:
+      contents: read
+      issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Ensure dependency-update label exists
         env:
@@ -180,13 +205,14 @@ jobs:
         if: steps.pinned.outputs.version != steps.latest.outputs.version
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # LATEST and DATE come from the GitHub releases API. See the cpal
+          # job: they reach the shell as variables, not as expanded text.
+          PINNED: ${{ steps.pinned.outputs.version }}
+          LATEST: ${{ steps.latest.outputs.version }}
+          LATEST_MINOR: ${{ steps.latest.outputs.minor }}
+          API_N: ${{ steps.baseline.outputs.api_n }}
+          DATE: ${{ steps.latest.outputs.date }}
         run: |
-          PINNED="${{ steps.pinned.outputs.version }}"
-          LATEST="${{ steps.latest.outputs.version }}"
-          LATEST_MINOR="${{ steps.latest.outputs.minor }}"
-          API_N="${{ steps.baseline.outputs.api_n }}"
-          DATE="${{ steps.latest.outputs.date }}"
-
           ABI_WARNING=""
           if [ "$LATEST_MINOR" -gt "$API_N" ]; then
             ABI_WARNING="

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main, development]
 
+# Every job here reads source, compiles, and runs tests. None writes to the
+# repository, opens an issue, or requests an OIDC token, so the whole workflow
+# runs on a read-only token.
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -15,11 +21,21 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      # Action references are pinned to commit SHAs with a version comment.
+      # The policy and its one exception (dtolnay/rust-toolchain) live in
+      # .github/zizmor.yml, which enforces them in CI.
+      #
+      # actions/checkout appears here at v6.1.0 and in the deny job at
+      # v6.0.2. The deny job was pinned earlier at the version current then;
+      # both are the version each site already ran. Dependabot's grouped
+      # github-actions update converges them.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: "rust"
       - run: sudo apt-get update && sudo apt-get install -y libasound2-dev
@@ -42,13 +58,9 @@ jobs:
     # seconds, so running it in parallel puts a licence or advisory failure in
     # front of a reviewer at the same time as a formatting one.
     steps:
-      # Third-party actions are pinned to immutable commits with a version
-      # comment, per the action pin policy documented in python-ci.yml: a
-      # floating major tag can be repointed by whoever controls the action.
-      # dtolnay/rust-toolchain is that policy's documented exception and keeps
-      # its rolling form. The other jobs in this workflow still use floating
-      # tags; converting them is separate work.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
         with:
@@ -72,13 +84,15 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: "rust"
       - run: cargo generate-lockfile
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: cargo-audit
       - run: cargo audit
@@ -96,9 +110,11 @@ jobs:
         os: [ubuntu-latest, macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: "rust"
       - name: Install ALSA (Linux only)
@@ -163,9 +179,11 @@ jobs:
           # executes them.
           - { name: capture+aec, command: "test", flags: "--no-default-features --features capture,aec" }
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: "rust"
       - run: sudo apt-get update && sudo apt-get install -y libasound2-dev
@@ -177,12 +195,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: "rust"
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -204,8 +224,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,6 +14,9 @@ jobs:
   cla:
     runs-on: ubuntu-latest
     steps:
-      - uses: decibri/decibri-cla-action@v1
+      # First-party action, pinned like every other reference. A new release
+      # of decibri-cla-action needs this SHA moved before it takes effect
+      # here; the floating `v1` tag no longer carries it automatically.
+      - uses: decibri/decibri-cla-action@df302efd816125bd596dd62fdc1896e467b74151 # v1
         with:
           store-token: ${{ secrets.CLA_STORE_TOKEN }}

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -11,39 +11,45 @@ on:
         default: false
         description: 'Tick to actually publish. Unticked = dry run (preflight only, no publish).'
 
+# Read-only at the workflow level. The write grants the publish job needs are
+# declared on that job. `attestations: write` was declared here for an
+# attest-build-provenance step that this workflow does not have; no step
+# requests it, so it is not granted.
 permissions:
-  # `contents: write` permits the `gh release create` step.
-  # `id-token: write` lets the `rust-lang/crates-io-auth-action` step
-  # exchange a GitHub OIDC token for a short-lived crates.io publish token.
-  # `attestations: write` is reserved for a future attest-build-provenance
-  # step against the .crate tarball.
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 jobs:
   preflight:
     name: Preflight (version match)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Run mode
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUBLISH_INPUT: ${{ inputs.publish }}
+          TAG: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish }}" != "true" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$PUBLISH_INPUT" != "true" ]; then
             echo "::notice::DRY RUN MODE (workflow_dispatch with publish=false). No publish will occur."
           else
-            echo "Publishing run. Trigger: ${{ github.event_name }}. Tag: ${{ github.ref_name }}"
+            echo "Publishing run. Trigger: ${EVENT_NAME}. Tag: ${TAG}"
           fi
 
       - name: Assert tag version matches workspace Cargo.toml
         if: github.event_name == 'push'
         shell: bash
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
           # Tag form: refs/tags/crate-v3.4.0 -> TAG_VERSION=3.4.0
-          TAG_VERSION="${{ github.ref_name }}"
-          TAG_VERSION="${TAG_VERSION#crate-v}"
+          TAG_VERSION="${TAG#crate-v}"
           echo "Tag version: ${TAG_VERSION}"
 
           # Workspace Cargo.toml: the `[workspace.package]` block's
@@ -73,8 +79,19 @@ jobs:
     # Required-reviewer protection on this environment gates the publish
     # behind a manual approval in the Actions UI.
     environment: crates
+    permissions:
+      # `contents: write` permits the `gh release create` step.
+      # `id-token: write` lets the `rust-lang/crates-io-auth-action` step
+      # exchange a GitHub OIDC token for a short-lived crates.io publish token.
+      contents: write
+      id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          # `cargo publish` and `gh release create` both authenticate with
+          # their own token, so the checkout does not need to leave one in
+          # .git/config.
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -90,7 +107,7 @@ jobs:
         # consumed by the next step's `CARGO_REGISTRY_TOKEN` env var.
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == true)
         id: auth
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
 
       - name: Publish to crates.io
         # Tag-push always publishes. workflow_dispatch publishes only when
@@ -104,7 +121,8 @@ jobs:
         if: github.event_name == 'push'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
         run: |
-          gh release create ${{ github.ref_name }} \
-            --title "${{ github.ref_name }}" \
+          gh release create "$TAG" \
+            --title "$TAG" \
             --generate-notes

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -11,15 +11,10 @@ on:
         default: false
         description: 'Tick to actually publish. Unticked = dry run (build, stage, verify-pack only; no publish).'
 
+# Read-only at the workflow level. The build job and the publish job each
+# declare the writes they need; the preflight job needs none.
 permissions:
-  # `contents: write` permits the `gh release create` step.
-  # `id-token: write` is required for npm Trusted Publisher OIDC token
-  # issuance.
-  # `attestations: write` permits the actions/attest-build-provenance step
-  # against the native addons.
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 # Single source of truth for the bundled ONNX Runtime version, read by
 # every platform job's preflight/download step. Also parsed by the
@@ -34,27 +29,36 @@ jobs:
   preflight:
     name: Preflight (version match)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Run mode
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUBLISH_INPUT: ${{ inputs.publish }}
+          TAG: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish }}" != "true" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$PUBLISH_INPUT" != "true" ]; then
             echo "::notice::DRY RUN MODE (workflow_dispatch with publish=false). No publish will occur."
           else
-            echo "Publishing run. Trigger: ${{ github.event_name }}. Tag: ${{ github.ref_name }}"
+            echo "Publishing run. Trigger: ${EVENT_NAME}. Tag: ${TAG}"
           fi
 
       - name: Assert tag version matches package manifests
         if: github.event_name == 'push'
         shell: bash
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
           # Tag form: refs/tags/npm-v3.4.0 -> TAG_VERSION=3.4.0
           # Pre-release tags (npm-v3.5.0-rc.1) are allowed; the suffix is
           # preserved and must match across every manifest if used.
-          TAG_VERSION="${{ github.ref_name }}"
-          TAG_VERSION="${TAG_VERSION#npm-v}"
+          TAG_VERSION="${TAG#npm-v}"
           echo "Tag version: ${TAG_VERSION}"
 
           MISMATCH=0
@@ -116,14 +120,23 @@ jobs:
             ort_platform_slug: linux-aarch64
             ort_ext: tgz
 
+    permissions:
+      # `id-token: write` and `attestations: write` are what
+      # actions/attest-build-provenance requires to sign the native addons;
+      # `contents: read` is the checkout.
+      contents: read
+      id-token: write
+      attestations: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '22'
 
@@ -235,11 +248,11 @@ jobs:
         run: ls -la npm/decibri/decibri.*.node
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: npm/decibri/decibri.*.node
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: decibri-${{ matrix.artifact }}
           # Only one of the libonnxruntime.* / onnxruntime.dll patterns matches
@@ -256,7 +269,7 @@ jobs:
 
       - name: Upload napi loader (Linux x64 only)
         if: matrix.artifact == 'linux-x64-gnu'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: decibri-loader
           path: |
@@ -271,10 +284,20 @@ jobs:
     # Required-reviewer protection on this environment gates the publish
     # behind a manual approval in the Actions UI.
     environment: npm
+    permissions:
+      # `contents: write` permits the `gh release create` step.
+      # `id-token: write` is required for npm Trusted Publisher OIDC token
+      # issuance. npm's provenance runs over that OIDC token and does not
+      # call the GitHub attestations API, so `attestations: write` belongs
+      # on the build job (attest-build-provenance) rather than here.
+      contents: write
+      id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
@@ -283,7 +306,7 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts/
 
@@ -455,9 +478,10 @@ jobs:
         if: github.event_name == 'push'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
         run: |
-          gh release create ${{ github.ref_name }} \
-            --title "${{ github.ref_name }}" \
+          gh release create "$TAG" \
+            --title "$TAG" \
             --generate-notes
 
       - name: Verify npm publish
@@ -467,9 +491,10 @@ jobs:
         # workflow_dispatch the tag is HEAD's most recent tag or empty;
         # the strip is a no-op for non-prefixed inputs.
         shell: bash
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
-          VERSION="${{ github.ref_name }}"
-          VERSION="${VERSION#npm-v}"
+          VERSION="${TAG#npm-v}"
           echo "Verifying npm registry view for decibri@${VERSION}"
           sleep 30
           npm view "decibri@${VERSION}"

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,6 +1,6 @@
 name: Publish to PyPI
 
-# Phase 10 (2026-05-02). Publishes the decibri Python wheel to TestPyPI
+# Phase 10 (2026-05-02). Publishes the decibri wheel to TestPyPI
 # (prerelease tags: python-v*a*, python-v*b*, python-v*rc*) or production
 # PyPI (stable tags: python-v\d+.\d+.\d+) via Trusted Publisher OIDC.
 #
@@ -41,9 +41,11 @@ on:
         default: false
         description: 'Tick to actually publish. Unticked = dry run (build and validate only).'
 
+# Read-only at the workflow level. `id-token: write` (required for Trusted
+# Publisher OIDC token issuance) is declared on the two publish jobs that
+# exchange it; the build and sdist jobs never request a token.
 permissions:
   contents: read
-  id-token: write    # required for Trusted Publisher OIDC token issuance
 
 env:
   # Single source of truth for the bundled ONNX Runtime version.
@@ -91,8 +93,12 @@ jobs:
             target: x86_64-pc-windows-msvc
             ort_platform_slug: win-x64
             ort_ext: zip
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # ALSA dev headers are needed for cpal -> alsa-sys on Linux. macOS and
       # Windows pull CoreAudio / WASAPI from system frameworks.
@@ -351,7 +357,7 @@ jobs:
               -v
 
       - name: Upload validated wheel artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheel-${{ matrix.target }}
           path: target/wheels/decibri-*.whl
@@ -383,8 +389,12 @@ jobs:
     name: Build sdist
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Build sdist
         # PyO3/maturin-action command: sdist produces a Cargo-default
@@ -421,7 +431,7 @@ jobs:
           twine check "$SDIST"
 
       - name: Upload sdist artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sdist
           path: target/wheels/decibri-*.tar.gz
@@ -457,7 +467,7 @@ jobs:
       # build-and-validate and the single sdist artifact from build-sdist
       # (0.1.3 addition). merge-multiple: true flattens both into dist/
       # without colliding (.whl vs .tar.gz extensions).
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist/
           merge-multiple: true
@@ -467,7 +477,7 @@ jobs:
         run: ls -la dist/
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist/
           repository-url: https://test.pypi.org/legacy/
@@ -505,7 +515,7 @@ jobs:
       # build-and-validate and the single sdist artifact from build-sdist
       # (0.1.3 addition). merge-multiple: true flattens both into dist/
       # without colliding (.whl vs .tar.gz extensions).
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist/
           merge-multiple: true
@@ -515,7 +525,7 @@ jobs:
         run: ls -la dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist/
           attestations: true

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -26,6 +26,11 @@ on:
     # schedules in this repo (check-upstream.yml runs Sundays 22:00 UTC).
     - cron: "0 4 * * *"
 
+# The single job here builds a wheel and runs tests. It writes nothing back to
+# the repository and requests no OIDC token, so it runs on a read-only token.
+permissions:
+  contents: read
+
 concurrency:
   # Distinct from ci.yml's `ci-${{ github.ref }}` group so Rust-side CI and
   # Python-side CI run in parallel per ref, cancelling only their own
@@ -115,24 +120,14 @@ jobs:
       # the abi3-floor canary; the matrix now exercises every supported
       # runtime explicitly).
       UV_PYTHON: ${{ matrix.python-version }}
-    # Action pin policy: third-party actions pinned to immutable commit SHAs
-    # with a `# vX.Y.Z` version comment that dependabot parses for updates.
-    # Floating major tags (@v6, @v8) were the attack vector for the 2025
-    # tj-actions/changed-files supply-chain compromise; SHA pins eliminate
-    # that class of risk. setup-uv v8 explicitly stopped publishing major
-    # tags for this reason, which is what surfaced this hardening pass.
-    #
-    # Exception: `dtolnay/rust-toolchain` is documented to use the rolling
-    # `@stable` / `@nightly` / `@1.83.0` form; the maintainer explicitly
-    # warns against SHA pinning (orphan-GC risk on the rolling branches).
-    # Acceptable because the action is a thin shell wrapper around rustup;
-    # the security boundary is rustup itself, not the action.
-    #
-    # The existing ci.yml workflow uses floating major tags (v6 / v2 etc).
-    # Pinning that workflow to SHAs is deferred to Phase 5 CI hardening
-    # (see Phase 1 plan §7.7).
+    # Action references are pinned to commit SHAs with a `# vX.Y.Z` version
+    # comment that dependabot parses for updates. The policy, and its one
+    # exception (dtolnay/rust-toolchain), live in .github/zizmor.yml, which
+    # enforces them across every workflow.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install libasound2-dev (Linux only)
         # cpal (transitive via decibri core) needs ALSA dev headers on Linux.
@@ -165,7 +160,15 @@ jobs:
         # platform (linux-x64, linux-aarch64, darwin-aarch64, win-x64),
         # so this single command works across all four matrix OSes
         # without per-OS conditionals.
-        run: uv python install ${{ matrix.python-version }}
+        #
+        # `shell: bash` is required, not cosmetic: the matrix includes
+        # windows-latest, whose default shell is pwsh, and `$PYTHON_VERSION`
+        # below is bash syntax. pwsh reads it as an undefined PowerShell
+        # variable and passes an empty argument to `uv python install`.
+        shell: bash
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: uv python install "$PYTHON_VERSION"
 
       - name: Sync dev environment (locked)
         working-directory: bindings/python

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,46 @@
+name: Workflow Audit
+
+# zizmor audits the workflow files themselves: action pins, job permissions,
+# expression expansion into run blocks, and trigger safety. Path-filtered to
+# .github/** because that is the only input it reads, and those files change
+# rarely; running it on every commit would be noise. workflow_dispatch is
+# there so the audit can be run on demand before a release tag is pushed.
+on:
+  push:
+    branches: [main, development]
+    paths:
+      - '.github/workflows/**'
+      - '.github/zizmor.yml'
+  pull_request:
+    branches: [main, development]
+    paths:
+      - '.github/workflows/**'
+      - '.github/zizmor.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zizmor-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    # Reads the workflow files and nothing else.
+    permissions:
+      contents: read
+    steps:
+      # An audit that checks for unpinned actions has to be pinned itself.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      # Pinned exactly. zizmor adds audits between releases, so an unpinned
+      # upgrade turns a green gate red on a commit that changed nothing.
+      # The policy and every accepted exception live in .github/zizmor.yml;
+      # the run fails on any finding not recorded there.
+      - name: Audit workflows
+        run: uvx zizmor@1.29.0 --no-progress .github/workflows

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,66 @@
+# zizmor configuration. https://docs.zizmor.sh/configuration/
+#
+# zizmor audits the workflow files in .github/workflows for GitHub Actions
+# security weaknesses. This file holds the repository's action-pin policy and
+# every accepted exception, so a finding is either fixed or recorded here with
+# a reason. The workflow that runs it is .github/workflows/zizmor.yml.
+
+rules:
+  # Action-pin policy. Every action reference is pinned to a commit SHA with a
+  # trailing `# vX.Y.Z` comment, which dependabot parses and rewrites on
+  # update. A floating tag (@v6, @v2) can be repointed at any commit by
+  # whoever controls the action repository.
+  #
+  # Exception: dtolnay/rust-toolchain is documented to use the rolling
+  # `@stable` / `@nightly` / `@1.83.0` form, and its maintainer warns against
+  # SHA pinning because the rolling branches are subject to orphan GC. The
+  # action is a thin wrapper around rustup, so the security boundary is rustup
+  # itself. `ref-pin` still requires a named ref and rejects a bare branch
+  # reference elsewhere.
+  unpinned-uses:
+    config:
+      policies:
+        dtolnay/rust-toolchain: ref-pin
+        "*": hash-pin
+
+  # cla.yml runs on pull_request_target because a CLA check has to post a
+  # check result on pull requests that arrive from forks, which the
+  # read-only pull_request token cannot do. The workflow checks out no code:
+  # its single step passes a token to the CLA action, so the untrusted head
+  # of the pull request is never fetched or executed.
+  dangerous-triggers:
+    ignore:
+      - cla.yml
+
+  # The cache keys these two workflows read are written only by workflows that
+  # require repository write access to trigger (tag push, workflow_dispatch,
+  # or a push to main / development). Pull requests from forks run against an
+  # isolated cache scope and cannot write into the base repository's caches,
+  # so there is no untrusted writer to poison them.
+  #
+  # The two publish-npm.yml entries are actions/setup-node steps that pass no
+  # `cache:` input, so they enable no caching at all.
+  cache-poisoning:
+    ignore:
+      - publish-npm.yml
+      - publish-pypi.yml
+
+  # `npm install -g npm@latest` in the publish job. npm trusted publishing
+  # needs a recent npm client, and pinning the client to a version makes it
+  # one more release-time bump that fails the publish when it goes stale.
+  # The package comes from the npm registry over the same trust path the
+  # publish itself uses.
+  adhoc-packages:
+    ignore:
+      - publish-npm.yml
+
+  # Remaining expansions in these two workflows are values the workflow
+  # computed itself: a static build matrix and the ORT download URL derived
+  # from it by an earlier step. No external input reaches them. The
+  # expansions that did carry external input (the crates.io and GitHub API
+  # responses in check-upstream.yml, and the tag name in the publish
+  # workflows) are passed through `env:` instead.
+  template-injection:
+    ignore:
+      - publish-pypi.yml
+      - python-ci.yml

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -19,7 +19,7 @@ publish = false
 # `decibri_python.{pyd,so}` (derived from crate name) and maturin would
 # have to rename during wheel packaging.
 #
-# `cdylib` only. `rlib` would let other Rust crates depend on us; we're a
+# `cdylib` only. `rlib` would let other crates depend on us; we're a
 # terminal binding crate, so cdylib is the sole output.
 name = "_decibri"
 crate-type = ["cdylib"]


### PR DESCRIPTION
Audits the workflows with zizmor and acts on what it found. No source change beyond one comment.

- `.github/workflows/zizmor.yml` audits the workflows, path-filtered on `.github/workflows/**` and available on manual dispatch.
- `.github/zizmor.yml` records the findings left in place, each with a reason, so a suppressed finding is a decision rather than a threshold.
- 12 action references are pinned to commit SHAs. Each SHA was read from the action's own repository at the ref that site already used, so this pins without upgrading.
- Every workflow is read-only at file level, with each write granted on the single job whose steps require it.
- Two comments carrying banned phrases are reworded.