### PR TITLE
Done. Both files staged, nothing committed.

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -9,6 +9,12 @@ name: OSV Scanner
 #   npm/decibri/package-lock.json    npm, the addon package's dependencies
 #   bindings/python/uv.lock          PyPI
 #
+# Findings go to the Security tab. This workflow does not fail on them.
+# Advisories are published continuously against dependencies decibri does not
+# control, so a gate here would turn red on the advisory database's schedule
+# rather than on a change made in this repository, and a check that stays red
+# for weeks stops being read.
+#
 # The `deny` job in ci.yml also reads advisories, but only for crates
 # reachable from the four targets in deny.toml, so the two are not
 # interchangeable. deny.toml records that boundary.
@@ -63,12 +69,11 @@ jobs:
       # Recursive from the repository root, so a lockfile added later is
       # scanned without editing this file.
       #
-      # continue-on-error because osv-scanner exits non-zero when it finds
-      # something, and the SARIF still has to reach the Security tab. The last
-      # step turns that outcome back into a job failure. Removing it makes the
-      # upload unreachable on exactly the runs that need it.
+      # osv-scanner exits non-zero when it finds something. continue-on-error
+      # keeps that exit code from failing the job, so a run with findings
+      # still reaches the upload below and still reports green. Removing it
+      # turns every finding into a failed check.
       - name: Scan lockfiles
-        id: scan
         continue-on-error: true
         run: osv-scanner scan source --recursive --format=sarif --output-file=results.sarif ./
       - name: Upload results to the Security tab
@@ -77,9 +82,3 @@ jobs:
         with:
           sarif_file: results.sarif
           category: osv-scanner
-      # Fails on any non-zero exit, a finding or a scanner error alike.
-      - name: Fail on findings
-        if: ${{ steps.scan.outcome == 'failure' }}
-        run: |
-          echo "::error::OSV-Scanner reported known vulnerabilities. See the Security tab."
-          exit 1

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -60,16 +60,16 @@ jobs:
         with:
           sarif_file: zizmor.sarif
           category: zizmor
-      # The gate, and the command this workflow has always run, so the pass
-      # and fail behaviour is unchanged: any finding not recorded in
-      # .github/zizmor.yml fails the job. It runs after the upload so that
-      # the findings reach the Security tab whether or not this step fails.
+      # The gate: any finding not recorded in .github/zizmor.yml fails the job.
       #
-      # Code scanning's convention is that a workflow uploading SARIF fails
-      # only on an internal error and leaves findings to the Security tab.
-      # That convention is deliberately not followed here. .github/zizmor.yml
-      # is an accepted-exception list, so an unrecorded finding means a
-      # workflow changed without being accounted for, and that should block a
-      # merge rather than file a report.
+      # .github/zizmor.yml is an accepted-exception list, so a finding outside
+      # it means a workflow file changed without that change being accounted
+      # for. The only input this audit reads is .github, so nothing outside
+      # this repository can raise a finding here and every one of them points
+      # at the commit that introduced it. Blocking the merge is what that
+      # calls for.
+      #
+      # This step runs after the upload so the findings reach the Security tab
+      # whether or not it fails.
       - name: Fail on unrecorded findings
         run: uvx zizmor@1.29.0 --no-progress .github/workflows


### PR DESCRIPTION
OSV-Scanner findings go to the Security tab. The job no longer fails on them.

Advisories are published against dependencies decibri does not control, so a gate here runs red on the world's schedule rather than on the repository's. A check that stays red stops being read.

- The failure step is removed from `.github/workflows/osv-scanner.yml`, along with the scan step id that only existed to feed it. `continue-on-error` on the scan step is unchanged and is what lets the job pass.
- The SARIF upload is unaffected. Its condition never referenced the scan's status, so findings were already reaching the Security tab.
- Both workflow files now record which behaviour they have and why. `zizmor` continues to fail on a finding, because its config is an accepted exception list and an unrecorded finding means a workflow changed without being accounted for.