### PR TITLE
chore(ci): send dependency and workflow findings to the Security tab

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,23 +80,6 @@ jobs:
       # 2 MB on a cold runner, which is too small to be worth caching.
       - run: cargo deny check
 
-  audit:
-    name: Security Audit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-        with:
-          persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
-        with:
-          shared-key: "rust"
-      - run: cargo generate-lockfile
-      - uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
-        with:
-          tool: cargo-audit
-      - run: cargo audit
-
   test-rust:
     name: Rust Tests (${{ matrix.os }})
     needs: lint
@@ -216,8 +199,6 @@ jobs:
         run: cd npm/decibri && npm run build
       - name: Run CI-safe tests
         run: node tests/test-ci.js
-      - name: Audit npm dependencies
-        run: cd npm/decibri && npm audit --omit=dev || true
 
   test-browser:
     name: Browser Tests

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,85 @@
+name: OSV Scanner
+
+# OSV-Scanner reads every lockfile in the repository and reports known
+# vulnerabilities against the OSV database. It covers four lockfiles across
+# three ecosystems, which no single other check in this repository does:
+#
+#   Cargo.lock                       crates.io
+#   package-lock.json                npm, the test runner's dependencies
+#   npm/decibri/package-lock.json    npm, the addon package's dependencies
+#   bindings/python/uv.lock          PyPI
+#
+# The `deny` job in ci.yml also reads advisories, but only for crates
+# reachable from the four targets in deny.toml, so the two are not
+# interchangeable. deny.toml records that boundary.
+#
+# Triggers match ci.yml, plus a weekly run: a lockfile that was clean when it
+# merged can be reported against later, so the scan repeats on a clock as well
+# as on a change. No path filter, for the same reason. The database moves
+# independently of this repository.
+on:
+  push:
+    branches: [main, development]
+  pull_request:
+    branches: [main, development]
+  schedule:
+    # Mondays, 05:23 UTC. Off the hour, where scheduled runs across GitHub
+    # queue together.
+    - cron: '23 5 * * 1'
+  workflow_dispatch:
+
+# Read-only at file level. The one job below raises its own scope for the
+# SARIF upload and nothing else.
+permissions:
+  contents: read
+
+concurrency:
+  group: osv-scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Lockfile Vulnerabilities
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Uploading SARIF to the Security tab. This is the only write scope in
+      # the workflow and this job is the only holder of it.
+      security-events: write
+      # codeql-action/upload-sarif reads the workflow run it uploads for.
+      actions: read
+    steps:
+      # Action references are pinned to commit SHAs with a version comment,
+      # per the policy in .github/zizmor.yml.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      # Pinned exactly, as cargo-deny and zizmor are. The scanner is installed
+      # from its GitHub release rather than run as a container action, which
+      # keeps the version visible here instead of inside an image tag.
+      - uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
+        with:
+          tool: osv-scanner@2.4.0
+      # Recursive from the repository root, so a lockfile added later is
+      # scanned without editing this file.
+      #
+      # continue-on-error because osv-scanner exits non-zero when it finds
+      # something, and the SARIF still has to reach the Security tab. The last
+      # step turns that outcome back into a job failure. Removing it makes the
+      # upload unreachable on exactly the runs that need it.
+      - name: Scan lockfiles
+        id: scan
+        continue-on-error: true
+        run: osv-scanner scan source --recursive --format=sarif --output-file=results.sarif ./
+      - name: Upload results to the Security tab
+        if: ${{ !cancelled() && hashFiles('results.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          sarif_file: results.sarif
+          category: osv-scanner
+      # Fails on any non-zero exit, a finding or a scanner error alike.
+      - name: Fail on findings
+        if: ${{ steps.scan.outcome == 'failure' }}
+        run: |
+          echo "::error::OSV-Scanner reported known vulnerabilities. See the Security tab."
+          exit 1

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -29,9 +29,14 @@ jobs:
   zizmor:
     name: zizmor
     runs-on: ubuntu-latest
-    # Reads the workflow files and nothing else.
     permissions:
+      # Reads the workflow files.
       contents: read
+      # Uploading SARIF to the Security tab. This is the only write scope in
+      # the workflow. Same shape as the scan job in osv-scanner.yml.
+      security-events: write
+      # codeql-action/upload-sarif reads the workflow run it uploads for.
+      actions: read
     steps:
       # An audit that checks for unpinned actions has to be pinned itself.
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -40,7 +45,31 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       # Pinned exactly. zizmor adds audits between releases, so an unpinned
       # upgrade turns a green gate red on a commit that changed nothing.
-      # The policy and every accepted exception live in .github/zizmor.yml;
-      # the run fails on any finding not recorded there.
-      - name: Audit workflows
+      # The policy and every accepted exception live in .github/zizmor.yml.
+      #
+      # SARIF is written to stdout, so it is redirected to a file. This run
+      # reports and does not gate: zizmor sets a finding-based exit code for
+      # its other output formats but not for SARIF, so it exits zero here
+      # even when it finds something. It still exits non-zero on an internal
+      # error, which is what should stop the job at this point.
+      - name: Audit workflows (SARIF)
+        run: uvx zizmor@1.29.0 --no-progress --format=sarif .github/workflows > zizmor.sarif
+      - name: Upload results to the Security tab
+        if: ${{ !cancelled() && hashFiles('zizmor.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          sarif_file: zizmor.sarif
+          category: zizmor
+      # The gate, and the command this workflow has always run, so the pass
+      # and fail behaviour is unchanged: any finding not recorded in
+      # .github/zizmor.yml fails the job. It runs after the upload so that
+      # the findings reach the Security tab whether or not this step fails.
+      #
+      # Code scanning's convention is that a workflow uploading SARIF fails
+      # only on an internal error and leaves findings to the Security tab.
+      # That convention is deliberately not followed here. .github/zizmor.yml
+      # is an accepted-exception list, so an unrecorded finding means a
+      # workflow changed without being accounted for, and that should block a
+      # merge rather than file a report.
+      - name: Fail on unrecorded findings
         run: uvx zizmor@1.29.0 --no-progress .github/workflows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "autocfg"

--- a/deny.toml
+++ b/deny.toml
@@ -22,6 +22,16 @@
 # with no skip entries. The duplicate versions in the lockfile (thiserror 1.x,
 # windows-sys 0.45) enter through cpal's Android branch, which none of these
 # four targets compiles, so they are absent from everything decibri ships.
+#
+# The restriction narrows `advisories` too, which is less obvious than its
+# effect on `bans`. A crate that reaches Cargo.lock but no shipped target sits
+# outside this graph, so an advisory against it is not reported here at all.
+# anyhow is the case that established this: RUSTSEC-2026-0190 enters the
+# lockfile through the wasip2 and wasip3 chain, and this check stays green on
+# it whatever `unsound` below is set to, while cargo-audit reports it.
+# .github/workflows/osv-scanner.yml covers the difference by reading every
+# lockfile flat, with no target resolution. Narrowing these targets without
+# that scan in place would drop advisory coverage silently.
 targets = [
     "x86_64-pc-windows-msvc",
     "aarch64-apple-darwin",

--- a/package-lock.json
+++ b/package-lock.json
@@ -867,9 +867,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -924,9 +924,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -944,7 +944,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
Two audits now report as code scanning alerts instead of only in a job log: lockfile vulnerabilities, which nothing reported before, and zizmor's workflow findings, which reached the job log alone.

Add OSV-Scanner. It reads all four lockfiles in the repository across three ecosystems, on the same push and pull request triggers as ci.yml, plus a weekly schedule and manual dispatch. The four are Cargo.lock, package-lock.json, npm/decibri/package-lock.json and bindings/python/uv.lock. 

Remove the cargo audit job. It is replaced by OSV rather than by cargo-deny. cargo deny check advisories resolves its graph against the four targets in deny.toml, so a lockfile crate that no shipped target compiles sits outside it, and anyhow is that case. cargo audit reported RUSTSEC-2026-0190 and exited zero, carrying no --deny warnings, so what it contributed was a report and not a gate. OSV reads every lockfile flat and fails on the same advisory, so the removal trades a report for something that gates.

Remove the npm audit step. It ran only in npm/decibri, carried both --omit=dev and || true, and so could not fail. OSV covers that lockfile and the root one on the same trigger.

Update anyhow to 1.0.103 and postcss to 8.5.26 so the new gate is green on arrival. postcss moves within vite's existing ^8.5.17 requirement, so vitest stays at 4.1.4. Neither is reachable from a shipped artifact: anyhow enters through the wasip2 and wasip3 chain, postcss through the test runner.

Upload zizmor's findings as SARIF and keep the job failing on any finding not recorded in .github/zizmor.yml. zizmor sets a finding-based exit code for its other output formats but not for SARIF, so the audit runs twice: one run writes the SARIF that is uploaded, and the gating run is the command the workflow already used. Code scanning's convention is to report without failing, and it is deliberately not followed, because .github/zizmor.yml is an accepted-exception list and an unrecorded finding should block a merge.

Record in deny.toml that restricting targets narrows the advisory graph as well as the ban graph, and that the OSV workflow covers the difference.