### PR TITLE
chore(deps): update js-yaml to 4.3.1

### DIFF
--- a/npm/decibri/package-lock.json
+++ b/npm/decibri/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "decibri",
-  "version": "4.0.0",
+  "version": "5.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "decibri",
-      "version": "4.0.0",
+      "version": "5.4.0",
       "cpu": [
         "x64",
         "arm64"
@@ -24,23 +24,63 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@decibri/decibri-darwin-arm64": "4.0.0",
-        "@decibri/decibri-linux-arm64-gnu": "4.0.0",
-        "@decibri/decibri-linux-x64-gnu": "4.0.0",
-        "@decibri/decibri-win32-x64-msvc": "4.0.0"
+        "@decibri/decibri-darwin-arm64": "5.4.0",
+        "@decibri/decibri-linux-arm64-gnu": "5.4.0",
+        "@decibri/decibri-linux-x64-gnu": "5.4.0",
+        "@decibri/decibri-win32-x64-msvc": "5.4.0"
       }
     },
     "node_modules/@decibri/decibri-darwin-arm64": {
-      "optional": true
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@decibri/decibri-darwin-arm64/-/decibri-darwin-arm64-5.4.0.tgz",
+      "integrity": "sha512-Z8Kz0wh/2xF21tAGV5P3mlZeNbTqnHwE0M1ovBpI/8wLbB4p83yaxA88bKE/7Za4/B9APn9dWREsHgXsDrUeWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
     "node_modules/@decibri/decibri-linux-arm64-gnu": {
-      "optional": true
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@decibri/decibri-linux-arm64-gnu/-/decibri-linux-arm64-gnu-5.4.0.tgz",
+      "integrity": "sha512-xpL2im1SqyJymCsErLwL5k6Z+zFEGowe2zX3MU4vqJ8aVA2xCteLOqwHt0Ny5ayi9lOCUnNt5nPLsYxtpMUkyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@decibri/decibri-linux-x64-gnu": {
-      "optional": true
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@decibri/decibri-linux-x64-gnu/-/decibri-linux-x64-gnu-5.4.0.tgz",
+      "integrity": "sha512-n84Oww9DdrsUM0f4DU0mD2PS0BhaveXssfScPKei2zrjxlvuIX3B43fk2OGLAOM6+NAK/XobBZapoEnpsLax5g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@decibri/decibri-win32-x64-msvc": {
-      "optional": true
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@decibri/decibri-win32-x64-msvc/-/decibri-win32-x64-msvc-5.4.0.tgz",
+      "integrity": "sha512-qKtnsif0xk2EHngzMvIEysKuUS6ToCWA1DKN2RdvgRRHdWbqQzyaJTOFWcvgMsUA8MhozT9MsdXm2o4mED2Q4g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.2",
@@ -1749,9 +1789,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Lockfile only. Resolves GHSA-5p4m-2wfm-xmqj, quadratic CPU consumption in `!!omap` resolution, which had no backport to 4.x below 4.3.1.

Development dependency in `npm/decibri`. No package was added or removed.