### PR TITLE
refactor(core): derive the detector feed in the core

### DIFF
--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -485,12 +485,10 @@ impl DecibriBridge {
         let running = self.running.clone();
         let format = self.format;
         // After the engine's normalize chain the output is mono, so the block
-        // size and the VAD downmix trigger are counted in OUTPUT channels (read
-        // from the stream), not the device channels. The binding-side downmix
-        // becomes a no-op once the engine has already delivered mono.
+        // size is counted in OUTPUT channels (read from the stream), not the
+        // device channels.
         let output_channels = stream.channels();
         let target_samples = self.frames_per_buffer as usize * output_channels as usize;
-        let channels = output_channels;
         let vad_probability = self.vad_probability.clone();
 
         // Move VAD into the pump thread (SileroVad is Send); it is handed back
@@ -523,28 +521,19 @@ impl DecibriBridge {
                         let frame = chunk.data;
 
                         // Run VAD on the f32 frame (before format conversion).
-                        // Both modes read the signal BEFORE the opt-in
-                        // enhancement step: when the tap is active, drain it;
-                        // otherwise the delivered frame already is that signal.
-                        // Reading the pre-enhancement signal means enabling an
-                        // enhancement step does not change detection, the same
-                        // guarantee for Silero and energy alike. Called once per
-                        // delivered chunk so the tap drains in lockstep. VAD
-                        // models a single channel, so downmix interleaved
-                        // multichannel frames to mono first: feeding interleaved
-                        // samples makes the score read consecutive channels as
-                        // successive mono samples. The interleaved `frame` is
+                        // Both modes read the detector feed the core derives:
+                        // the signal BEFORE the opt-in enhancement step when
+                        // the tap is active, otherwise the delivered frame,
+                        // collapsed to mono by the core when it carries more
+                        // than one channel. Reading the pre-enhancement signal
+                        // means enabling an enhancement step does not change
+                        // detection, the same guarantee for Silero and energy
+                        // alike. Called once per delivered chunk so the tap
+                        // drains in lockstep. The interleaved `frame` is
                         // untouched and is still what gets emitted to JS below.
                         if vad.is_some() || energy_vad {
-                            let pre_enh = pump_stream.vad_input(frame.len());
-                            let vad_frame: &[f32] = pre_enh.as_deref().unwrap_or(&frame);
-                            let downmixed;
-                            let vad_input: &[f32] = if channels > 1 {
-                                downmixed = sample::downmix_to_mono(vad_frame, channels);
-                                &downmixed
-                            } else {
-                                vad_frame
-                            };
+                            let feed = pump_stream.detector_feed(&frame);
+                            let vad_input: &[f32] = feed.as_deref().unwrap_or(&frame);
                             if let Some(ref mut v) = vad {
                                 if let Ok(result) = v.process(vad_input) {
                                     vad_probability

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -57,8 +57,7 @@ use decibri::microphone::{
     AudioChunk, DenoiseModel, HighpassFilter, Microphone, MicrophoneConfig, MicrophoneStream,
 };
 use decibri::sample::{
-    downmix_to_mono, f32_le_bytes_to_f32, f32_to_f32_le_bytes, f32_to_i16_le_bytes,
-    i16_le_bytes_to_f32, rms,
+    f32_le_bytes_to_f32, f32_to_f32_le_bytes, f32_to_i16_le_bytes, i16_le_bytes_to_f32, rms,
 };
 use decibri::speaker::{Speaker, SpeakerConfig, SpeakerStream};
 use decibri::vad::{SileroVad, VadConfig};
@@ -741,29 +740,20 @@ impl MicrophoneBridge {
             return Ok(None);
         };
 
-        // Run VAD on the signal BEFORE the opt-in enhancement step. Only read()
-        // touches `vad`, so this lock never contends with stop(). Drain the
-        // pre-enhancement tap once (when a transform is active); otherwise the
-        // delivered chunk already is that signal. Reading the pre-enhancement
-        // signal means enabling enhancement does not change detection in either
-        // mode. Called once per delivered chunk so the tap drains in lockstep.
+        // Run VAD on the detector feed the core derives: the signal BEFORE the
+        // opt-in enhancement step when the tap is active, otherwise the
+        // delivered chunk, collapsed to mono by the core when it carries more
+        // than one channel. Only read() touches `vad`, so this lock never
+        // contends with stop(). Reading the pre-enhancement signal means
+        // enabling enhancement does not change detection in either mode.
+        // Called once per delivered chunk so the tap drains in lockstep.
         // `chunk.data` stays untouched and is what the caller receives below.
         {
             let mut vad_guard = lock_recover(&self.vad);
             let silero = vad_guard.as_mut();
             if self.energy_vad || silero.is_some() {
-                let pre_enh = stream.vad_input(chunk.data.len());
-                let vad_frame: &[f32] = pre_enh.as_deref().unwrap_or(&chunk.data);
-                // VAD models a single channel. Downmix interleaved multichannel
-                // audio to mono first so consecutive channels are not misread as
-                // successive mono samples.
-                let downmixed;
-                let vad_input: &[f32] = if chunk.channels > 1 {
-                    downmixed = downmix_to_mono(vad_frame, chunk.channels);
-                    &downmixed
-                } else {
-                    vad_frame
-                };
+                let feed = stream.detector_feed(&chunk.data);
+                let vad_input: &[f32] = feed.as_deref().unwrap_or(&chunk.data);
                 if let Some(vad) = silero {
                     let result = py
                         .detach(|| vad.process(vad_input))

--- a/crates/decibri/src/microphone.rs
+++ b/crates/decibri/src/microphone.rs
@@ -494,6 +494,13 @@ pub struct MicrophoneStream {
     // with zero overhead. `Mutex<VecDeque<f32>>` is `Send + Sync`, so the type
     // stays `Send + Sync`.
     vad_tap: Option<Mutex<VecDeque<f32>>>,
+    // The channel count the tap signal is interleaved at: the chain's
+    // post-normalize count, read from the chain at construction, or the
+    // device count when there is no chain (where the tap is never active).
+    // [`detector_feed`](Self::detector_feed) collapses the tap at this count,
+    // which is fixed for the stream's lifetime, so no lock is needed to read
+    // it.
+    tap_channels: u16,
     // Memory bound (in samples) for `vad_tap`, computed from the target rate at
     // construction (see `VAD_TAP_BOUND_SECS`). Oldest tapped samples are dropped
     // beyond this so a consumer that enables an enhancement step but never drains
@@ -932,6 +939,46 @@ impl MicrophoneStream {
         Some(tap.drain(..take).collect())
     }
 
+    /// The detector feed for one delivered chunk: the mono samples a
+    /// voice-activity detector reads.
+    ///
+    /// Binding-internal plumbing: a binding that runs voice-activity detection
+    /// calls this right after a `next_chunk` / `try_next_chunk` delivery,
+    /// passing the delivered chunk, and feeds the returned samples (or, on
+    /// `None`, the delivered chunk itself) to the detector. Not part of the
+    /// stable FFI-consumer surface.
+    ///
+    /// The feed is the pre-transform signal from
+    /// [`vad_input`](Self::vad_input) when the tap is active, and the
+    /// delivered chunk otherwise. Either signal is collapsed to mono when it
+    /// carries more than one channel: each interleaved frame becomes one
+    /// sample, the average of its channels. The tap is collapsed at the
+    /// chain's own post-normalize channel count, the count the tapped samples
+    /// are interleaved at; the delivered chunk is collapsed at the stream's
+    /// delivered count.
+    ///
+    /// # Returns
+    /// - `Some(v)`: `v` is the mono detector feed for this delivery.
+    /// - `None`: `delivered` already is the feed; read it directly, with no
+    ///   allocation or copy.
+    ///
+    /// # Thread safety
+    /// As [`vad_input`](Self::vad_input): takes only the tap mutex, so it
+    /// composes with a concurrent [`next_chunk`](Self::next_chunk).
+    pub fn detector_feed(&self, delivered: &[f32]) -> Option<Vec<f32>> {
+        if let Some(tap) = self.vad_input(delivered.len()) {
+            return Some(if self.tap_channels > 1 {
+                crate::sample::downmix_to_mono(&tap, self.tap_channels)
+            } else {
+                tap
+            });
+        }
+        if self.channels > 1 {
+            return Some(crate::sample::downmix_to_mono(delivered, self.channels));
+        }
+        None
+    }
+
     /// Take the last device/driver error reported while streaming, if any.
     ///
     /// When the cpal error callback fires (device unplug, driver failure) it
@@ -1303,6 +1350,12 @@ impl Microphone {
             Some(stage) if stage.has_transform() => Some(Mutex::new(VecDeque::new())),
             _ => None,
         };
+        // The count the tap signal is interleaved at, read from the chain (see
+        // the field docs). With no chain the tap is never active; the device
+        // count stands in.
+        let tap_channels = capture_stage
+            .as_ref()
+            .map_or(channels, CaptureStage::tap_channels);
         let vad_tap_cap = target_rate as usize * VAD_TAP_BOUND_SECS;
         // The tap memory bound must sit far above the chain's conditioning
         // latency, so an actively draining detector never reaches it even when a
@@ -1331,6 +1384,7 @@ impl Microphone {
             capture_stage: capture_stage.map(Mutex::new),
             chain_flushed: AtomicBool::new(false),
             vad_tap,
+            tap_channels,
             vad_tap_cap,
             #[cfg(feature = "aec")]
             aec_reference,
@@ -1374,6 +1428,13 @@ mod tests {
             Some(stage) if stage.has_transform() => Some(Mutex::new(VecDeque::new())),
             _ => None,
         };
+        // As `Microphone::start`: the tap count comes from the chain, with the
+        // given count standing in when there is no chain. The `channels`
+        // argument stays the stream's own (delivered) count, so a test can set
+        // the two apart on purpose.
+        let tap_channels = capture_stage
+            .as_ref()
+            .map_or(channels, CaptureStage::tap_channels);
         let stream = MicrophoneStream {
             _stream: BackendStream::empty(),
             receiver,
@@ -1385,6 +1446,7 @@ mod tests {
             reblock_buffer: Mutex::new(VecDeque::new()),
             capture_stage: capture_stage.map(Mutex::new),
             vad_tap,
+            tap_channels,
             vad_tap_cap: 16000 * VAD_TAP_BOUND_SECS,
             chain_flushed: AtomicBool::new(false),
             #[cfg(feature = "aec")]
@@ -2166,6 +2228,147 @@ mod tests {
             d_mean.abs() < 1e-3,
             "the delivered output has the DC offset removed (post-transform)"
         );
+    }
+
+    /// A capture stage chain whose normalize segment ends above one channel:
+    /// no downmix (the device count equals the target count) and a DC-removal
+    /// transform, so the tap is active and its resolved count is 2. Built
+    /// through `build_capture_stage` exactly as `Microphone::start` builds it.
+    /// The tests that use it fill the tap directly and never run a block
+    /// through the chain: the in-place transform wrappers assert mono, so no
+    /// multichannel signal can cross the transform segment.
+    fn two_channel_tap_chain() -> CaptureStage {
+        build_capture_stage(
+            2,
+            2,
+            16_000,
+            16_000,
+            Transforms {
+                dc_removal: true,
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .expect("a transform builds a chain")
+    }
+
+    /// `detector_feed` collapses a multichannel tap to mono: each interleaved
+    /// frame becomes the average of its channels, so the feed halves in length
+    /// and a detector reads one channel-averaged signal. Regression: a feed
+    /// handed to a detector interleaved, where the score would read
+    /// consecutive channels as successive mono samples.
+    #[test]
+    fn detector_feed_collapses_a_multichannel_tap() {
+        let (stream, _sender, _running) = test_stream_with(Some(two_channel_tap_chain()), 2);
+
+        let frames = 160;
+        let left: Vec<f32> = (0..frames).map(|i| (i % 8) as f32 * 0.125 - 0.5).collect();
+        let interleaved: Vec<f32> = left.iter().flat_map(|&l| [l, l + 0.5]).collect();
+        let expected: Vec<f32> = left.iter().map(|&l| l + 0.25).collect();
+        stream.push_vad_tap(interleaved.clone());
+
+        // The delivered chunk only sizes the drain here; the tap is what the
+        // feed is derived from.
+        let feed = stream
+            .detector_feed(&interleaved)
+            .expect("a transform keeps the tap active");
+        assert_eq!(
+            feed.len(),
+            frames,
+            "the feed is mono: one sample per interleaved frame"
+        );
+        for (i, (got, want)) in feed.iter().zip(&expected).enumerate() {
+            assert!(
+                (got - want).abs() < 1e-6,
+                "feed sample {i} is the frame's channel average (got {got}, want {want})"
+            );
+        }
+    }
+
+    /// `detector_feed` is the identity on the mono path: with a mono tap the
+    /// feed is the pre-transform signal unchanged in length and value, and
+    /// with no chain it returns `None` so the delivered chunk is read directly
+    /// with no copy. Regression: a collapse that reshapes or rescales a signal
+    /// that is already mono.
+    #[test]
+    fn detector_feed_is_the_identity_on_the_mono_path() {
+        // Mono tap: the feed is the pre-transform (DC-offset-intact) signal.
+        let stage = build_capture_stage(
+            1,
+            1,
+            16_000,
+            16_000,
+            Transforms {
+                dc_removal: true,
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .expect("dc-only chain");
+        let (stream, sender, running) = test_stream_with(Some(stage), 1);
+        let n = 320;
+        sender.send(make_native_chunk(vec![0.5_f32; n])).unwrap();
+        drop(sender);
+        running.store(false, Ordering::Relaxed);
+        let chunk = stream
+            .next_chunk(n, Some(Duration::from_millis(100)))
+            .expect("the chain delivers")
+            .expect("a full block is buffered");
+        let feed = stream
+            .detector_feed(&chunk.data)
+            .expect("a transform keeps the tap active");
+        assert_eq!(feed.len(), n, "a mono feed keeps its length");
+        assert!(
+            feed.iter().all(|&s| (s - 0.5).abs() < 1e-6),
+            "a mono feed is the pre-transform signal unchanged"
+        );
+
+        // No chain: the delivered chunk already is the feed.
+        let (stream, sender, running) = test_stream();
+        sender.send(make_chunk(0.25)).unwrap();
+        drop(sender);
+        running.store(false, Ordering::Relaxed);
+        let chunk = stream
+            .next_chunk(1, Some(Duration::from_millis(100)))
+            .expect("the direct path delivers")
+            .expect("a block is buffered");
+        assert!(
+            stream.detector_feed(&chunk.data).is_none(),
+            "no chain: the delivered chunk already is the feed"
+        );
+    }
+
+    /// `detector_feed` collapses the tap at the CHAIN's post-normalize count,
+    /// not the stream's delivered count: a stream whose stored delivered count
+    /// is set apart from the chain's tap count on purpose still averages each
+    /// tapped frame at the chain's count. Regression: the derivation quietly
+    /// switching to the delivered count, which reads a signal tapped mid-chain
+    /// at the count of a different point in the chain.
+    #[test]
+    fn detector_feed_reads_the_chain_tap_count_not_the_delivered_count() {
+        // The chain taps at 2 channels; the stream's own count is set to 1.
+        let (stream, _sender, _running) = test_stream_with(Some(two_channel_tap_chain()), 1);
+
+        let frames = 160;
+        let left: Vec<f32> = (0..frames).map(|i| (i % 4) as f32 * 0.25 - 0.375).collect();
+        let interleaved: Vec<f32> = left.iter().flat_map(|&l| [l, l + 0.25]).collect();
+        let expected: Vec<f32> = left.iter().map(|&l| l + 0.125).collect();
+        stream.push_vad_tap(interleaved.clone());
+
+        let feed = stream
+            .detector_feed(&interleaved)
+            .expect("a transform keeps the tap active");
+        assert_eq!(
+            feed.len(),
+            frames,
+            "the collapse runs at the chain's tap count, not the stream's count"
+        );
+        for (i, (got, want)) in feed.iter().zip(&expected).enumerate() {
+            assert!(
+                (got - want).abs() < 1e-6,
+                "feed sample {i} is the frame's channel average (got {got}, want {want})"
+            );
+        }
     }
 
     /// The tap stays aligned with the delivered output through the resampler's

--- a/crates/decibri/src/stage.rs
+++ b/crates/decibri/src/stage.rs
@@ -1136,6 +1136,18 @@ impl CaptureStage {
         self.output_channels
     }
 
+    /// The channel count the [`tap`](Self::tap) signal is interleaved at: the
+    /// count the `normalize` segment ends at.
+    ///
+    /// Resolved at construction by walking the `normalize` stages'
+    /// [`Stage::output_channels`] from the device count the chain was built
+    /// with, so it reports what the stages actually do rather than a count
+    /// named alongside them. A consumer reading the tap collapses or
+    /// interprets it at this count.
+    pub(crate) fn tap_channels(&self) -> u16 {
+        self.tap_channels
+    }
+
     /// The summed algorithmic latency, in samples at the output rate, of the
     /// `transform` (conditioning) stages: the amount by which the delivered,
     /// post-conditioning output trails the post-normalize signal the
@@ -1292,7 +1304,7 @@ pub(crate) fn build_capture_stage(
     // only channel count it accepts, and the rate its engine is constructed at.
     // Nothing runs between it and the VAD tap, so the detector reads the
     // echo-removed signal. The order is pinned by this push position and
-    // `build_orders_aec_last_in_normalize`.
+    // `build_ends_normalize_at_the_canceller`.
     #[cfg(feature = "aec")]
     if let Some(settings) = aec {
         normalize.push(Box::new(AecStage::new(settings, target_rate)?));
@@ -3947,6 +3959,44 @@ mod tests {
         assert!(
             removed >= 20.0,
             "a target-rate reference must cancel the resampled echo (removed {removed:.1} dB)"
+        );
+    }
+
+    /// The canceller holds the LAST slot in the normalize segment, after the
+    /// downmix and the resample, so nothing runs between it and the tap and
+    /// the tap carries the echo-removed signal. A full normalize segment pins
+    /// the position through the stage that answers metrics: only the last
+    /// slot's stage is the canceller. Regression: a stage added to the
+    /// segment's tail, which would push the canceller off the end and hand the
+    /// tap a signal the canceller has not seen.
+    #[cfg(feature = "aec")]
+    #[test]
+    fn build_ends_normalize_at_the_canceller() {
+        let queue = Arc::new(AecReferenceRing::new(16_000));
+        let chain = aec_chain(2, 48_000, 16_000, false, &queue, 16_000);
+        assert_eq!(
+            chain.normalize.len(),
+            3,
+            "downmix, resample, canceller: three normalize stages"
+        );
+        assert!(
+            chain
+                .normalize
+                .last()
+                .expect("a non-empty normalize segment")
+                .aec_metrics()
+                .is_some(),
+            "the canceller holds the last normalize slot"
+        );
+        assert!(
+            chain.normalize[..chain.normalize.len() - 1]
+                .iter()
+                .all(|stage| stage.aec_metrics().is_none()),
+            "no stage before the last is the canceller"
+        );
+        assert!(
+            chain.transform.is_empty(),
+            "with conditioning off the chain ends at the normalize segment"
         );
     }
 


### PR DESCRIPTION
- Add MicrophoneStream::detector_feed: the mono detector feed for one delivered chunk, draining the pre-transform tap and collapsing a multichannel signal by frame averaging at the chain's post-normalize channel count.
- Reduce the Node and Python capture paths to reading the derived feed, with the delivered chunk read directly when no feed is returned.
- Expose the chain's post-normalize channel count on CaptureStage and carry it on MicrophoneStream.
- Pin the canceller's place at the end of the normalize segment with build_ends_normalize_at_the_canceller, the test the push-site comment names.
- Pin detector_feed's collapse above one channel, its identity on the mono path, and the channel count it collapses at.