### PR TITLE
fix(core)!: name only the floor in the channel-count message

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -17,8 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- **BREAKING: `Speaker` and `AsyncSpeaker` no longer raise `ChannelsOutOfRange` for `channels` above 32.** They accept any count above zero. A count above 32 is offered to the device at `start()`, and a device that cannot serve it raises `SpeakerChannelsUnsupported`, where construction previously raised `ChannelsOutOfRange`. `Speaker(channels=0)` still raises `ChannelsOutOfRange` with an unchanged message. How many channels a device serves depends on the `sample_rate` asked for as well as the count. A count above 16383 raises `StreamOpenFailed` naming that limit.
+- **BREAKING: `Speaker` and `AsyncSpeaker` no longer raise `ChannelsOutOfRange` for `channels` above 32.** They accept any count above zero. A count above 32 is offered to the device at `start()`, and a device that cannot serve it raises `SpeakerChannelsUnsupported`, where construction previously raised `ChannelsOutOfRange`. `Speaker(channels=0)` still raises `ChannelsOutOfRange`. How many channels a device serves depends on the `sample_rate` asked for as well as the count. A count above 16383 raises `StreamOpenFailed` naming that limit.
 - **BREAKING: an output channel count above the device's reported figure now raises `SpeakerChannelsUnsupported` where it raised `StreamOpenFailed`.** `StreamOpenFailed` remains the exception for an output open that failed for any other reason.
+- **BREAKING: `ChannelsOutOfRange` now carries the message `channels must be at least 1`.** It carried `channels must be between 1 and 32`, naming an upper bound that neither `Microphone` nor `Speaker` enforces. Code matching `str(exc)` must match the new text. The exception class and the input that raises it are unchanged: `channels=0` on either.
 
 ## [0.9.0] - 2026-08-04
 

--- a/bindings/python/tests/test_config.py
+++ b/bindings/python/tests/test_config.py
@@ -112,7 +112,7 @@ def test_zero_channels_is_out_of_range() -> None:
     """A zero channel count raises the plain ChannelsOutOfRange at construction."""
     with pytest.raises(ChannelsOutOfRange) as exc_info:
         Microphone(channels=0)
-    assert str(exc_info.value) == "channels must be between 1 and 32"
+    assert str(exc_info.value) == "channels must be at least 1"
 
 
 @pytest.mark.parametrize(
@@ -179,7 +179,7 @@ def test_speaker_zero_channels_is_out_of_range() -> None:
     """A zero channel count raises at Speaker construction, not at start()."""
     with pytest.raises(ChannelsOutOfRange) as exc_info:
         Speaker(channels=0)
-    assert str(exc_info.value) == "channels must be between 1 and 32"
+    assert str(exc_info.value) == "channels must be at least 1"
 
 
 @pytest.mark.parametrize(

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -18,8 +18,9 @@ For other decibri packages, see:
 
 ### Changed
 
-- **BREAKING: `SpeakerConfig::validate` no longer refuses a channel count above 32.** It bounds `channels` below only. A count above 32 is offered to the device when the stream is opened, and a device that cannot serve it reports `SpeakerChannelsUnsupported` rather than `ChannelsOutOfRange`. Code matching `ChannelsOutOfRange` to detect a rejected output channel count must also match `SpeakerChannelsUnsupported`; `channels: 0` still reports `ChannelsOutOfRange` with an unchanged message. How many channels a device serves depends on the sample rate asked for as well as the count.
+- **BREAKING: `SpeakerConfig::validate` no longer refuses a channel count above 32.** It bounds `channels` below only. A count above 32 is offered to the device when the stream is opened, and a device that cannot serve it reports `SpeakerChannelsUnsupported` rather than `ChannelsOutOfRange`. Code matching `ChannelsOutOfRange` to detect a rejected output channel count must also match `SpeakerChannelsUnsupported`; `channels: 0` still reports `ChannelsOutOfRange`. How many channels a device serves depends on the sample rate asked for as well as the count.
 - **BREAKING: an output channel count above the device's reported figure now reports `SpeakerChannelsUnsupported` where it reported `StreamOpenFailed`.** `StreamOpenFailed` remains the report for an output open that failed for any other reason.
+- **BREAKING: `DecibriError::ChannelsOutOfRange` now displays as `channels must be at least 1`.** It displayed `channels must be between 1 and 32`, naming an upper bound that neither `MicrophoneConfig::validate` nor `SpeakerConfig::validate` enforces. Code matching the message text must match the new text. The variant, its `code()` and the input that reports it are unchanged: a channel count of 0 on either surface.
 - A channel count above 16383 is refused before the platform audio library sees it, as `StreamOpenFailed` naming that limit. 16383 is the largest count the Windows audio API can carry for a 32-bit float stream.
 
 ## [6.0.0] - 2026-08-04

--- a/crates/decibri/src/error.rs
+++ b/crates/decibri/src/error.rs
@@ -43,10 +43,11 @@ pub enum DecibriError {
     /// == 0`. Neither surface has an upper bound in its own validation: capture
     /// is mono only and reports [`Self::MultichannelNotSupported`] above one,
     /// and playback leaves the maximum to the device, which answers when the
-    /// stream is opened ([`Self::SpeakerChannelsUnsupported`]). The message is a
-    /// frozen exact-match string that downstream consumers branch on, so its
-    /// text is unchanged.
-    #[error("channels must be between 1 and 32")]
+    /// stream is opened ([`Self::SpeakerChannelsUnsupported`]). The message
+    /// names the floor only, because no upper bound is enforced anywhere. It is
+    /// an exact-match string that downstream consumers branch on, so it is
+    /// frozen at the text below.
+    #[error("channels must be at least 1")]
     ChannelsOutOfRange,
 
     /// A microphone capture configuration requested more than one channel.
@@ -1090,13 +1091,13 @@ mod tests {
     }
 
     /// The `ChannelsOutOfRange` Display message is a frozen exact-match string
-    /// that downstream consumers branch on. Regression: widening the speaker's
-    /// accepted channel count reworded it.
+    /// that downstream consumers branch on, and it names the floor only.
+    /// Regression: a ceiling named in the text that no validation enforces.
     #[test]
     fn channels_out_of_range_message_is_frozen() {
         assert_eq!(
             DecibriError::ChannelsOutOfRange.to_string(),
-            "channels must be between 1 and 32"
+            "channels must be at least 1"
         );
     }
 

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -18,9 +18,10 @@ For other decibri packages, see:
 
 ### Changed
 
-- **BREAKING: `Speaker` no longer throws a `RangeError` for `channels` above 32.** It accepts any count above zero. A count above 32 is offered to the device when playback starts, and a device that cannot serve it throws a `DecibriError` with code `SPEAKER_CHANNELS_UNSUPPORTED` on the `'error'` event (or as a rejection from `writeAsync()`), where it previously threw `RangeError: channels must be between 1 and 32` from the constructor. `new Speaker({ channels: 0 })` still throws that `RangeError`. How many channels a device serves depends on the `sampleRate` asked for as well as the count. A count above 16383 carries `STREAM_OPEN_FAILED` naming that limit.
+- **BREAKING: `Speaker` no longer throws a `RangeError` for `channels` above 32.** It accepts any count above zero. A count above 32 is offered to the device when playback starts, and a device that cannot serve it throws a `DecibriError` with code `SPEAKER_CHANNELS_UNSUPPORTED` on the `'error'` event (or as a rejection from `writeAsync()`), where it previously threw `RangeError: channels must be between 1 and 32` from the constructor. `new Speaker({ channels: 0 })` still throws a `RangeError`. How many channels a device serves depends on the `sampleRate` asked for as well as the count. A count above 16383 carries `STREAM_OPEN_FAILED` naming that limit.
 - **BREAKING: an output channel count above the device's reported figure now carries `SPEAKER_CHANNELS_UNSUPPORTED` where it carried `STREAM_OPEN_FAILED`.** `STREAM_OPEN_FAILED` remains the code for an output open that failed for any other reason.
-- The browser `Speaker` and `Microphone` are unchanged. Both still accept 1 to 32 channels, the range the Web Audio specification requires an implementation to support.
+- **BREAKING: the `RangeError` thrown for a `channels` count below 1 now carries the message `channels must be at least 1`.** It carried `channels must be between 1 and 32`, naming an upper bound that neither `Microphone` nor `Speaker` enforces. Code matching the message text must match the new text. The error class and the input that throws it are unchanged: `channels: 0` on either constructor or `open()`.
+- The browser `Speaker` and `Microphone` are unchanged. Both still accept 1 to 32 channels, the range the Web Audio specification requires an implementation to support, and both keep their own `channels must be between 1 and 32, got <n>` message, which that range does enforce.
 
 ## [5.4.0] - 2026-08-04
 

--- a/npm/decibri/src/decibri-output.js
+++ b/npm/decibri/src/decibri-output.js
@@ -73,7 +73,7 @@ class Speaker extends Writable {
     // 'SPEAKER_CHANNELS_UNSUPPORTED' naming the count the device reports.
     const channels = options.channels ?? 1;
     if (channels < 1) {
-      throw new RangeError('channels must be between 1 and 32');
+      throw new RangeError('channels must be at least 1');
     }
 
     const dtype = options.dtype ?? 'int16';

--- a/npm/decibri/src/decibri.js
+++ b/npm/decibri/src/decibri.js
@@ -151,7 +151,7 @@ class Microphone extends Readable {
     // additive. The `channels` option is kept for that forward compatibility.
     const channels = options.channels ?? 1;
     if (channels < 1) {
-      throw new RangeError('channels must be between 1 and 32');
+      throw new RangeError('channels must be at least 1');
     }
     if (channels > 1) {
       throw new RangeError('multichannel capture is not supported; channels must be 1 (mono)');

--- a/npm/decibri/src/errors.js
+++ b/npm/decibri/src/errors.js
@@ -75,7 +75,7 @@ class OrtPathError extends OrtError {
 // the core ever sees it).
 const RANGE_PREFIXES = [
   'sample rate must be between',
-  'channels must be between',
+  'channels must be at least',
   'multichannel capture is not supported',
   'frames per buffer must be between',
   'agc target level must be between',

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -70,7 +70,7 @@ async function testErrors() {
 
   // channels: mono only. A value below 1 is a plain range error; a value above
   // 1 is rejected as multichannel (not silently downmixed to mono).
-  assertThrows(() => new Microphone({ channels: 0 }), RangeError, 'channels must be between 1 and 32');
+  assertThrows(() => new Microphone({ channels: 0 }), RangeError, 'channels must be at least 1');
   assertThrows(() => new Microphone({ channels: 2 }), RangeError, 'multichannel capture is not supported; channels must be 1 (mono)');
   assertThrows(() => new Microphone({ channels: 33 }), RangeError, 'multichannel capture is not supported; channels must be 1 (mono)');
 

--- a/tests/test-async-open.js
+++ b/tests/test-async-open.js
@@ -127,7 +127,7 @@ async function testDeterministic() {
   await assertRejects(
     () => Speaker.open({ channels: 0 }),
     RangeError,
-    'channels must be between 1 and 32',
+    'channels must be at least 1',
     'Speaker.open bad channels'
   );
 

--- a/tests/test-ci.js
+++ b/tests/test-ci.js
@@ -78,7 +78,7 @@ assertThrows(() => new Microphone({ sampleRate: 384001 }), RangeError, 'sample r
 
 // channels: mono only. A value below 1 is a plain range error; a value above
 // 1 is rejected as multichannel (not silently downmixed to mono).
-assertThrows(() => new Microphone({ channels: 0 }), RangeError, 'channels must be between 1 and 32');
+assertThrows(() => new Microphone({ channels: 0 }), RangeError, 'channels must be at least 1');
 assertThrows(() => new Microphone({ channels: 2 }), RangeError, 'multichannel capture is not supported; channels must be 1 (mono)');
 assertThrows(() => new Microphone({ channels: 33 }), RangeError, 'multichannel capture is not supported; channels must be 1 (mono)');
 
@@ -169,7 +169,7 @@ console.log('--- Group 3: Speaker error messages ---');
 
 assertThrows(() => new Speaker({ sampleRate: 0 }), RangeError, 'sample rate must be between 1000 and 384000');
 assertThrows(() => new Speaker({ sampleRate: 384001 }), RangeError, 'sample rate must be between 1000 and 384000');
-assertThrows(() => new Speaker({ channels: 0 }), RangeError, 'channels must be between 1 and 32');
+assertThrows(() => new Speaker({ channels: 0 }), RangeError, 'channels must be at least 1');
 // Channels is bounded below only. A count above the former cap is no longer
 // refused by the wrapper: it constructs where an output device is present, and
 // fails for a device reason where none is (a CI runner). What it must never be
@@ -1349,7 +1349,7 @@ async function asyncOpenTests() {
   await assertRejects(
     () => Speaker.open({ channels: 0 }),
     RangeError,
-    'channels must be between 1 and 32'
+    'channels must be at least 1'
   );
   // The async factory shares _prepareOptions with the constructor, so it is
   // bounded below only in the same way. Regression: the two validation paths

--- a/tests/test-output.js
+++ b/tests/test-output.js
@@ -81,7 +81,7 @@ async function testErrors() {
 
   // channels: bounded below only. A high count is left for the device to
   // answer when the stream opens (Group 8), not refused here.
-  assertThrows(() => new Speaker({ channels: 0 }), RangeError, 'channels must be between 1 and 32');
+  assertThrows(() => new Speaker({ channels: 0 }), RangeError, 'channels must be at least 1');
 
   // dtype
   assertThrows(() => new Speaker({ dtype: 'wav' }), TypeError, "dtype must be 'int16' or 'float32'");


### PR DESCRIPTION
The ChannelsOutOfRange message read "channels must be between 1 and 32", naming an upper bound that no validation enforces on either surface. It now reads "channels must be at least 1".

- MicrophoneConfig::validate and SpeakerConfig::validate both reach the variant only at a count of zero. Capture reports MultichannelNotSupported above one, and playback leaves the maximum to the device, which answers through SpeakerChannelsUnsupported.
- The variant keeps its name, its code and its place in the catalogue. No validation is added, removed or altered.
- The two Node wrapper pre-check copies are matched to the core text, and the RANGE_PREFIXES classification entry in errors.js moves with it so a native ChannelsOutOfRange still reaches a RangeError.
- The browser Microphone and Speaker keep their own message, which their own 1 to 32 range does enforce.

BREAKING CHANGE: the ChannelsOutOfRange message text changed from "channels must be between 1 and 32" to "channels must be at least 1". Code matching the message string exactly will stop matching. The error class, the exception class, the error code and the input that produces it are all unchanged.