### PR TITLE
fix(core): correct the bundled Silero VAD version label and split the model notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Supports:
 Decibri ships two VAD modes:
 
 - **Energy mode**: lightweight RMS threshold.
-- **Silero mode**: ML-based detection using the Silero VAD v5 ONNX model. More accurate, especially in noisy environments. The model (~2.3 MB) is bundled; no downloads or API keys required.
+- **Silero mode**: ML-based detection using the Silero VAD v6.2 ONNX model. More accurate, especially in noisy environments. The model (~2.3 MB) is bundled; no downloads or API keys required.
 
 ```python
 import decibri

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -15,12 +15,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `SpeakerChannelsUnsupported`, raised when an output device cannot serve the requested `channels`. The message names the count asked for, the count the device reports (the figure `SpeakerInfo.max_output_channels` carries) and the platform's own message.
 - `reference_channels` on the `Aec` dataclass: the channel count of the far-end reference pushed through `push_aec_reference`. Default 1 (mono). With a count above 1 the pushed samples are read as interleaved frames and each frame is averaged to one mono sample before the canceller sees it. The collapse is opt-in: a caller pushing a multichannel reference must declare the count, and an undeclared multichannel push keeps its current behaviour, cancelling nothing and reporting no error. The declared count must match the pushed buffer: a mismatch is not detected and raises no error, and shows up only as `aec_metrics().delay_samples` staying `None` with no fault reported. A count below 1 raises `AecConfigInvalid`; the only ceiling is the field's own 16-bit carrier. A mono reference against playback through more than one loudspeaker has a cancellation ceiling: the canceller models one room response applied to the channel average, so a placement where the per-loudspeaker echo paths differ leaves a residual that adaptation does not remove.
 - The wheel now includes `decibri/_ort/THIRD-PARTY-NOTICES.md`, the third-party license notices for the bundled ONNX Runtime dynamic library it ships alongside and for the third-party material incorporated into it, with a source-availability statement for the MPL-2.0-licensed Eigen code it contains.
+- The wheel and the sdist now include `decibri/models/THIRD-PARTY-NOTICES.md`, carrying the origin, version and license text for the two bundled ONNX models together with the training-data attribution the denoise checkpoint requires. It ships beside the weights it covers. `decibri/models/README.md` alongside it documents each model's tensor interface and points at the notice.
 
 ### Changed
 
 - **BREAKING: `Speaker` and `AsyncSpeaker` no longer raise `ChannelsOutOfRange` for `channels` above 32.** They accept any count above zero. A count above 32 is offered to the device at `start()`, and a device that cannot serve it raises `SpeakerChannelsUnsupported`, where construction previously raised `ChannelsOutOfRange`. `Speaker(channels=0)` still raises `ChannelsOutOfRange`. How many channels a device serves depends on the `sample_rate` asked for as well as the count. A count above 16383 raises `StreamOpenFailed` naming that limit.
 - **BREAKING: an output channel count above the device's reported figure now raises `SpeakerChannelsUnsupported` where it raised `StreamOpenFailed`.** `StreamOpenFailed` remains the exception for an output open that failed for any other reason.
 - **BREAKING: `ChannelsOutOfRange` now carries the message `channels must be at least 1`.** It carried `channels must be between 1 and 32`, naming an upper bound that neither `Microphone` nor `Speaker` enforces. Code matching `str(exc)` must match the new text. The exception class and the input that raises it are unchanged: `channels=0` on either.
+
+### Fixed
+
+- The bundled Silero VAD model is documented as v6.2, the version that ships. The notice beside the model in the wheel named v5. Which model file ships is unchanged.
+- The Silero VAD tensor specification in `decibri/models/README.md` names the tensors the model exposes: `input`, `state` and `sr` in, `output` and `stateN` out. It described a four-input form carrying separate `h` and `c` LSTM tensors.
 
 ## [0.9.0] - 2026-08-04
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -90,7 +90,9 @@ include = [
     { path = "python/decibri/models/fastenhancer_t.onnx", format = ["sdist", "wheel"] },
     # The model notice file (license text plus dataset attribution) ships next
     # to the weights so the required attribution travels with the files it
-    # covers, in both the sdist and the wheel.
+    # covers, in both the sdist and the wheel. README.md alongside it documents
+    # each model's tensor interface.
+    { path = "python/decibri/models/THIRD-PARTY-NOTICES.md", format = ["sdist", "wheel"] },
     { path = "python/decibri/models/README.md", format = ["sdist", "wheel"] },
     # Per-platform ONNX Runtime dynamic library bundled by python-ci.yml's
     # download/extract step before maturin runs. Wheel-only: the dylib is

--- a/bindings/python/python/decibri/models/README.md
+++ b/bindings/python/python/decibri/models/README.md
@@ -1,66 +1,42 @@
 # Models
 
 This directory holds the third-party model files decibri bundles, together with
-the license notices each one requires. These notices ship inside the published
-npm and PyPI packages alongside the model weights, so the attribution travels
-with the files it covers.
+the tensor interface each one exposes. The license notice every model requires
+is in `THIRD-PARTY-NOTICES.md` beside this file, and ships alongside the weights
+it covers inside the published npm and PyPI packages.
 
 ## silero_vad.onnx
 
-- **Name:** Silero VAD v5
-- **License:** MIT
-- **Source:** https://github.com/snakers4/silero-vad
-- **Size:** ~2.2 MB
+- **Model:** Silero VAD v6.2
+- **Source:** https://github.com/snakers4/silero-vad (release `v6.2`)
+- **Size:** ~2.2 MB (2,327,524 bytes)
 - **Purpose:** Voice Activity Detection. Determines whether an audio frame contains human speech
 
 ### Input/Output Specification
 
+Verified from the model file (ONNX IR version 8, opset 16, exported with spox).
+All tensors are fp32 except `sr`, which is i64. The batch, sample-count and
+state dimensions are declared dynamic; the shapes below are what the model takes
+and produces at batch 1.
+
 **Inputs:**
-- `input`: f32[batch, window_size]: audio samples (512 at 16kHz, 256 at 8kHz)
-- `sr`: i64[batch]: sample rate
-- `h`: f32[2, batch, 64]: LSTM hidden state
-- `c`: f32[2, batch, 64]: LSTM cell state
+- `input`: f32[batch, context_size + window_size]: audio samples. Each call is fed the previous window's last `context_size` samples followed by the current window (64 + 512 = 576 at 16 kHz, 32 + 256 = 288 at 8 kHz), where `context_size` is `window_size / 8`.
+- `state`: f32[2, batch, 128]: combined LSTM hidden and cell state
+- `sr`: i64 scalar: sample rate
 
 **Outputs:**
 - `output`: f32[batch, 1]: speech probability (0.0 to 1.0)
-- `hn`: f32[2, batch, 64]: updated hidden state
-- `cn`: f32[2, batch, 64]: updated cell state
+- `stateN`: f32[2, batch, 128]: updated state
 
-Note: Exact tensor names may differ. Verified at build time from the model file.
-
-### License Notice
-
-This model is a third-party artifact, not proprietary to decibri. It is
-distributed under the MIT License, reproduced in full below.
-
-```text
-MIT License
-
-Copyright (c) 2020-present Silero Team
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
+Streaming contract: the model carries no state of its own between calls. Initialize
+`state` to zeros and the audio context to zeros at the start of a stream, feed each
+call's `stateN` back as the next call's `state`, and carry the last `context_size`
+samples of each window forward as the next call's context. Feeding a bare window
+with no context prepended scores even loud speech at the non-speech floor.
 
 ## fastenhancer_t.onnx
 
-- **Name:** FastEnhancer-T (tiny tier), VoiceBank-DEMAND checkpoint, waveform variant
-- **License:** MIT
+- **Model:** FastEnhancer-T (tiny tier), VoiceBank-DEMAND checkpoint, waveform variant
 - **Source:** https://github.com/aask1357/fastenhancer (release `onnx-vd-v1.0.0`)
 - **Size:** ~122 KB (125,036 bytes)
 - **Purpose:** Single-channel speech enhancement (denoise). Maps a window of noisy speech samples to a hop of cleaned speech samples, frame by frame, for streaming use.
@@ -89,61 +65,3 @@ receives audio samples with no spectral processing of its own. The three cache
 tensors hold the model's overlap-add and recurrent state. Initialize them to
 zeros at the start of a stream and feed each call's `cache_out` values back as
 the next call's `cache_in` values.
-
-### License Notice
-
-This model is a third-party artifact, not proprietary to decibri. The model
-code and weights are distributed under the MIT License, reproduced in full
-below.
-
-```text
-MIT License
-
-Copyright (c) 2025 AHN Sung Hwan
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
-
-### Training-Data Attribution
-
-The bundled checkpoint is trained on the VoiceBank-DEMAND noisy speech dataset,
-which pairs clean speech from the CSTR VCTK Corpus with noise from the DEMAND
-database. Each source dataset requires attribution:
-
-- **VoiceBank-DEMAND.** Valentini-Botinhao, Cassia. (2017). Noisy speech
-  database for training speech enhancement algorithms and TTS models, 2016
-  [sound]. University of Edinburgh, School of Informatics, Centre for Speech
-  Technology Research (CSTR). Licensed under Creative Commons Attribution 4.0
-  International (CC BY 4.0), https://creativecommons.org/licenses/by/4.0/.
-  https://doi.org/10.7488/ds/2117
-
-- **CSTR VCTK Corpus (version 0.92).** Yamagishi, Junichi; Veaux, Christophe;
-  MacDonald, Kirsten. (2019). CSTR VCTK Corpus: English Multi-speaker Corpus
-  for CSTR Voice Cloning Toolkit (version 0.92) [sound]. University of
-  Edinburgh, Centre for Speech Technology Research (CSTR). Licensed under the
-  Open Data Commons Attribution License (ODC-By) v1.0,
-  https://opendatacommons.org/licenses/by/1-0/.
-  https://doi.org/10.7488/ds/2645
-
-- **DEMAND.** Thiemann, Joachim; Ito, Nobutaka; Vincent, Emmanuel. (2013).
-  DEMAND: a collection of multi-channel recordings of acoustic noise in
-  diverse environments. Licensed under Creative Commons
-  Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0),
-  https://creativecommons.org/licenses/by-sa/3.0/.
-  https://doi.org/10.5281/zenodo.1227121

--- a/bindings/python/python/decibri/models/THIRD-PARTY-NOTICES.md
+++ b/bindings/python/python/decibri/models/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,110 @@
+# Third-Party Notices
+
+This directory redistributes the model files listed below, together with the
+license notices they require. The notices ship inside the published npm and
+PyPI packages alongside the model weights they cover, so the attribution
+travels with the files. `README.md` beside this file documents each model's
+tensor interface.
+
+## Silero VAD
+
+- **Name:** Silero VAD
+- **Version:** v6.2
+- **License:** MIT
+- **Source:** https://github.com/snakers4/silero-vad (release `v6.2`)
+- **Files covered:** `silero_vad.onnx`
+
+### License Notice
+
+This model is a third-party artifact, not proprietary to decibri. It is
+distributed under the MIT License, reproduced in full below.
+
+```text
+MIT License
+
+Copyright (c) 2020-present Silero Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## FastEnhancer
+
+- **Name:** FastEnhancer-T (tiny tier), VoiceBank-DEMAND checkpoint, waveform variant
+- **Version:** `onnx-vd-v1.0.0`
+- **License:** MIT
+- **Source:** https://github.com/aask1357/fastenhancer (release `onnx-vd-v1.0.0`)
+- **Files covered:** `fastenhancer_t.onnx`
+
+### License Notice
+
+This model is a third-party artifact, not proprietary to decibri. The model
+code and weights are distributed under the MIT License, reproduced in full
+below.
+
+```text
+MIT License
+
+Copyright (c) 2025 AHN Sung Hwan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+### Training-Data Attribution
+
+The bundled checkpoint is trained on the VoiceBank-DEMAND noisy speech dataset,
+which pairs clean speech from the CSTR VCTK Corpus with noise from the DEMAND
+database. Each source dataset requires attribution:
+
+- **VoiceBank-DEMAND.** Valentini-Botinhao, Cassia. (2017). Noisy speech
+  database for training speech enhancement algorithms and TTS models, 2016
+  [sound]. University of Edinburgh, School of Informatics, Centre for Speech
+  Technology Research (CSTR). Licensed under Creative Commons Attribution 4.0
+  International (CC BY 4.0), https://creativecommons.org/licenses/by/4.0/.
+  https://doi.org/10.7488/ds/2117
+
+- **CSTR VCTK Corpus (version 0.92).** Yamagishi, Junichi; Veaux, Christophe;
+  MacDonald, Kirsten. (2019). CSTR VCTK Corpus: English Multi-speaker Corpus
+  for CSTR Voice Cloning Toolkit (version 0.92) [sound]. University of
+  Edinburgh, Centre for Speech Technology Research (CSTR). Licensed under the
+  Open Data Commons Attribution License (ODC-By) v1.0,
+  https://opendatacommons.org/licenses/by/1-0/.
+  https://doi.org/10.7488/ds/2645
+
+- **DEMAND.** Thiemann, Joachim; Ito, Nobutaka; Vincent, Emmanuel. (2013).
+  DEMAND: a collection of multi-channel recordings of acoustic noise in
+  diverse environments. Licensed under Creative Commons
+  Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0),
+  https://creativecommons.org/licenses/by-sa/3.0/.
+  https://doi.org/10.5281/zenodo.1227121

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -23,6 +23,10 @@ For other decibri packages, see:
 - **BREAKING: `DecibriError::ChannelsOutOfRange` now displays as `channels must be at least 1`.** It displayed `channels must be between 1 and 32`, naming an upper bound that neither `MicrophoneConfig::validate` nor `SpeakerConfig::validate` enforces. Code matching the message text must match the new text. The variant, its `code()` and the input that reports it are unchanged: a channel count of 0 on either surface.
 - A channel count above 16383 is refused before the platform audio library sees it, as `StreamOpenFailed` naming that limit. 16383 is the largest count the Windows audio API can carry for a 32-bit float stream.
 
+### Fixed
+
+- The `vad` module and `SileroVad` documentation name Silero VAD v6.2. They named v5. The inference path, the tensor names it binds and the VAD outputs it produces are unchanged.
+
 ## [6.0.0] - 2026-08-04
 
 ### Added

--- a/crates/decibri/src/vad.rs
+++ b/crates/decibri/src/vad.rs
@@ -1,4 +1,4 @@
-//! Voice Activity Detection using the Silero VAD v5 ONNX model.
+//! Voice Activity Detection using the Silero VAD v6.2 ONNX model.
 //!
 //! Silero VAD is a pre-trained ML model that detects human speech in audio.
 //! It runs inference on 512-sample windows (at 16kHz) and returns a speech
@@ -111,7 +111,7 @@ pub struct VadResult {
     pub is_speech: bool,
 }
 
-/// Silero VAD v5 inference engine.
+/// Silero VAD v6.2 inference engine.
 ///
 /// Stateful: maintains LSTM hidden/cell state across calls.
 /// Call `process()` with each audio chunk. Call `reset()` to clear state.
@@ -128,7 +128,7 @@ pub struct SileroVad {
     accumulator: Vec<f32>,
     /// 512 for 16kHz, 256 for 8kHz.
     window_size: usize,
-    /// Silero v5 audio context: the last `context_size` samples of the previous
+    /// Silero v6.2 audio context: the last `context_size` samples of the previous
     /// window, prepended to each window before inference (zeros at start and
     /// after `reset`). The model is fed `context ++ window`, so the input is
     /// `context_size + window_size` samples (576 at 16 kHz). This is separate
@@ -166,7 +166,7 @@ impl SileroVad {
             .with_intra_threads(1)
             .build()?;
 
-        // Silero v5 context size is window_size / 8 (64 at 16 kHz, 32 at 8 kHz).
+        // Silero v6.2 context size is window_size / 8 (64 at 16 kHz, 32 at 8 kHz).
         let context_size = window_size / 8;
 
         Ok(Self {
@@ -238,7 +238,7 @@ impl SileroVad {
     /// `ort::Session` directly. The trait owns the marshaling between
     /// borrowed input slices and the backend's native tensor types.
     fn infer_window(&mut self, window: &[f32]) -> Result<f32, DecibriError> {
-        // Silero v5 requires a `context_size`-sample audio context prepended to
+        // Silero v6.2 requires a `context_size`-sample audio context prepended to
         // each window: the model is fed `context ++ window` (576 samples at
         // 16 kHz). The context is the last `context_size` samples of the
         // previous window (zeros initially / after reset). Feeding only the bare
@@ -333,7 +333,7 @@ impl SileroVad {
         }
 
         // Carry the last context_size samples of this window forward as the
-        // context for the next window (matches Silero v5's `OnnxWrapper`).
+        // context for the next window (matches Silero v6.2's `OnnxWrapper`).
         self.context
             .copy_from_slice(&window[self.window_size - self.context_size..]);
 
@@ -583,7 +583,7 @@ mod tests {
     //
     // The fixture (see `golden_fixture`) alternates silent windows with windows
     // of formant-synthesized voiced audio (a diphthong with breath noise). With
-    // the correct Silero v5 invocation the voiced bursts cross the 0.5 speech
+    // the correct Silero v6.2 invocation the voiced bursts cross the 0.5 speech
     // threshold (peaks around 0.9) while the silent windows stay low (about
     // 0.002 to 0.06), so the trajectory spans both regimes and the two bursts
     // exercise the LSTM and the audio-context carry across silence-to-onset
@@ -591,7 +591,7 @@ mod tests {
     //
     // These EXPECTED_GOLDEN values were regenerated when the Silero context bug
     // was fixed. Earlier the inference path fed only the bare 512-sample window,
-    // omitting the 64-sample audio context Silero v5 requires, so every window
+    // omitting the 64-sample audio context Silero v6.2 requires, so every window
     // (even loud speech) scored at the non-speech floor (~0.0005) and nothing
     // crossed 0.5. The values now reflect the corrected `context ++ window`
     // invocation, where `infer_window` prepends the previous window's last 64

--- a/models/README.md
+++ b/models/README.md
@@ -1,66 +1,42 @@
 # Models
 
 This directory holds the third-party model files decibri bundles, together with
-the license notices each one requires. These notices ship inside the published
-npm and PyPI packages alongside the model weights, so the attribution travels
-with the files it covers.
+the tensor interface each one exposes. The license notice every model requires
+is in `THIRD-PARTY-NOTICES.md` beside this file, and ships alongside the weights
+it covers inside the published npm and PyPI packages.
 
 ## silero_vad.onnx
 
-- **Name:** Silero VAD v5
-- **License:** MIT
-- **Source:** https://github.com/snakers4/silero-vad
-- **Size:** ~2.2 MB
+- **Model:** Silero VAD v6.2
+- **Source:** https://github.com/snakers4/silero-vad (release `v6.2`)
+- **Size:** ~2.2 MB (2,327,524 bytes)
 - **Purpose:** Voice Activity Detection. Determines whether an audio frame contains human speech
 
 ### Input/Output Specification
 
+Verified from the model file (ONNX IR version 8, opset 16, exported with spox).
+All tensors are fp32 except `sr`, which is i64. The batch, sample-count and
+state dimensions are declared dynamic; the shapes below are what the model takes
+and produces at batch 1.
+
 **Inputs:**
-- `input`: f32[batch, window_size]: audio samples (512 at 16kHz, 256 at 8kHz)
-- `sr`: i64[batch]: sample rate
-- `h`: f32[2, batch, 64]: LSTM hidden state
-- `c`: f32[2, batch, 64]: LSTM cell state
+- `input`: f32[batch, context_size + window_size]: audio samples. Each call is fed the previous window's last `context_size` samples followed by the current window (64 + 512 = 576 at 16 kHz, 32 + 256 = 288 at 8 kHz), where `context_size` is `window_size / 8`.
+- `state`: f32[2, batch, 128]: combined LSTM hidden and cell state
+- `sr`: i64 scalar: sample rate
 
 **Outputs:**
 - `output`: f32[batch, 1]: speech probability (0.0 to 1.0)
-- `hn`: f32[2, batch, 64]: updated hidden state
-- `cn`: f32[2, batch, 64]: updated cell state
+- `stateN`: f32[2, batch, 128]: updated state
 
-Note: Exact tensor names may differ. Verified at build time from the model file.
-
-### License Notice
-
-This model is a third-party artifact, not proprietary to decibri. It is
-distributed under the MIT License, reproduced in full below.
-
-```text
-MIT License
-
-Copyright (c) 2020-present Silero Team
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
+Streaming contract: the model carries no state of its own between calls. Initialize
+`state` to zeros and the audio context to zeros at the start of a stream, feed each
+call's `stateN` back as the next call's `state`, and carry the last `context_size`
+samples of each window forward as the next call's context. Feeding a bare window
+with no context prepended scores even loud speech at the non-speech floor.
 
 ## fastenhancer_t.onnx
 
-- **Name:** FastEnhancer-T (tiny tier), VoiceBank-DEMAND checkpoint, waveform variant
-- **License:** MIT
+- **Model:** FastEnhancer-T (tiny tier), VoiceBank-DEMAND checkpoint, waveform variant
 - **Source:** https://github.com/aask1357/fastenhancer (release `onnx-vd-v1.0.0`)
 - **Size:** ~122 KB (125,036 bytes)
 - **Purpose:** Single-channel speech enhancement (denoise). Maps a window of noisy speech samples to a hop of cleaned speech samples, frame by frame, for streaming use.
@@ -89,61 +65,3 @@ receives audio samples with no spectral processing of its own. The three cache
 tensors hold the model's overlap-add and recurrent state. Initialize them to
 zeros at the start of a stream and feed each call's `cache_out` values back as
 the next call's `cache_in` values.
-
-### License Notice
-
-This model is a third-party artifact, not proprietary to decibri. The model
-code and weights are distributed under the MIT License, reproduced in full
-below.
-
-```text
-MIT License
-
-Copyright (c) 2025 AHN Sung Hwan
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
-
-### Training-Data Attribution
-
-The bundled checkpoint is trained on the VoiceBank-DEMAND noisy speech dataset,
-which pairs clean speech from the CSTR VCTK Corpus with noise from the DEMAND
-database. Each source dataset requires attribution:
-
-- **VoiceBank-DEMAND.** Valentini-Botinhao, Cassia. (2017). Noisy speech
-  database for training speech enhancement algorithms and TTS models, 2016
-  [sound]. University of Edinburgh, School of Informatics, Centre for Speech
-  Technology Research (CSTR). Licensed under Creative Commons Attribution 4.0
-  International (CC BY 4.0), https://creativecommons.org/licenses/by/4.0/.
-  https://doi.org/10.7488/ds/2117
-
-- **CSTR VCTK Corpus (version 0.92).** Yamagishi, Junichi; Veaux, Christophe;
-  MacDonald, Kirsten. (2019). CSTR VCTK Corpus: English Multi-speaker Corpus
-  for CSTR Voice Cloning Toolkit (version 0.92) [sound]. University of
-  Edinburgh, Centre for Speech Technology Research (CSTR). Licensed under the
-  Open Data Commons Attribution License (ODC-By) v1.0,
-  https://opendatacommons.org/licenses/by/1-0/.
-  https://doi.org/10.7488/ds/2645
-
-- **DEMAND.** Thiemann, Joachim; Ito, Nobutaka; Vincent, Emmanuel. (2013).
-  DEMAND: a collection of multi-channel recordings of acoustic noise in
-  diverse environments. Licensed under Creative Commons
-  Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0),
-  https://creativecommons.org/licenses/by-sa/3.0/.
-  https://doi.org/10.5281/zenodo.1227121

--- a/models/THIRD-PARTY-NOTICES.md
+++ b/models/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,110 @@
+# Third-Party Notices
+
+This directory redistributes the model files listed below, together with the
+license notices they require. The notices ship inside the published npm and
+PyPI packages alongside the model weights they cover, so the attribution
+travels with the files. `README.md` beside this file documents each model's
+tensor interface.
+
+## Silero VAD
+
+- **Name:** Silero VAD
+- **Version:** v6.2
+- **License:** MIT
+- **Source:** https://github.com/snakers4/silero-vad (release `v6.2`)
+- **Files covered:** `silero_vad.onnx`
+
+### License Notice
+
+This model is a third-party artifact, not proprietary to decibri. It is
+distributed under the MIT License, reproduced in full below.
+
+```text
+MIT License
+
+Copyright (c) 2020-present Silero Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## FastEnhancer
+
+- **Name:** FastEnhancer-T (tiny tier), VoiceBank-DEMAND checkpoint, waveform variant
+- **Version:** `onnx-vd-v1.0.0`
+- **License:** MIT
+- **Source:** https://github.com/aask1357/fastenhancer (release `onnx-vd-v1.0.0`)
+- **Files covered:** `fastenhancer_t.onnx`
+
+### License Notice
+
+This model is a third-party artifact, not proprietary to decibri. The model
+code and weights are distributed under the MIT License, reproduced in full
+below.
+
+```text
+MIT License
+
+Copyright (c) 2025 AHN Sung Hwan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+### Training-Data Attribution
+
+The bundled checkpoint is trained on the VoiceBank-DEMAND noisy speech dataset,
+which pairs clean speech from the CSTR VCTK Corpus with noise from the DEMAND
+database. Each source dataset requires attribution:
+
+- **VoiceBank-DEMAND.** Valentini-Botinhao, Cassia. (2017). Noisy speech
+  database for training speech enhancement algorithms and TTS models, 2016
+  [sound]. University of Edinburgh, School of Informatics, Centre for Speech
+  Technology Research (CSTR). Licensed under Creative Commons Attribution 4.0
+  International (CC BY 4.0), https://creativecommons.org/licenses/by/4.0/.
+  https://doi.org/10.7488/ds/2117
+
+- **CSTR VCTK Corpus (version 0.92).** Yamagishi, Junichi; Veaux, Christophe;
+  MacDonald, Kirsten. (2019). CSTR VCTK Corpus: English Multi-speaker Corpus
+  for CSTR Voice Cloning Toolkit (version 0.92) [sound]. University of
+  Edinburgh, Centre for Speech Technology Research (CSTR). Licensed under the
+  Open Data Commons Attribution License (ODC-By) v1.0,
+  https://opendatacommons.org/licenses/by/1-0/.
+  https://doi.org/10.7488/ds/2645
+
+- **DEMAND.** Thiemann, Joachim; Ito, Nobutaka; Vincent, Emmanuel. (2013).
+  DEMAND: a collection of multi-channel recordings of acoustic noise in
+  diverse environments. Licensed under Creative Commons
+  Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0),
+  https://creativecommons.org/licenses/by-sa/3.0/.
+  https://doi.org/10.5281/zenodo.1227121

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -16,6 +16,7 @@ For other decibri packages, see:
 - Error code `SPEAKER_CHANNELS_UNSUPPORTED` on `DecibriError`, for an output device that cannot serve the requested `channels`. The message names the count asked for, the count the device reports (the figure `SpeakerInfo.maxOutputChannels` carries) and the platform's own message.
 - `referenceChannels` on the `aec` option object: the channel count of the far-end reference pushed through `pushAecReference`. Default 1 (mono). With a count above 1 the pushed samples are read as interleaved frames and each frame is averaged to one mono sample before the canceller sees it. The collapse is opt-in: a caller pushing a multichannel reference must declare the count, and an undeclared multichannel push keeps its current behaviour, cancelling nothing and reporting no error. The declared count must match the pushed buffer: a mismatch is not detected and raises no error, and shows up only as `aecMetrics().delaySamples` staying `null` with no fault reported. A count below 1 throws a `RangeError`; the only ceiling is the option's own 16-bit carrier. A mono reference against playback through more than one loudspeaker has a cancellation ceiling: the canceller models one room response applied to the channel average, so a placement where the per-loudspeaker echo paths differ leaves a residual that adaptation does not remove.
 - Each of the four platform packages (`@decibri/decibri-win32-x64-msvc`, `@decibri/decibri-darwin-arm64`, `@decibri/decibri-linux-x64-gnu`, `@decibri/decibri-linux-arm64-gnu`) now includes `THIRD-PARTY-NOTICES.md`, the third-party license notices for the ONNX Runtime dynamic libraries the package carries and for the third-party material incorporated into them, with a source-availability statement for the MPL-2.0-licensed Eigen code they contain.
+- `models/THIRD-PARTY-NOTICES.md`, carrying the origin, version and license text for the two bundled ONNX models together with the training-data attribution the denoise checkpoint requires. It ships beside the weights it covers. `models/README.md` alongside it documents each model's tensor interface and points at the notice.
 
 ### Changed
 
@@ -24,6 +25,11 @@ For other decibri packages, see:
 - **BREAKING: the `RangeError` thrown for a `channels` count below 1 now carries the message `channels must be at least 1`.** It carried `channels must be between 1 and 32`, naming an upper bound that neither `Microphone` nor `Speaker` enforces. Code matching the message text must match the new text. The error class and the input that throws it are unchanged: `channels: 0` on either constructor or `open()`.
 - **BREAKING: the browser `Microphone` rejects a `channels` count above 1.** It accepted 1 to 32 and delivered the first channel only. A count above 1 now throws `RangeError: multichannel capture is not supported; channels must be 1 (mono)`, and a count below 1 throws `RangeError: channels must be at least 1` where it threw a `TypeError`. Both class and message are the Node entry's for the same values, so the two entries reject the same input the same way. `channels: 1` is unchanged.
 - The browser `Speaker` is unchanged. It still accepts 1 to 32 channels, the range the Web Audio specification requires an implementation to support, and keeps its own `channels must be between 1 and 32, got <n>` message, which that range does enforce.
+
+### Fixed
+
+- The bundled Silero VAD model is documented as v6.2, the version that ships. The `model` field on `VadOptions`, the `vad` option on `MicrophoneOptions`, the README and the notice beside the model named v5. Which model file ships is unchanged.
+- The Silero VAD tensor specification in `models/README.md` names the tensors the model exposes: `input`, `state` and `sr` in, `output` and `stateN` out. It described a four-input form carrying separate `h` and `c` LSTM tensors.
 
 ## [5.4.0] - 2026-08-04
 

--- a/npm/decibri/README.md
+++ b/npm/decibri/README.md
@@ -293,7 +293,7 @@ mic.on('silence', () => console.log('silent'));
 
 ### Silero mode
 
-ML-based detection using the Silero VAD v5 model. More accurate than energy mode, especially in noisy environments.
+ML-based detection using the Silero VAD v6.2 model. More accurate than energy mode, especially in noisy environments.
 
 ```javascript
 const mic = new Microphone({ vad: { model: 'silero', threshold: 0.5 } });

--- a/npm/decibri/models/README.md
+++ b/npm/decibri/models/README.md
@@ -1,66 +1,42 @@
 # Models
 
 This directory holds the third-party model files decibri bundles, together with
-the license notices each one requires. These notices ship inside the published
-npm and PyPI packages alongside the model weights, so the attribution travels
-with the files it covers.
+the tensor interface each one exposes. The license notice every model requires
+is in `THIRD-PARTY-NOTICES.md` beside this file, and ships alongside the weights
+it covers inside the published npm and PyPI packages.
 
 ## silero_vad.onnx
 
-- **Name:** Silero VAD v5
-- **License:** MIT
-- **Source:** https://github.com/snakers4/silero-vad
-- **Size:** ~2.2 MB
+- **Model:** Silero VAD v6.2
+- **Source:** https://github.com/snakers4/silero-vad (release `v6.2`)
+- **Size:** ~2.2 MB (2,327,524 bytes)
 - **Purpose:** Voice Activity Detection. Determines whether an audio frame contains human speech
 
 ### Input/Output Specification
 
+Verified from the model file (ONNX IR version 8, opset 16, exported with spox).
+All tensors are fp32 except `sr`, which is i64. The batch, sample-count and
+state dimensions are declared dynamic; the shapes below are what the model takes
+and produces at batch 1.
+
 **Inputs:**
-- `input`: f32[batch, window_size]: audio samples (512 at 16kHz, 256 at 8kHz)
-- `sr`: i64[batch]: sample rate
-- `h`: f32[2, batch, 64]: LSTM hidden state
-- `c`: f32[2, batch, 64]: LSTM cell state
+- `input`: f32[batch, context_size + window_size]: audio samples. Each call is fed the previous window's last `context_size` samples followed by the current window (64 + 512 = 576 at 16 kHz, 32 + 256 = 288 at 8 kHz), where `context_size` is `window_size / 8`.
+- `state`: f32[2, batch, 128]: combined LSTM hidden and cell state
+- `sr`: i64 scalar: sample rate
 
 **Outputs:**
 - `output`: f32[batch, 1]: speech probability (0.0 to 1.0)
-- `hn`: f32[2, batch, 64]: updated hidden state
-- `cn`: f32[2, batch, 64]: updated cell state
+- `stateN`: f32[2, batch, 128]: updated state
 
-Note: Exact tensor names may differ. Verified at build time from the model file.
-
-### License Notice
-
-This model is a third-party artifact, not proprietary to decibri. It is
-distributed under the MIT License, reproduced in full below.
-
-```text
-MIT License
-
-Copyright (c) 2020-present Silero Team
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
+Streaming contract: the model carries no state of its own between calls. Initialize
+`state` to zeros and the audio context to zeros at the start of a stream, feed each
+call's `stateN` back as the next call's `state`, and carry the last `context_size`
+samples of each window forward as the next call's context. Feeding a bare window
+with no context prepended scores even loud speech at the non-speech floor.
 
 ## fastenhancer_t.onnx
 
-- **Name:** FastEnhancer-T (tiny tier), VoiceBank-DEMAND checkpoint, waveform variant
-- **License:** MIT
+- **Model:** FastEnhancer-T (tiny tier), VoiceBank-DEMAND checkpoint, waveform variant
 - **Source:** https://github.com/aask1357/fastenhancer (release `onnx-vd-v1.0.0`)
 - **Size:** ~122 KB (125,036 bytes)
 - **Purpose:** Single-channel speech enhancement (denoise). Maps a window of noisy speech samples to a hop of cleaned speech samples, frame by frame, for streaming use.
@@ -89,61 +65,3 @@ receives audio samples with no spectral processing of its own. The three cache
 tensors hold the model's overlap-add and recurrent state. Initialize them to
 zeros at the start of a stream and feed each call's `cache_out` values back as
 the next call's `cache_in` values.
-
-### License Notice
-
-This model is a third-party artifact, not proprietary to decibri. The model
-code and weights are distributed under the MIT License, reproduced in full
-below.
-
-```text
-MIT License
-
-Copyright (c) 2025 AHN Sung Hwan
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
-
-### Training-Data Attribution
-
-The bundled checkpoint is trained on the VoiceBank-DEMAND noisy speech dataset,
-which pairs clean speech from the CSTR VCTK Corpus with noise from the DEMAND
-database. Each source dataset requires attribution:
-
-- **VoiceBank-DEMAND.** Valentini-Botinhao, Cassia. (2017). Noisy speech
-  database for training speech enhancement algorithms and TTS models, 2016
-  [sound]. University of Edinburgh, School of Informatics, Centre for Speech
-  Technology Research (CSTR). Licensed under Creative Commons Attribution 4.0
-  International (CC BY 4.0), https://creativecommons.org/licenses/by/4.0/.
-  https://doi.org/10.7488/ds/2117
-
-- **CSTR VCTK Corpus (version 0.92).** Yamagishi, Junichi; Veaux, Christophe;
-  MacDonald, Kirsten. (2019). CSTR VCTK Corpus: English Multi-speaker Corpus
-  for CSTR Voice Cloning Toolkit (version 0.92) [sound]. University of
-  Edinburgh, Centre for Speech Technology Research (CSTR). Licensed under the
-  Open Data Commons Attribution License (ODC-By) v1.0,
-  https://opendatacommons.org/licenses/by/1-0/.
-  https://doi.org/10.7488/ds/2645
-
-- **DEMAND.** Thiemann, Joachim; Ito, Nobutaka; Vincent, Emmanuel. (2013).
-  DEMAND: a collection of multi-channel recordings of acoustic noise in
-  diverse environments. Licensed under Creative Commons
-  Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0),
-  https://creativecommons.org/licenses/by-sa/3.0/.
-  https://doi.org/10.5281/zenodo.1227121

--- a/npm/decibri/models/THIRD-PARTY-NOTICES.md
+++ b/npm/decibri/models/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,110 @@
+# Third-Party Notices
+
+This directory redistributes the model files listed below, together with the
+license notices they require. The notices ship inside the published npm and
+PyPI packages alongside the model weights they cover, so the attribution
+travels with the files. `README.md` beside this file documents each model's
+tensor interface.
+
+## Silero VAD
+
+- **Name:** Silero VAD
+- **Version:** v6.2
+- **License:** MIT
+- **Source:** https://github.com/snakers4/silero-vad (release `v6.2`)
+- **Files covered:** `silero_vad.onnx`
+
+### License Notice
+
+This model is a third-party artifact, not proprietary to decibri. It is
+distributed under the MIT License, reproduced in full below.
+
+```text
+MIT License
+
+Copyright (c) 2020-present Silero Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## FastEnhancer
+
+- **Name:** FastEnhancer-T (tiny tier), VoiceBank-DEMAND checkpoint, waveform variant
+- **Version:** `onnx-vd-v1.0.0`
+- **License:** MIT
+- **Source:** https://github.com/aask1357/fastenhancer (release `onnx-vd-v1.0.0`)
+- **Files covered:** `fastenhancer_t.onnx`
+
+### License Notice
+
+This model is a third-party artifact, not proprietary to decibri. The model
+code and weights are distributed under the MIT License, reproduced in full
+below.
+
+```text
+MIT License
+
+Copyright (c) 2025 AHN Sung Hwan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+### Training-Data Attribution
+
+The bundled checkpoint is trained on the VoiceBank-DEMAND noisy speech dataset,
+which pairs clean speech from the CSTR VCTK Corpus with noise from the DEMAND
+database. Each source dataset requires attribution:
+
+- **VoiceBank-DEMAND.** Valentini-Botinhao, Cassia. (2017). Noisy speech
+  database for training speech enhancement algorithms and TTS models, 2016
+  [sound]. University of Edinburgh, School of Informatics, Centre for Speech
+  Technology Research (CSTR). Licensed under Creative Commons Attribution 4.0
+  International (CC BY 4.0), https://creativecommons.org/licenses/by/4.0/.
+  https://doi.org/10.7488/ds/2117
+
+- **CSTR VCTK Corpus (version 0.92).** Yamagishi, Junichi; Veaux, Christophe;
+  MacDonald, Kirsten. (2019). CSTR VCTK Corpus: English Multi-speaker Corpus
+  for CSTR Voice Cloning Toolkit (version 0.92) [sound]. University of
+  Edinburgh, Centre for Speech Technology Research (CSTR). Licensed under the
+  Open Data Commons Attribution License (ODC-By) v1.0,
+  https://opendatacommons.org/licenses/by/1-0/.
+  https://doi.org/10.7488/ds/2645
+
+- **DEMAND.** Thiemann, Joachim; Ito, Nobutaka; Vincent, Emmanuel. (2013).
+  DEMAND: a collection of multi-channel recordings of acoustic noise in
+  diverse environments. Licensed under Creative Commons
+  Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0),
+  https://creativecommons.org/licenses/by-sa/3.0/.
+  https://doi.org/10.5281/zenodo.1227121

--- a/npm/decibri/src/decibri.d.ts
+++ b/npm/decibri/src/decibri.d.ts
@@ -42,7 +42,7 @@ export interface VersionInfo {
 export interface VadOptions {
   /**
    * Which detector to run.
-   * - `'silero'`: Silero VAD v5 ML model (more accurate, ~1ms inference)
+   * - `'silero'`: Silero VAD v6.2 ML model (more accurate, ~1ms inference)
    * - `'energy'`: RMS energy threshold (lightweight, no model)
    */
   model: 'silero' | 'energy';
@@ -237,7 +237,7 @@ export interface MicrophoneOptions extends ReadableOptions {
   /**
    * Voice activity detection. One of:
    * - `false`: disabled (default)
-   * - `'silero'`: Silero VAD v5 ML model (more accurate, ~1ms inference)
+   * - `'silero'`: Silero VAD v6.2 ML model (more accurate, ~1ms inference)
    * - `'energy'`: RMS energy threshold (lightweight)
    * - a `VadOptions` config object `{ model, threshold?, holdoffMs? }` to tune
    *   the threshold and holdoff for the chosen model

--- a/tests/test-ci.js
+++ b/tests/test-ci.js
@@ -1408,6 +1408,150 @@ console.log('--- Group 8g: third-party notice version pins ---');
 console.log('  Group 8g done\n');
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// Group 8h: bundled model pins (deterministic, no hardware required)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// Two ONNX models ship inside the main npm package and inside the wheel and the
+// sdist published to PyPI, each next to the models/THIRD-PARTY-NOTICES.md that
+// carries their license notices and the models/README.md that documents their
+// tensor interfaces. The repository holds three copies of that directory: the
+// root `models/` that the Rust tests and examples read, and the two packaged
+// copies. Nothing copies one to the others, so only these assertions hold them
+// together.
+//
+// Each model's SHA-256 is pinned so that replacing a model file fails this suite
+// and forces the notice beside it to be revisited. Pinned alongside each hash is
+// the version the notice states, asserted in both files, so a swap that moves
+// the hash but leaves the label behind fails here rather than shipping a notice
+// naming a version the bytes are not. Each license block inside the notice is
+// hashed against the upstream LICENSE file it reproduces, so the text cannot
+// drift from what its holder wrote. The packaging declarations that carry both
+// files into the published artifacts are asserted as well, because a notice that
+// stops shipping is the failure this guards against.
+
+console.log('--- Group 8h: bundled model pins ---');
+
+{
+  const fs = require('fs');
+  const crypto = require('crypto');
+  const repoRoot = path.join(__dirname, '..');
+  const sha256 = (buf) => crypto.createHash('sha256').update(buf).digest('hex');
+
+  // Directories holding a copy of the two models, their notice and their
+  // interface documentation. The first is the copy the Rust tests read; the
+  // other two are the copies that ship.
+  const modelDirs = [
+    path.join('models'),
+    path.join('npm', 'decibri', 'models'),
+    path.join('bindings', 'python', 'python', 'decibri', 'models'),
+  ];
+  const NOTICE = 'THIRD-PARTY-NOTICES.md';
+  const README = 'README.md';
+
+  // SHA-256 of each bundled model file, with the version the notice states for
+  // it. Moving one of these hashes means a different model is shipping, and the
+  // notice has to be re-checked against the new file's origin before the pin
+  // moves; the version pin beside it is what makes that a failure rather than a
+  // silent mislabel. `noticeVersion` is the notice's exact bullet, `label` the
+  // token both files have to carry.
+  const modelPins = {
+    'silero_vad.onnx': {
+      sha256: '1a153a22f4509e292a94e67d6f9b85e8deb25b4988682b7e174c65279d8788e3',
+      noticeVersion: '- **Version:** v6.2',
+      label: 'v6.2',
+    },
+    'fastenhancer_t.onnx': {
+      sha256: '9ed1b928d18fbead4db69bfbeb4ff99e3007f12abf9887d40fd41732674ccd0d',
+      noticeVersion: '- **Version:** `onnx-vd-v1.0.0`',
+      label: 'onnx-vd-v1.0.0',
+    },
+  };
+
+  for (const [name, pin] of Object.entries(modelPins)) {
+    const copies = modelDirs.map((dir) => fs.readFileSync(path.join(repoRoot, dir, name)));
+    assert(sha256(copies[0]) === pin.sha256, `${modelDirs[0]}/${name} matches its pinned SHA-256`);
+    for (let i = 1; i < copies.length; i++) {
+      assert(
+        copies[i].equals(copies[0]),
+        `${modelDirs[i]}/${name} is byte-identical to ${modelDirs[0]}/${name}`
+      );
+    }
+  }
+
+  // Both files travel with the models, so both are held byte-identical across
+  // the three copies.
+  const readFrom = (dir, file) => fs.readFileSync(path.join(repoRoot, dir, file));
+  for (const file of [NOTICE, README]) {
+    const copies = modelDirs.map((dir) => readFrom(dir, file));
+    for (let i = 1; i < copies.length; i++) {
+      assert(
+        copies[i].equals(copies[0]),
+        `${modelDirs[i]}/${file} is byte-identical to ${modelDirs[0]}/${file}`
+      );
+    }
+  }
+
+  // SHA-256 of each upstream LICENSE file with trailing newlines removed, which
+  // is how the notice carries it inside a fenced block. Silero VAD is
+  // github.com/snakers4/silero-vad; FastEnhancer is github.com/aask1357/fastenhancer.
+  const licensePins = [
+    ['Silero VAD', '2e63e9a38b6e8fc0c7bc37ce174caca1862870856c6daf5697cfb785e925520b'],
+    ['FastEnhancer', '3be376575fa9dfdfdce80b089717b354fb106979ea1ea8e56469260ed7005b24'],
+  ];
+  const noticeText = readFrom(modelDirs[0], NOTICE).toString('utf8').replace(/\r\n/g, '\n');
+  const readmeText = readFrom(modelDirs[0], README).toString('utf8').replace(/\r\n/g, '\n');
+  const blocks = [...noticeText.matchAll(/```text\n([\s\S]*?)```/g)].map((m) => m[1]);
+  assert(
+    blocks.length === licensePins.length,
+    `models/${NOTICE} carries ${licensePins.length} fenced license blocks (found ${blocks.length})`
+  );
+  licensePins.forEach(([label, pin], i) => {
+    const payload = (blocks[i] || '').replace(/\n+$/, '');
+    assert(
+      sha256(Buffer.from(payload, 'utf8')) === pin,
+      `models/${NOTICE} reproduces the ${label} LICENSE unaltered`
+    );
+  });
+
+  for (const [name, pin] of Object.entries(modelPins)) {
+    assert(noticeText.includes(name), `models/${NOTICE} names ${name}`);
+    assert(readmeText.includes(name), `models/${README} names ${name}`);
+    assert(
+      noticeText.includes(pin.noticeVersion),
+      `models/${NOTICE} states ${pin.label} for ${name}`
+    );
+    assert(readmeText.includes(pin.label), `models/${README} states ${pin.label} for ${name}`);
+  }
+
+  // The split only works if a reader of the interface documentation is sent to
+  // the notice, so the pointer is asserted rather than left to convention.
+  assert(readmeText.includes(NOTICE), `models/${README} points at ${NOTICE}`);
+
+  // The notice only satisfies the license if it reaches the published artifacts.
+  // These declarations are what carry it there. npm packs the whole directory,
+  // so one entry covers both files; maturin names each path explicitly.
+  assert(
+    Array.isArray(pkg.files) && pkg.files.includes('models/'),
+    'npm/decibri/package.json packs models/'
+  );
+  const pyproject = fs.readFileSync(
+    path.join(repoRoot, 'bindings', 'python', 'pyproject.toml'),
+    'utf8'
+  );
+  for (const file of [NOTICE, README]) {
+    const declaration = new RegExp(
+      `path\\s*=\\s*"python/decibri/models/${file.replace(/\./g, '\\.')}",\\s*format\\s*=\\s*\\["sdist",\\s*"wheel"\\]`
+    );
+    assert(
+      declaration.test(pyproject),
+      `bindings/python/pyproject.toml ships models/${file} in the sdist and the wheel`
+    );
+  }
+}
+
+console.log('  Group 8h done\n');
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // Group 9: async open() factories (deterministic, no hardware required)
 // ═══════════════════════════════════════════════════════════════════════════════
 //


### PR DESCRIPTION
- The bundled silero_vad.onnx is Silero VAD v6.2. Fifteen sites named v5: the model notice and its two packaged copies, the root and npm READMEs, the vad option and VadOptions.model type documentation, and eight comment and rustdoc sites in vad.rs. Which model file ships is unchanged.
- The Silero VAD tensor specification in the model notice named a four-input form carrying separate h and c LSTM tensors. It now names the tensors the model exposes: input, state and sr in, output and stateN out, with the model's IR version, opset and streaming contract. The inference path already bound the correct tensors and is unchanged.
- The model license notices move out of models/README.md into models/THIRD-PARTY-NOTICES.md beside the weights they cover, matching the filename the ONNX Runtime notices use and the pattern license scanners look for. The license text is reproduced unaltered. README.md keeps the tensor and usage documentation and points at the notice.
- Both files ship in the main npm package, the wheel and the sdist. The maturin include names the new file; the npm files array already packs the directory.
- tests/test-ci.js pins both models' SHA-256, holds both files byte-identical across the three copies, hashes each license block against the upstream LICENSE, and pins the version each notice states so a model swap that moves the hash but not the label fails.
