### PR TITLE
refactor(core): carry K channels through the capture chain

### DIFF
--- a/crates/decibri/src/denoise.rs
+++ b/crates/decibri/src/denoise.rs
@@ -1,11 +1,14 @@
-//! Single-channel speech enhancement (denoise) for the capture path.
+//! Speech enhancement (denoise) for the capture path: a single-channel model
+//! run over each carried channel.
 //!
 //! Wraps the bundled FastEnhancer-T ONNX model as a capture [`Stage`]. The model
 //! is the waveform-in / waveform-out variant: it bakes the complete spectral path
 //! (windowing, the forward and inverse DFT, power compression, and overlap-add)
 //! into its graph, so this stage owns no spectral DSP. The host's job is purely
-//! to re-block the captured waveform into the model's analysis frames, carry the
-//! three streaming caches across calls, and concatenate the returned hops.
+//! to re-block the captured waveform into the model's analysis frames, carry
+//! each channel's three streaming caches across calls, and concatenate the
+//! returned hops. One session serves every channel: the weights are loaded
+//! once, and each channel keeps only its own cache set.
 //!
 //! # Streaming contract (verified against the model and an offline reference)
 //!
@@ -15,7 +18,7 @@
 //! the three updated caches. Frames advance by the hop (256), so consecutive
 //! windows overlap by 512 - 256 = 256 samples, and the caches must be fed back
 //! each call. The stream is left-padded by one (window - hop) = 256-sample
-//! half-window of zeros (the [`accumulator`](Denoise::accumulator) takes 256 zeros
+//! half-window of zeros (each channel's accumulator takes 256 zeros
 //! when its first sample arrives) so the first analysis window is
 //! `[zeros(256), samples(256)]`, which matches how the upstream streaming export
 //! initialises its internal buffer. The
@@ -51,29 +54,20 @@ const CACHE0_LEN: usize = 256;
 /// Length of each recurrent cache `cache_*_1`/`cache_*_2[1, 16, 20]`, flattened.
 const CACHE_REC_LEN: usize = 16 * 20;
 
-/// FastEnhancer-T denoise stage: a framed, stateful capture [`Stage`] that maps a
-/// stream of noisy speech samples to enhanced speech samples.
-///
-/// Length-changing and latency-introducing: each [`process`](Stage::process)
-/// emits whole 256-sample hops as enough input accumulates, buffering the
-/// remainder, so its output count trails its input by the framing latency until
-/// [`flush`](Stage::flush) drains the tail at close. The tail exists to frame the
-/// audio the stage received, so a stage that received none emits nothing at
-/// flush. It runs in the `transform` segment after the VAD tap, so that latency
-/// surfaces as a bounded tap lead and never reaches the detector.
-pub(crate) struct Denoise {
-    /// The model behind the shared ONNX session seam. Loaded from a caller-
-    /// supplied path; the crate embeds no model bytes.
-    session: Box<dyn OnnxSession>,
-    /// Pending samples not yet consumed by a frame. Empty until the stage
-    /// receives its first sample, when [`process`](Stage::process) seeds it with
+/// One channel's streaming state: the framing accumulator and the three model
+/// caches. The stage holds one of these per carried channel against the one
+/// shared session, so the model weights are loaded once however many channels
+/// run through them.
+struct ChannelState {
+    /// Pending samples not yet consumed by a frame. Empty until the channel
+    /// receives its first sample, when [`Stage::process`] seeds it with
     /// `WINDOW - HOP` zeros (the left-pad half-window); each frame then consumes
     /// `HOP` from the front and retains the `WINDOW - HOP`-sample overlap for the
     /// next window, so once seeded it never empties again until
-    /// [`flush`](Stage::flush) clears it.
+    /// [`Stage::flush`] clears it.
     ///
-    /// Invariant, which [`flush`](Stage::flush) reads: an empty accumulator means
-    /// the stage holds no audio to frame, so it has nothing to drain.
+    /// Invariant, which [`Stage::flush`] reads: an empty accumulator means
+    /// the channel holds no audio to frame, so it has nothing to drain.
     accumulator: Vec<f32>,
     /// The model's overlap-add tail buffer (`cache_*_0`), carried across calls.
     cache0: Vec<f32>,
@@ -83,11 +77,50 @@ pub(crate) struct Denoise {
     cache2: Vec<f32>,
 }
 
+impl ChannelState {
+    fn new() -> Self {
+        Self {
+            // Empty until the first sample arrives; `process` lays down the
+            // left-pad half-window then.
+            accumulator: Vec::new(),
+            cache0: vec![0.0; CACHE0_LEN],
+            cache1: vec![0.0; CACHE_REC_LEN],
+            cache2: vec![0.0; CACHE_REC_LEN],
+        }
+    }
+}
+
+/// FastEnhancer-T denoise stage: a framed, stateful capture [`Stage`] that maps a
+/// stream of noisy speech samples to enhanced speech samples, every carried
+/// channel through the one shared model session with its own cache set.
+///
+/// Length-changing and latency-introducing: each [`process`](Stage::process)
+/// emits whole 256-sample hops as enough input accumulates, buffering the
+/// remainder, so its output count trails its input by the framing latency until
+/// [`flush`](Stage::flush) drains the tail at close. The tail exists to frame the
+/// audio the stage received, so a stage that received none emits nothing at
+/// flush. It runs in the `transform` segment after the VAD tap, so that latency
+/// surfaces as a bounded tap lead and never reaches the detector. Above one
+/// channel the block is planar and every channel's run is framed by its own
+/// [`ChannelState`], in channel order; equal-length runs in yield equal-length
+/// runs out, since every accumulator advances by the same count.
+pub(crate) struct Denoise {
+    /// The model behind the shared ONNX session seam. Loaded from a caller-
+    /// supplied path; the crate embeds no model bytes. One session serves
+    /// every channel.
+    session: Box<dyn OnnxSession>,
+    /// One streaming state per carried channel, index i framing planar run i.
+    /// The length is resolved at chain build time; no fixed maximum exists.
+    states: Vec<ChannelState>,
+}
+
 impl Denoise {
     /// Build the stage, loading the model from `path` through the shared ONNX
     /// session seam (the same path Silero VAD loads through). Initialises ORT
     /// once per process, like [`crate::vad::SileroVad::new`], so a denoise-only
-    /// build still works without a VAD.
+    /// build still works without a VAD. `channels` is the carried channel
+    /// count the stage frames, one cache set per channel; a count of zero is
+    /// floored to one.
     ///
     /// # Errors
     /// - [`DecibriError::ModelLoadFailed`] if the model file cannot be opened.
@@ -96,6 +129,7 @@ impl Denoise {
         model: DenoiseModel,
         path: &Path,
         ort_library_path: Option<&Path>,
+        channels: u16,
     ) -> Result<Self, DecibriError> {
         // ORT initialises exactly once per process (first-wins). A VAD in the
         // same process may have done it already; if not, denoise does it here,
@@ -116,28 +150,27 @@ impl Denoise {
 
         Ok(Self {
             session,
-            // Empty until the first sample arrives; `process` lays down the
-            // left-pad half-window then.
-            accumulator: Vec::new(),
-            cache0: vec![0.0; CACHE0_LEN],
-            cache1: vec![0.0; CACHE_REC_LEN],
-            cache2: vec![0.0; CACHE_REC_LEN],
+            states: (0..channels.max(1)).map(|_| ChannelState::new()).collect(),
         })
     }
 
     /// Run one analysis window through the model, appending the enhanced hop to
-    /// `out` and advancing the three caches. Reads the front `WINDOW` samples of
-    /// the accumulator; the caller drains `HOP` afterward.
-    fn run_frame(&mut self, out: &mut Vec<f32>) -> Result<(), DecibriError> {
+    /// `out` and advancing the channel's three caches. Reads the front `WINDOW`
+    /// samples of the channel's accumulator; the caller drains `HOP` afterward.
+    fn run_frame(
+        session: &mut dyn OnnxSession,
+        state: &mut ChannelState,
+        out: &mut Vec<f32>,
+    ) -> Result<(), DecibriError> {
         // Copy the window out so the accumulator can be drained afterward and so
-        // the borrow of `self.accumulator` does not overlap the `&mut self.session`
+        // the borrow of the accumulator does not overlap the `&mut` session
         // call (mirrors SileroVad::infer_window building its own input buffer).
-        let window: Vec<f32> = self.accumulator[..WINDOW].to_vec();
+        let window: Vec<f32> = state.accumulator[..WINDOW].to_vec();
         let wav_in_shape = [1i64, WINDOW as i64];
         let cache0_shape = [1i64, CACHE0_LEN as i64];
         let cache_rec_shape = [1i64, 16, 20];
 
-        let outputs = self.session.run(OnnxInputs {
+        let outputs = session.run(OnnxInputs {
             items: &[
                 (
                     "wav_in",
@@ -150,21 +183,21 @@ impl Denoise {
                     "cache_in_0",
                     OnnxTensorView {
                         shape: &cache0_shape,
-                        data: OnnxTensorData::F32(&self.cache0),
+                        data: OnnxTensorData::F32(&state.cache0),
                     },
                 ),
                 (
                     "cache_in_1",
                     OnnxTensorView {
                         shape: &cache_rec_shape,
-                        data: OnnxTensorData::F32(&self.cache1),
+                        data: OnnxTensorData::F32(&state.cache1),
                     },
                 ),
                 (
                     "cache_in_2",
                     OnnxTensorView {
                         shape: &cache_rec_shape,
-                        data: OnnxTensorData::F32(&self.cache2),
+                        data: OnnxTensorData::F32(&state.cache2),
                     },
                 ),
             ],
@@ -176,18 +209,23 @@ impl Denoise {
         }
         out.extend_from_slice(wav_out);
 
-        copy_cache(&outputs, "cache_out_0", &mut self.cache0)?;
-        copy_cache(&outputs, "cache_out_1", &mut self.cache1)?;
-        copy_cache(&outputs, "cache_out_2", &mut self.cache2)?;
+        copy_cache(&outputs, "cache_out_0", &mut state.cache0)?;
+        copy_cache(&outputs, "cache_out_1", &mut state.cache1)?;
+        copy_cache(&outputs, "cache_out_2", &mut state.cache2)?;
         Ok(())
     }
 
-    /// Emit every whole frame the accumulator currently holds, advancing by `HOP`
-    /// each time and retaining the `WINDOW - HOP` overlap for the next window.
-    fn drain_ready(&mut self, out: &mut Vec<f32>) -> Result<(), DecibriError> {
-        while self.accumulator.len() >= WINDOW {
-            self.run_frame(out)?;
-            self.accumulator.drain(..HOP);
+    /// Emit every whole frame the channel's accumulator currently holds,
+    /// advancing by `HOP` each time and retaining the `WINDOW - HOP` overlap
+    /// for the next window.
+    fn drain_ready(
+        session: &mut dyn OnnxSession,
+        state: &mut ChannelState,
+        out: &mut Vec<f32>,
+    ) -> Result<(), DecibriError> {
+        while state.accumulator.len() >= WINDOW {
+            Self::run_frame(session, state, out)?;
+            state.accumulator.drain(..HOP);
         }
         Ok(())
     }
@@ -195,54 +233,90 @@ impl Denoise {
 
 impl Stage for Denoise {
     fn process(&mut self, input: Block<'_>, out: &mut Vec<f32>) -> Result<(), DecibriError> {
-        // The model takes one channel, and the accumulator below frames a single
-        // time series: an interleaved block pushed through it would be framed
-        // across channels rather than along each. Stated here rather than
-        // assumed, so a chain that ever hands this stage more than one channel
-        // says so.
+        // The count the stage was built for and the count the block carries are
+        // the same number reaching it by two routes, exactly as for the other
+        // per-channel stages. Each accumulator frames a single time series: a
+        // block at another count would frame at least one channel's samples
+        // across a channel boundary.
         debug_assert_eq!(
-            input.channels(),
-            1,
-            "the denoise model requires mono, got {} channels",
+            input.channels() as usize,
+            self.states.len(),
+            "the denoise stage was built for {} channels and handed {}",
+            self.states.len(),
             input.channels()
         );
         if input.is_empty() {
             return Ok(());
         }
-        if self.accumulator.is_empty() {
-            // Left-pad the stream by one half-window of zeros so the first
-            // analysis window is `[zeros(256), first 256 samples]`. Laid down on
-            // the first sample rather than at construction, so an accumulator
-            // that is still empty means the stage has received no audio.
-            self.accumulator.resize(WINDOW - HOP, 0.0);
+        let frames = input.frames();
+        let Denoise { session, states } = self;
+        let mut emitted = None;
+        for (channel, state) in states.iter_mut().enumerate() {
+            if state.accumulator.is_empty() {
+                // Left-pad the stream by one half-window of zeros so the first
+                // analysis window is `[zeros(256), first 256 samples]`. Laid
+                // down on the first sample rather than at construction, so an
+                // accumulator that is still empty means the channel has
+                // received no audio.
+                state.accumulator.resize(WINDOW - HOP, 0.0);
+            }
+            state
+                .accumulator
+                .extend_from_slice(&input.samples()[channel * frames..(channel + 1) * frames]);
+            let before = out.len();
+            Self::drain_ready(session.as_mut(), state, out)?;
+            let count = out.len() - before;
+            // Equal-length runs in yield equal-length runs out: every
+            // accumulator advances by the same count, so every channel emits
+            // the same number of whole hops, which is what keeps the planar
+            // layout valid downstream.
+            debug_assert!(
+                emitted.is_none_or(|e: usize| e == count),
+                "equally fed channels emit equally many hops"
+            );
+            emitted = Some(count);
         }
-        self.accumulator.extend_from_slice(input.samples());
-        self.drain_ready(out)
+        Ok(())
     }
 
     fn flush(&mut self, out: &mut Vec<f32>) -> Result<(), DecibriError> {
-        // The tail drains the audio still inside the model's framing, so a stage
-        // holding none contributes nothing. An empty accumulator means either no
-        // sample ever arrived or the tail has already been drained; both emit
-        // nothing here.
-        if self.accumulator.is_empty() {
-            return Ok(());
+        // The tail drains the audio still inside the model's framing, so a
+        // channel holding none contributes nothing. An empty accumulator means
+        // either no sample ever arrived or the tail has already been drained;
+        // both emit nothing here. The channels are fed equally, so either
+        // every accumulator holds audio or none does, and the drained tails
+        // are equally long: the appended tail is planar like every processed
+        // block.
+        let Denoise { session, states } = self;
+        let mut emitted = None;
+        for state in states.iter_mut() {
+            if state.accumulator.is_empty() {
+                continue;
+            }
+
+            // Pad the stream out by one full window of zeros (the upstream
+            // offline recipe right-pads by n_fft) so the leftover real samples
+            // and the model's overlap-add tail are pushed out as final hops,
+            // then drain.
+            let padded_len = state.accumulator.len() + WINDOW;
+            state.accumulator.resize(padded_len, 0.0);
+            let before = out.len();
+            Self::drain_ready(session.as_mut(), state, out)?;
+            let count = out.len() - before;
+            debug_assert!(
+                emitted.is_none_or(|e: usize| e == count),
+                "equally fed channels drain equally long tails"
+            );
+            emitted = Some(count);
+
+            // Leave the channel reusable: drop the pending samples and zero the
+            // streaming caches, so a subsequent stream starts clean and lays
+            // down its own left-pad on its first sample.
+            state.accumulator.clear();
+            state.cache0.fill(0.0);
+            state.cache1.fill(0.0);
+            state.cache2.fill(0.0);
         }
-
-        // Pad the stream out by one full window of zeros (the upstream offline
-        // recipe right-pads by n_fft) so the leftover real samples and the
-        // model's overlap-add tail are pushed out as final hops, then drain.
-        let padded_len = self.accumulator.len() + WINDOW;
-        self.accumulator.resize(padded_len, 0.0);
-        self.drain_ready(out)?;
-
-        // Leave the stage reusable: drop the pending samples and zero the
-        // streaming caches, so a subsequent stream starts clean and lays down its
-        // own left-pad on its first sample.
-        self.accumulator.clear();
-        self.cache0.fill(0.0);
-        self.cache1.fill(0.0);
-        self.cache2.fill(0.0);
         Ok(())
     }
 
@@ -342,12 +416,12 @@ mod tests {
     /// tracks the input minus the framing latency.
     #[test]
     fn denoise_stage_processes_and_advances_caches() {
-        let mut stage = Denoise::new(DenoiseModel::FastEnhancerT, &model_path(), None)
+        let mut stage = Denoise::new(DenoiseModel::FastEnhancerT, &model_path(), None, 1)
             .expect("bundled FastEnhancer-T model loads");
 
         // Caches start zeroed and the accumulator is empty until fed.
-        assert!(stage.accumulator.is_empty());
-        assert!(stage.cache0.iter().all(|&v| v == 0.0));
+        assert!(stage.states[0].accumulator.is_empty());
+        assert!(stage.states[0].cache0.iter().all(|&v| v == 0.0));
 
         let input = noisy(4096);
         let mut out = Vec::new();
@@ -369,11 +443,12 @@ mod tests {
 
         // The caches advanced (the model wrote streaming state back).
         assert!(
-            stage.cache0.iter().any(|&v| v != 0.0),
+            stage.states[0].cache0.iter().any(|&v| v != 0.0),
             "the overlap-add cache advanced"
         );
         assert!(
-            stage.cache1.iter().any(|&v| v != 0.0) || stage.cache2.iter().any(|&v| v != 0.0),
+            stage.states[0].cache1.iter().any(|&v| v != 0.0)
+                || stage.states[0].cache2.iter().any(|&v| v != 0.0),
             "a recurrent cache advanced"
         );
     }
@@ -383,7 +458,7 @@ mod tests {
     /// the left-pad re-seeded).
     #[test]
     fn denoise_flush_drains_tail_and_resets() {
-        let mut stage = Denoise::new(DenoiseModel::FastEnhancerT, &model_path(), None)
+        let mut stage = Denoise::new(DenoiseModel::FastEnhancerT, &model_path(), None, 1)
             .expect("bundled FastEnhancer-T model loads");
 
         let mut out = Vec::new();
@@ -406,8 +481,70 @@ mod tests {
 
         // Reusable: caches re-zeroed, accumulator cleared so the next stream lays
         // down its own left-pad.
-        assert!(stage.cache0.iter().all(|&v| v == 0.0), "caches re-zeroed");
-        assert!(stage.accumulator.is_empty(), "pending samples cleared");
+        assert!(
+            stage.states[0].cache0.iter().all(|&v| v == 0.0),
+            "caches re-zeroed"
+        );
+        assert!(
+            stage.states[0].accumulator.is_empty(),
+            "pending samples cleared"
+        );
+    }
+
+    /// Every carried channel runs through the one shared session with its own
+    /// cache set: a two-channel stage fed the same signal on both channels
+    /// emits two identical runs, each bit-identical to a single-channel stage
+    /// over that signal alone, through process and flush. This pins the
+    /// per-channel machinery's shape (one session, one cache set per channel,
+    /// every delivered channel denoised): dropping a channel's cache set, or
+    /// running a channel through another channel's caches, breaks the
+    /// equality.
+    #[test]
+    fn every_channel_runs_through_its_own_cache_set() {
+        let input = noisy(4096);
+
+        // The single-channel reference, processed and flushed.
+        let mut mono = Denoise::new(DenoiseModel::FastEnhancerT, &model_path(), None, 1)
+            .expect("bundled FastEnhancer-T model loads");
+        let mut expected = Vec::new();
+        mono.process(Block::new(&input, 1), &mut expected)
+            .expect("mono process");
+        let expected_processed = expected.len();
+        mono.flush(&mut expected).expect("mono flush");
+
+        // The two-channel stage over a planar block carrying the signal twice.
+        let mut stereo = Denoise::new(DenoiseModel::FastEnhancerT, &model_path(), None, 2)
+            .expect("bundled FastEnhancer-T model loads");
+        assert_eq!(stereo.states.len(), 2, "one cache set per channel");
+        let planar: Vec<f32> = input.iter().chain(&input).copied().collect();
+        let mut out = Vec::new();
+        stereo
+            .process(Block::new(&planar, 2), &mut out)
+            .expect("stereo process");
+        assert_eq!(
+            out.len(),
+            2 * expected_processed,
+            "equally fed channels emit equally many hops"
+        );
+        assert_eq!(
+            &out[..expected_processed],
+            &expected[..expected_processed],
+            "channel 0 equals the single-channel stage, bit for bit"
+        );
+        assert_eq!(
+            &out[expected_processed..],
+            &expected[..expected_processed],
+            "channel 1 equals the single-channel stage, bit for bit"
+        );
+
+        // The flush drains both channels' tails as planar runs, each equal to
+        // the single-channel tail.
+        let mut tails = Vec::new();
+        stereo.flush(&mut tails).expect("stereo flush");
+        let tail = &expected[expected_processed..];
+        assert_eq!(tails.len(), 2 * tail.len(), "equally long tails");
+        assert_eq!(&tails[..tail.len()], tail, "channel 0's tail matches");
+        assert_eq!(&tails[tail.len()..], tail, "channel 1's tail matches");
     }
 
     /// A stage that received no audio emits nothing at flush: the padding exists
@@ -415,7 +552,7 @@ mod tests {
     /// so a tail of any length fails.
     #[test]
     fn unfed_flush_emits_nothing() {
-        let mut stage = Denoise::new(DenoiseModel::FastEnhancerT, &model_path(), None)
+        let mut stage = Denoise::new(DenoiseModel::FastEnhancerT, &model_path(), None, 1)
             .expect("bundled FastEnhancer-T model loads");
 
         let mut tail = Vec::new();
@@ -446,7 +583,7 @@ mod tests {
     /// padded stream forms.
     #[test]
     fn a_stage_fed_a_little_audio_still_drains_its_tail() {
-        let mut stage = Denoise::new(DenoiseModel::FastEnhancerT, &model_path(), None)
+        let mut stage = Denoise::new(DenoiseModel::FastEnhancerT, &model_path(), None, 1)
             .expect("bundled FastEnhancer-T model loads");
 
         let mut processed = Vec::new();
@@ -481,7 +618,7 @@ mod tests {
         let missing = Path::new(env!("CARGO_MANIFEST_DIR")).join("no-such-model.onnx");
         // Match on the Result (not `expect_err`) because `Denoise` holds a
         // `Box<dyn OnnxSession>` and is not `Debug`.
-        let err = match Denoise::new(DenoiseModel::FastEnhancerT, &missing, None) {
+        let err = match Denoise::new(DenoiseModel::FastEnhancerT, &missing, None, 1) {
             Ok(_) => panic!("a missing model file must fail to load"),
             Err(e) => e,
         };
@@ -721,7 +858,7 @@ mod tests {
     /// Run a signal through the real denoise stage (process then flush), exactly as
     /// the capture chain drives it, and return the enhanced output.
     fn run_denoise(model: &Path, input: &[f32]) -> Vec<f32> {
-        let mut stage = Denoise::new(DenoiseModel::FastEnhancerT, model, None)
+        let mut stage = Denoise::new(DenoiseModel::FastEnhancerT, model, None, 1)
             .expect("bundled FastEnhancer-T model loads");
         let mut out = Vec::new();
         stage

--- a/crates/decibri/src/gain.rs
+++ b/crates/decibri/src/gain.rs
@@ -1,10 +1,13 @@
 //! Adaptive level control for the capture chain.
 //!
 //! [`LevelControl`] is one internal engine that drives a captured signal's level
-//! toward a target by applying a smoothed, rate-limited gain. It is a same-length,
-//! sample-in-sample-out stage: it reads one sample and writes one sample, carrying
-//! its level estimate and current gain across blocks, so it wraps through the
-//! chain's `InPlace` adapter exactly like the DC blocker and the high-pass biquad.
+//! toward a target by applying a smoothed, rate-limited gain. It is a same-length
+//! stage: it reads one frame and writes one frame, carrying
+//! its level estimate and current gain across blocks. In the chain it wraps
+//! through the `Linked` adapter: one detector reading each frame across every
+//! delivered channel, one gain applied to all of them, so the inter-channel
+//! balance is preserved. The per-sample [`InPlaceDsp`] form is the same
+//! control loop over a single run, and the two are identical at one channel.
 //! It adds no algorithmic delay (no look-ahead), so it declares zero latency.
 //!
 //! The engine is built around a [`LevelMode`] seam that selects what it measures
@@ -15,7 +18,7 @@
 //! variant plus its measurement and rate constants, with no change to the control
 //! loop, the chain wiring, or the byte-identical off path.
 
-use crate::stage::InPlaceDsp;
+use crate::stage::{InPlaceDsp, LinkedDsp};
 
 /// Convert a level in decibels relative to full scale to a linear amplitude
 /// (`1.0` = full scale). `0 dBFS` maps to `1.0`, `-20 dBFS` to `0.1`.
@@ -192,6 +195,66 @@ impl LevelControl {
             LevelMode::Agc => sample,
         }
     }
+
+    /// Advance the control loop by one frame whose weighted mean square across
+    /// its channels is `weighted_sq` (at one channel, the one weighted sample
+    /// squared). One call moves the level estimate, the presence gate and the
+    /// gain envelope by one step, whatever the channel count: the loop's time
+    /// constants count frames, which advance at the sample rate the engine was
+    /// built for.
+    fn update(&mut self, weighted_sq: f32) {
+        // Advance the level estimate. A fast-start blend (a running average
+        // until the steady-state coefficient takes over) primes the estimate
+        // from the opening samples, so the gain decision is correct within
+        // tens of milliseconds rather than over the full window.
+        let coeff = self.level_coeff.max(1.0 / (self.sample_count + 1) as f32);
+        self.level_sq += coeff * (weighted_sq - self.level_sq);
+        self.sample_count = self.sample_count.saturating_add(1);
+        let level = self.level_sq.sqrt();
+
+        // Presence gate (the noise-floor guard) with a hangover, so a silent
+        // or noise-only stretch holds the upward rise while a brief inter-word
+        // gap does not.
+        let present = if level > self.noise_floor_linear {
+            self.hangover_remaining = self.hangover_samples;
+            true
+        } else if self.hangover_remaining > 0 {
+            self.hangover_remaining -= 1;
+            true
+        } else {
+            false
+        };
+
+        if present {
+            let desired =
+                (self.target_linear / level).clamp(self.min_gain_linear, self.max_gain_linear);
+            if desired > self.gain {
+                // Upward: gated on presence (true here), rate-limited. Fast
+                // during the opening warm-up, then the gentle steady slope.
+                if self.warmup_remaining > 0 {
+                    self.gain += (desired - self.gain) * self.warmup_coeff;
+                } else {
+                    self.gain = (self.gain * self.rise_step).min(desired);
+                }
+            } else {
+                // Downward (attack): fast, never gated, so a loud onset is
+                // always pulled down promptly.
+                self.gain += (desired - self.gain) * self.attack_coeff;
+            }
+
+            // Spend the warm-up window only while signal is present, so a
+            // silent or noise-only opening does not burn the fast-start
+            // before the first real signal arrives. The fast convergence the
+            // warm-up buys is then applied to that first signal, not wasted
+            // on an opening pause.
+            if self.warmup_remaining > 0 {
+                self.warmup_remaining -= 1;
+            }
+        }
+        // When not present the gain is frozen and the warm-up is preserved:
+        // neither rise nor fall, so the level is held through silence and the
+        // fast-start is saved for the first present signal.
+    }
 }
 
 impl InPlaceDsp for LevelControl {
@@ -203,59 +266,33 @@ impl InPlaceDsp for LevelControl {
             // construction (unboosted), and the gain lags the measurement by one
             // sample (a feedback loop, no look-ahead, zero added latency).
             *sample = x * self.gain;
-
-            // Advance the level estimate. A fast-start blend (a running average
-            // until the steady-state coefficient takes over) primes the estimate
-            // from the opening samples, so the gain decision is correct within
-            // tens of milliseconds rather than over the full window.
             let weighted = self.weigh(x);
-            let coeff = self.level_coeff.max(1.0 / (self.sample_count + 1) as f32);
-            self.level_sq += coeff * (weighted * weighted - self.level_sq);
-            self.sample_count = self.sample_count.saturating_add(1);
-            let level = self.level_sq.sqrt();
+            self.update(weighted * weighted);
+        }
+    }
+}
 
-            // Presence gate (the noise-floor guard) with a hangover, so a silent
-            // or noise-only stretch holds the upward rise while a brief inter-word
-            // gap does not.
-            let present = if level > self.noise_floor_linear {
-                self.hangover_remaining = self.hangover_samples;
-                true
-            } else if self.hangover_remaining > 0 {
-                self.hangover_remaining -= 1;
-                true
-            } else {
-                false
-            };
-
-            if present {
-                let desired =
-                    (self.target_linear / level).clamp(self.min_gain_linear, self.max_gain_linear);
-                if desired > self.gain {
-                    // Upward: gated on presence (true here), rate-limited. Fast
-                    // during the opening warm-up, then the gentle steady slope.
-                    if self.warmup_remaining > 0 {
-                        self.gain += (desired - self.gain) * self.warmup_coeff;
-                    } else {
-                        self.gain = (self.gain * self.rise_step).min(desired);
-                    }
-                } else {
-                    // Downward (attack): fast, never gated, so a loud onset is
-                    // always pulled down promptly.
-                    self.gain += (desired - self.gain) * self.attack_coeff;
-                }
-
-                // Spend the warm-up window only while signal is present, so a
-                // silent or noise-only opening does not burn the fast-start
-                // before the first real signal arrives. The fast convergence the
-                // warm-up buys is then applied to that first signal, not wasted
-                // on an opening pause.
-                if self.warmup_remaining > 0 {
-                    self.warmup_remaining -= 1;
-                }
+impl LinkedDsp for LevelControl {
+    fn process_planar(&mut self, planar: &mut [f32], channels: u16) {
+        let channels = channels.max(1) as usize;
+        let frames = planar.len() / channels;
+        for frame in 0..frames {
+            // Apply the current gain to every channel of the frame first, then
+            // update the gain once from the frame's weighted mean square
+            // across the channels: one detector, one gain, so the
+            // inter-channel balance is exactly preserved and the gain lags the
+            // measurement by one frame, as the per-sample form lags by one
+            // sample. At one channel the mean is the one sample's square and
+            // this loop is the per-sample loop.
+            let mut sum_sq = 0.0f32;
+            for channel in 0..channels {
+                let sample = &mut planar[channel * frames + frame];
+                let x = *sample;
+                *sample = x * self.gain;
+                let weighted = self.weigh(x);
+                sum_sq += weighted * weighted;
             }
-            // When not present the gain is frozen and the warm-up is preserved:
-            // neither rise nor fall, so the level is held through silence and the
-            // fast-start is saved for the first present signal.
+            self.update(sum_sq / channels as f32);
         }
     }
 }
@@ -264,10 +301,13 @@ impl InPlaceDsp for LevelControl {
 /// safety net that catches a transient the level control's wound-up gain would
 /// otherwise let exceed full scale.
 ///
-/// It is a same-length, sample-in-sample-out stage with no look-ahead, so it
-/// wraps through the chain's `InPlace` adapter exactly like the DC blocker, the
-/// high-pass biquad, and [`LevelControl`], and declares zero latency. It runs
-/// last in the conditioning chain, after [`LevelControl`].
+/// It is a same-length stage with no look-ahead, so it declares zero latency,
+/// and it runs last in the conditioning chain, after [`LevelControl`]. In the
+/// chain it wraps through the `Linked` adapter like [`LevelControl`]: one
+/// detector reading each frame's sample peak across every delivered channel,
+/// one gain applied to all of them, with the hard clamp still applied to each
+/// sample. The per-sample [`InPlaceDsp`] form is the same two layers over a
+/// single run, and the two are identical at one channel.
 ///
 /// # Two layers
 /// The limiter combines fast feedback gain reduction with a hard-ceiling
@@ -339,44 +379,80 @@ impl Limiter {
             release_coeff: coeff(Self::RELEASE_TC_SECS),
         }
     }
+
+    /// Advance the feedback gain by one frame whose sample peak across its
+    /// channels is `magnitude` (at one channel, the one sample's magnitude).
+    fn update(&mut self, magnitude: f32) {
+        // Feedback gain reduction: the gain that would bring this peak to the
+        // ceiling (unity when the peak already sits below it). `magnitude` is
+        // strictly above the positive ceiling here, so the divide is safe.
+        let desired = if magnitude > self.ceiling_linear {
+            self.ceiling_linear / magnitude
+        } else {
+            1.0
+        };
+        // Pull down fast (attack) when more reduction is needed, recover
+        // slowly (release) otherwise.
+        let coeff = if desired < self.gain {
+            self.attack_coeff
+        } else {
+            self.release_coeff
+        };
+        self.gain += (desired - self.gain) * coeff;
+    }
+
+    /// The hard-ceiling backstop: the clamp is the final operation, so no
+    /// output sample can exceed the ceiling whatever the gain state, even
+    /// on the instantaneous worst case the smoothed gain has not yet
+    /// caught. A non-finite (NaN) sample, which the clamp would otherwise
+    /// pass through unchanged, is flushed to silence first, so every
+    /// delivered sample is finite and within the ceiling: the limiter is
+    /// the last conditioning stage, so a glitched device frame must not
+    /// reach the consumer or detector. A finite or infinite product is
+    /// bounded by the clamp (an infinity clamps to the ceiling).
+    fn clamp_to_ceiling(&self, y: f32) -> f32 {
+        if y.is_nan() {
+            0.0
+        } else {
+            y.clamp(-self.ceiling_linear, self.ceiling_linear)
+        }
+    }
 }
 
 impl InPlaceDsp for Limiter {
     fn process_in_place(&mut self, samples: &mut [f32]) {
         for sample in samples.iter_mut() {
             let x = *sample;
-            let mag = x.abs();
-            // Feedback gain reduction: the gain that would bring this peak to the
-            // ceiling (unity when the sample already sits below it). `mag` is
-            // strictly above the positive ceiling here, so the divide is safe.
-            let desired = if mag > self.ceiling_linear {
-                self.ceiling_linear / mag
-            } else {
-                1.0
-            };
-            // Pull down fast (attack) when more reduction is needed, recover
-            // slowly (release) otherwise.
-            let coeff = if desired < self.gain {
-                self.attack_coeff
-            } else {
-                self.release_coeff
-            };
-            self.gain += (desired - self.gain) * coeff;
-            // Hard-ceiling backstop: the clamp is the final operation, so no
-            // output sample can exceed the ceiling whatever the gain state, even
-            // on the instantaneous worst case the smoothed gain has not yet
-            // caught. A non-finite (NaN) sample, which the clamp would otherwise
-            // pass through unchanged, is flushed to silence first, so every
-            // delivered sample is finite and within the ceiling: the limiter is
-            // the last conditioning stage, so a glitched device frame must not
-            // reach the consumer or detector. A finite or infinite product is
-            // bounded by the clamp (an infinity clamps to the ceiling).
+            self.update(x.abs());
             let y = x * self.gain;
-            *sample = if y.is_nan() {
-                0.0
-            } else {
-                y.clamp(-self.ceiling_linear, self.ceiling_linear)
-            };
+            *sample = self.clamp_to_ceiling(y);
+        }
+    }
+}
+
+impl LinkedDsp for Limiter {
+    fn process_planar(&mut self, planar: &mut [f32], channels: u16) {
+        let channels = channels.max(1) as usize;
+        let frames = planar.len() / channels;
+        for frame in 0..frames {
+            // One detector reading per frame: the frame's sample peak across
+            // every channel. The gain then applies to all of the frame's
+            // channels, so a peak on one channel ducks every channel by the
+            // same amount and the inter-channel balance is preserved through
+            // the gain path; the hard clamp stays per sample. A non-finite
+            // sample contributes nothing to the peak (the fold starts at zero
+            // and `max` discards a NaN operand) and is flushed by the clamp,
+            // matching the per-sample form at one channel.
+            let mut peak = 0.0f32;
+            for channel in 0..channels {
+                peak = peak.max(planar[channel * frames + frame].abs());
+            }
+            self.update(peak);
+            for channel in 0..channels {
+                let sample = &mut planar[channel * frames + frame];
+                let y = *sample * self.gain;
+                *sample = self.clamp_to_ceiling(y);
+            }
         }
     }
 }
@@ -848,6 +924,142 @@ mod tests {
             out_rms > in_rms * 0.95,
             "the quiet passage recovers to ~unity after the loud transient \
              (in {in_rms}, out {out_rms})"
+        );
+    }
+
+    // ── The linked (across-channel) forms ───────────────────────────────
+    //
+    // The chain drives both engines through the `Linked` adapter: one
+    // detector reading each frame across every channel, one gain applied to
+    // all of them. These pin the two properties that define that form: it is
+    // bit-identical to the per-sample form at one channel, and above one
+    // channel it preserves the inter-channel balance that per-channel
+    // detection would destroy.
+
+    /// At one channel the linked level control is the per-sample form, bit
+    /// for bit, including non-finite samples: the two loops perform the same
+    /// operations in the same order, and the frame mean square over one
+    /// channel is that sample's square.
+    #[test]
+    fn linked_level_control_at_one_channel_matches_the_per_sample_form() {
+        let mut input = tone(amp_for_dbfs(-30.0), 220.0, 0.5);
+        input[100] = f32::NAN;
+        input[200] = f32::INFINITY;
+
+        let mut per_sample = LevelControl::agc(TARGET_DB, SR);
+        let mut a = input.clone();
+        per_sample.process_in_place(&mut a);
+
+        let mut linked = LevelControl::agc(TARGET_DB, SR);
+        let mut b = input.clone();
+        linked.process_planar(&mut b, 1);
+
+        assert_eq!(a.len(), b.len());
+        for (i, (x, y)) in a.iter().zip(&b).enumerate() {
+            assert!(
+                x.to_bits() == y.to_bits(),
+                "sample {i}: linked at one channel is bit-identical ({x} vs {y})"
+            );
+        }
+    }
+
+    /// At one channel the linked limiter is the per-sample form, bit for bit,
+    /// including non-finite samples (a NaN contributes nothing to the frame
+    /// peak, exactly as the per-sample detector treats it, and the clamp
+    /// flushes it either way).
+    #[test]
+    fn linked_limiter_at_one_channel_matches_the_per_sample_form() {
+        let mut input = tone(0.95, 1_000.0, 0.3);
+        input[0] = f32::NAN;
+        input[10] = f32::INFINITY;
+        input[20] = f32::NEG_INFINITY;
+
+        let mut per_sample = Limiter::new(-1.0, SR);
+        let mut a = input.clone();
+        per_sample.process_in_place(&mut a);
+
+        let mut linked = Limiter::new(-1.0, SR);
+        let mut b = input.clone();
+        linked.process_planar(&mut b, 1);
+
+        assert_eq!(a.len(), b.len());
+        for (i, (x, y)) in a.iter().zip(&b).enumerate() {
+            assert!(
+                x.to_bits() == y.to_bits(),
+                "sample {i}: linked at one channel is bit-identical ({x} vs {y})"
+            );
+        }
+    }
+
+    /// The linked level control preserves the inter-channel ratio exactly:
+    /// one gain applies to every channel of a frame, so a channel at half the
+    /// other's amplitude leaves at half the other's amplitude, sample for
+    /// sample, while the quiet signal is still driven up toward the target.
+    /// Per-channel detection would drive both channels toward the same
+    /// target, erasing the ratio; that is the named alternative for
+    /// separately-mic'd speakers, not this engine's behaviour.
+    #[test]
+    fn linked_level_control_preserves_the_inter_channel_ratio() {
+        let frames = SR as usize;
+        let loud = tone(amp_for_dbfs(-38.0), 220.0, 1.0);
+        // Planar: channel 0's run, then channel 1's at exactly half.
+        let mut planar: Vec<f32> = loud
+            .iter()
+            .copied()
+            .chain(loud.iter().map(|&s| 0.5 * s))
+            .collect();
+
+        let mut linked = LevelControl::agc(TARGET_DB, SR);
+        linked.process_planar(&mut planar, 2);
+
+        for frame in 0..frames {
+            assert_eq!(
+                planar[frames + frame],
+                0.5 * planar[frame],
+                "frame {frame}: the shared gain keeps the exact half ratio"
+            );
+        }
+        // Not vacuous: the quiet pair was materially raised toward the target.
+        let tail = rms(&planar[frames - 4000..frames]);
+        let input_tail = rms(&loud[frames - 4000..]);
+        assert!(
+            tail > 2.0 * input_tail,
+            "the level control raised the signal materially ({input_tail} -> {tail})"
+        );
+    }
+
+    /// The linked limiter ducks every channel by the one shared gain: a peak
+    /// on one channel attenuates the other channel too, holding the balance,
+    /// where per-channel detection would leave the below-ceiling channel
+    /// untouched. The over-ceiling channel still settles at the ceiling.
+    #[test]
+    fn linked_limiter_ducks_every_channel_together() {
+        let ceiling_db = -1.0f32;
+        let ceiling = db_to_linear(ceiling_db);
+        let frames = (0.3 * SR as f32) as usize;
+        let hot = tone(1.2, 1_000.0, 0.3);
+        let quiet = tone(0.2, 1_000.0, 0.3);
+        let mut planar: Vec<f32> = hot.iter().chain(&quiet).copied().collect();
+
+        let mut linked = Limiter::new(ceiling_db, SR);
+        linked.process_planar(&mut planar, 2);
+
+        let win = (0.05 * SR as f32) as usize;
+        let hot_out = &planar[frames - win..frames];
+        let quiet_out = &planar[2 * frames - win..];
+
+        // The hot channel is held at or below the ceiling.
+        let peak = hot_out.iter().fold(0.0f32, |m, s| m.max(s.abs()));
+        assert!(peak <= ceiling, "the hot channel is capped ({peak})");
+
+        // The quiet channel, never itself above the ceiling, is attenuated by
+        // the same shared gain. A per-channel limiter would deliver it
+        // bit-identical to its input; the linked form must not.
+        let in_rms = rms(&quiet[frames - win..]);
+        let out_rms = rms(quiet_out);
+        assert!(
+            out_rms < 0.95 * in_rms,
+            "the quiet channel is ducked with the hot one ({in_rms} -> {out_rms})"
         );
     }
 

--- a/crates/decibri/src/microphone.rs
+++ b/crates/decibri/src/microphone.rs
@@ -1309,15 +1309,17 @@ impl Microphone {
         let native_channels = CpalBackend.native_input_channels(&self.device)?;
         let frames_per_buffer = self.config.frames_per_buffer;
 
-        // Build the normalize chain for this device. The target is mono (1
-        // channel) at the requested rate: `build_capture_stage` adds a channel
+        // Build the normalize chain for this device. The target is the
+        // configured delivered count at the requested rate:
+        // `build_capture_stage` adds a channel
         // stage for a multichannel device (the average, or the gather the
         // channel map selects) and a resample when the native rate differs,
         // and returns `None` only for a mono device already at the target rate
-        // with no map. The stream reports the OUTPUT channel count (mono when
-        // the chain collapses, which is what the exact-size `samples` math is
-        // counted in) and the target rate.
-        let target_channels: u16 = 1;
+        // with no map. The stream reports the OUTPUT channel count (the count
+        // the exact-size `samples` math is counted in) and the target rate.
+        // `validate()` bounds the accepted set of `channels`, so the value
+        // reaching the chain here is a validated one.
+        let target_channels: u16 = self.config.channels;
 
         // The channel map names device channels, so it is checked here, after
         // device resolution, against the same report that sets the open count.

--- a/crates/decibri/src/stage.rs
+++ b/crates/decibri/src/stage.rs
@@ -3,11 +3,14 @@
 //! A [`CaptureStage`] conditions raw device capture into the canonical format the
 //! consumer receives, running between the cpal callback's native buffers and the
 //! exact-size reblock in [`crate::microphone`]. The chain has two segments. The
-//! `normalize` segment holds up to three stages: [`Downmix`], which averages a
-//! multichannel device down to mono, then [`ResampleStage`], which converts the
-//! device's native sample rate to the requested target rate, then the echo
-//! canceller, which removes the echo of caller-supplied far-end audio. Downmix
-//! runs first so the resampler receives mono, the format it expects; the echo
+//! `normalize` segment holds up to four stages: [`Downmix`], which averages a
+//! multichannel device down to mono (or the [`Select`] gather a channel map
+//! replaces it with), then [`Deinterleave`] when more than one channel
+//! continues past that point, then [`ResampleStage`], which converts the
+//! device's native sample rate to the requested target rate with one engine
+//! per carried channel, then the echo canceller, which removes the echo of
+//! caller-supplied far-end audio. The channel stage runs first so every later
+//! stage sees the delivered channel count; the echo
 //! canceller runs last so it receives mono at the target rate, the only format
 //! it accepts. The optional `transform` segment runs after `normalize`, holding
 //! the conditioning a consumer opts into: the same-length [`DcBlocker`]
@@ -25,11 +28,16 @@
 //!
 //! # Channel layout
 //!
-//! A block crossing a stage boundary is INTERLEAVED and carries the channel
-//! count it is interleaved at, as a [`Block`]. Inside a stage that reads across
-//! channels the samples are PLANAR: one contiguous run per channel,
-//! deinterleaved once at the head of the chain, at the position [`Downmix`]
-//! occupies, and re-interleaved at delivery. Interleaved at the boundaries and
+//! Audio enters the chain INTERLEAVED, and every signal that leaves it (the
+//! delivered output and the detector tap) is interleaved again; in between,
+//! the chain runs PLANAR: one contiguous run per channel. A block crossing a
+//! stage boundary carries the channel count it is laid out at, as a
+//! [`Block`]. The [`Deinterleave`] stage rearranges the block once at the
+//! head of the chain, in the position [`Downmix`] occupies or immediately
+//! after the channel stage standing there (that stage reads the interleaved
+//! device frames), and the block is re-interleaved at each delivery. At one
+//! channel the two layouts are the same arrangement, so no rearrangement is
+//! built. Interleaved at the boundaries and
 //! planar inside is the single arrangement this chain uses. A stage that picks
 //! the other one at either point is what this convention exists to rule out,
 //! because two stages disagreeing about the layout of the buffer between them
@@ -296,47 +304,174 @@ impl Stage for Select {
     }
 }
 
-/// Resample mono interleaved audio from the device's native rate to the
-/// requested target rate, wrapping the owned [`PolyphaseResampler`].
+/// Rearrange one interleaved buffer into the planar layout, appended to `dst`:
+/// `channels` contiguous runs, one per channel, each run holding that
+/// channel's sample from every frame in order. Any trailing partial frame is
+/// truncated, matching [`Block::frames`] and [`sample::downmix_to_mono`].
+fn deinterleave_into(samples: &[f32], channels: u16, dst: &mut Vec<f32>) {
+    let channels = channels.max(1) as usize;
+    let frames = samples.len() / channels;
+    dst.reserve(frames * channels);
+    for channel in 0..channels {
+        dst.extend(samples.chunks_exact(channels).map(|frame| frame[channel]));
+    }
+}
+
+/// Rearrange one planar buffer (as [`deinterleave_into`] lays it out) back
+/// into interleaved frames, appended to `dst`. The buffer's length must be a
+/// multiple of `channels`: the chain only re-interleaves buffers whose runs it
+/// built at equal length.
+fn interleave_into(planar: &[f32], channels: u16, dst: &mut Vec<f32>) {
+    let channels = channels.max(1) as usize;
+    debug_assert!(
+        planar.len().is_multiple_of(channels),
+        "a planar buffer holds equal-length runs: {} samples cannot split into {} channels",
+        planar.len(),
+        channels
+    );
+    let frames = planar.len() / channels;
+    dst.reserve(frames * channels);
+    for frame in 0..frames {
+        dst.extend((0..channels).map(|channel| planar[channel * frames + frame]));
+    }
+}
+
+/// Splice one planar buffer onto another run by run: run i of `carried`
+/// becomes carried's run i followed by `tail`'s run i, so a stage's drained
+/// tail continues each channel's own run. With `carried` empty the result is
+/// `tail`'s runs unchanged. Both buffers hold `channels` equal-length runs.
+fn splice_planar_tail(carried: &mut Vec<f32>, tail: &[f32], channels: u16) {
+    let channels = channels.max(1) as usize;
+    debug_assert!(
+        carried.len().is_multiple_of(channels) && tail.len().is_multiple_of(channels),
+        "planar buffers hold equal-length runs: {} and {} samples cannot both split into {} channels",
+        carried.len(),
+        tail.len(),
+        channels
+    );
+    let carried_frames = carried.len() / channels;
+    let tail_frames = tail.len() / channels;
+    let mut spliced = Vec::with_capacity(carried.len() + tail.len());
+    for channel in 0..channels {
+        spliced
+            .extend_from_slice(&carried[channel * carried_frames..(channel + 1) * carried_frames]);
+        spliced.extend_from_slice(&tail[channel * tail_frames..(channel + 1) * tail_frames]);
+    }
+    *carried = spliced;
+}
+
+/// Rearrange interleaved frames into the planar layout the chain runs inside:
+/// one contiguous run per channel. Pushed once at the head of the `normalize`
+/// segment when more than one channel continues past the channel stage; a
+/// chain carrying one channel builds no rearrangement, the two layouts being
+/// the same arrangement there. The count passes through unchanged.
+struct Deinterleave;
+
+impl Stage for Deinterleave {
+    fn process(&mut self, input: Block<'_>, out: &mut Vec<f32>) -> Result<(), DecibriError> {
+        deinterleave_into(input.samples(), input.channels(), out);
+        Ok(())
+    }
+}
+
+/// Resample planar audio from the device's native rate to the requested target
+/// rate: one owned [`PolyphaseResampler`] per carried channel, each engine
+/// processing its channel's contiguous run.
 ///
 /// [`build_capture_stage`] adds this stage only when the native and target
 /// rates differ; a device already at the target rate omits it. It is placed
-/// after [`Downmix`] in the chain so the resampler receives mono, the format it
-/// expects.
-struct ResampleStage(PolyphaseResampler);
+/// after the channel stage (and [`Deinterleave`]) in the chain, so each engine
+/// receives one channel's run, the mono stream its documented contract
+/// requires. Every engine is constructed from the same rate pair, so the
+/// engine choice, the coefficient table and the group delay are identical
+/// across channels, and equal-length input runs yield equal-length output
+/// runs on every call: the emission cadence is a function of the rate pair
+/// and the count of samples fed, never of their values.
+struct ResampleStage {
+    /// One engine per carried channel, index i processing planar run i. The
+    /// length is resolved at chain build time; no fixed maximum exists.
+    engines: Vec<PolyphaseResampler>,
+}
+
+impl ResampleStage {
+    /// Build `channels` engines for the `native_rate` to `target_rate` pair.
+    /// Construction validates the rate pair once per engine, identically; the
+    /// `?` bridges a failure to `DecibriError::ResampleConfigInvalid` via
+    /// `From<ResamplerError>`.
+    fn new(native_rate: u32, target_rate: u32, channels: u16) -> Result<Self, DecibriError> {
+        let engines = (0..channels.max(1))
+            .map(|_| PolyphaseResampler::new(native_rate, target_rate))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self { engines })
+    }
+}
 
 impl Stage for ResampleStage {
     fn process(&mut self, input: Block<'_>, out: &mut Vec<f32>) -> Result<(), DecibriError> {
-        // The wrapped engine is mono by documented contract, and reading an
-        // interleaved block as one time series would filter across channels
-        // rather than along each. Stated here rather than assumed, so a chain
-        // that ever hands this stage more than one channel says so.
+        // The count the stage was built for and the count the block carries are
+        // the same number reaching it by two routes, exactly as for `Downmix`
+        // and `Select`. A block at another count would hand at least one engine
+        // a run that is not one channel's samples.
         debug_assert_eq!(
-            input.channels(),
-            1,
-            "the resampler requires mono, got {} channels",
+            input.channels() as usize,
+            self.engines.len(),
+            "the resampler was built for {} channels and handed {}",
+            self.engines.len(),
             input.channels()
         );
-        // The resampler appends to `out`. Its one steady-path error rejects a
-        // block that arrives after the flush; the callers stop feeding a flushed
-        // chain, so it is propagated rather than assumed away.
-        self.0.process(input.samples(), out)?;
+        // Each engine appends its channel's output; equal-length runs in yield
+        // equal-length runs out, which is what keeps the planar layout valid
+        // downstream. The one steady-path error rejects a block that arrives
+        // after the flush; the callers stop feeding a flushed chain, so it is
+        // propagated rather than assumed away, and it strikes every engine at
+        // the same call or none.
+        let frames = input.frames();
+        let mut emitted = None;
+        for (channel, engine) in self.engines.iter_mut().enumerate() {
+            let before = out.len();
+            engine.process(
+                &input.samples()[channel * frames..(channel + 1) * frames],
+                out,
+            )?;
+            let count = out.len() - before;
+            debug_assert!(
+                emitted.is_none_or(|e: usize| e == count),
+                "identical engines fed equal-length runs emit equal-length runs"
+            );
+            emitted = Some(count);
+        }
         Ok(())
     }
 
     fn flush(&mut self, out: &mut Vec<f32>) -> Result<(), DecibriError> {
-        // Drain the resampler's group-delay tail (and any partial-frame carry)
-        // into `out`. Called once at close; the resampler appends and is
-        // infallible, so wrap it as `Ok(())`.
-        self.0.flush(out);
+        // Drain each engine's group-delay tail (and any partial-frame carry)
+        // into `out`, in channel order, so the appended tail is planar like
+        // every processed block. Called once at close; the engines append and
+        // are infallible, so wrap it as `Ok(())`. Identical engines hold
+        // identical-length tails, which the assertion states.
+        let mut emitted = None;
+        for engine in self.engines.iter_mut() {
+            let before = out.len();
+            engine.flush(out);
+            let count = out.len() - before;
+            debug_assert!(
+                emitted.is_none_or(|e: usize| e == count),
+                "identical engines hold equal-length tails"
+            );
+            emitted = Some(count);
+        }
         Ok(())
     }
 
     fn latency_samples(&self) -> usize {
-        // Forward the resampler's own group delay. It is already expressed at
-        // the output rate, and is zero when the rates match and the resampler is
-        // a passthrough.
-        self.0.latency_samples()
+        // Forward one engine's group delay: every engine is constructed from
+        // the same rate pair, so the figure is identical across channels and
+        // the channels stay aligned. It is already expressed at the output
+        // rate, and is zero when the rates match and the engine is a
+        // passthrough.
+        self.engines
+            .first()
+            .map_or(0, |engine| engine.latency_samples())
     }
 }
 
@@ -812,8 +947,8 @@ impl Stage for AecStage {
 }
 
 /// A same-length DSP step: filters a buffer of samples in place, producing
-/// exactly as many output samples as it received. The adapter [`InPlace`] wraps
-/// any `InPlaceDsp` as a [`Stage`].
+/// exactly as many output samples as it received. The adapter [`PerChannel`]
+/// wraps any `InPlaceDsp` as a [`Stage`], one instance per channel.
 ///
 /// `Send` so the wrapped step can live behind the stream's `Mutex`, matching the
 /// [`Stage`] bound. `pub(crate)` so a stage authored in another module (the
@@ -824,31 +959,86 @@ pub(crate) trait InPlaceDsp: Send {
     fn process_in_place(&mut self, samples: &mut [f32]);
 }
 
-/// Adapts an [`InPlaceDsp`] to the [`Stage`] interface. `process` copies the
-/// input into `out` then filters it in place, so the output length equals the
-/// input length; `flush` keeps the [`Stage`] default no-op, since a same-length
-/// DSP holds no end-of-stream tail.
-struct InPlace<T: InPlaceDsp>(T);
+/// Adapts an [`InPlaceDsp`] to the [`Stage`] interface over any channel count:
+/// one wrapped instance per channel, each filtering its own planar run in
+/// place, so the recursive state every `InPlaceDsp` carries (the DC blocker's
+/// and biquad's filter memory) advances along one channel and never across
+/// two. The output length equals the input length; `flush` keeps the
+/// [`Stage`] default no-op, since a same-length DSP holds no end-of-stream
+/// tail.
+struct PerChannel<T: InPlaceDsp> {
+    /// One instance per channel, index i filtering planar run i. The length is
+    /// resolved at chain build time; no fixed maximum exists.
+    instances: Vec<T>,
+}
 
-impl<T: InPlaceDsp> Stage for InPlace<T> {
+impl<T: InPlaceDsp> PerChannel<T> {
+    /// One `instance()` per channel. A count of zero is floored to one, as
+    /// [`Block::new`] floors its channel count.
+    fn new(channels: u16, instance: impl Fn() -> T) -> Self {
+        Self {
+            instances: (0..channels.max(1)).map(|_| instance()).collect(),
+        }
+    }
+}
+
+impl<T: InPlaceDsp> Stage for PerChannel<T> {
     fn process(&mut self, input: Block<'_>, out: &mut Vec<f32>) -> Result<(), DecibriError> {
-        // Every `InPlaceDsp` behind this wrapper carries recursive state across
-        // samples (the DC blocker's and biquad's filter memory, the level
-        // control's and limiter's gain estimate), and a flat pass over an
-        // interleaved block would run that state across channels rather than
-        // along each. Stated here rather than assumed, so a chain that ever
-        // hands this wrapper more than one channel says so.
+        // The count the wrapper was built for and the count the block carries
+        // are the same number reaching it by two routes, exactly as for
+        // `Downmix` and `Select`. A block at another count would hand at least
+        // one instance a run that is not one channel's samples, filtering its
+        // recursive state across a channel boundary.
         debug_assert_eq!(
-            input.channels(),
-            1,
-            "the scalar in-place wrapper requires mono, got {} channels",
+            input.channels() as usize,
+            self.instances.len(),
+            "the per-channel wrapper was built for {} channels and handed {}",
+            self.instances.len(),
             input.channels()
         );
+        let frames = input.frames();
+        debug_assert_eq!(
+            input.len(),
+            frames * self.instances.len(),
+            "a planar block holds equal-length runs"
+        );
         // The caller clears `out` first, so this is an exact-length copy of the
-        // input that the DSP then rewrites in place: one input sample, one output
-        // sample.
+        // input that each instance then rewrites in place over its own run: one
+        // input sample, one output sample.
         out.extend_from_slice(input.samples());
-        self.0.process_in_place(out);
+        for (channel, instance) in self.instances.iter_mut().enumerate() {
+            instance.process_in_place(&mut out[channel * frames..(channel + 1) * frames]);
+        }
+        Ok(())
+    }
+}
+
+/// A same-length DSP step whose detection runs across channels: filters a
+/// planar buffer in place, reading each frame across every channel and
+/// applying one shared gain to all of them, the length unchanged. The adapter
+/// [`Linked`] wraps any `LinkedDsp` as a [`Stage`].
+///
+/// `Send` for the same reason as [`InPlaceDsp`]; `pub(crate)` so the engines
+/// authored in [`crate::gain`] can implement it.
+pub(crate) trait LinkedDsp: Send {
+    /// Filter `planar` in place: `channels` contiguous equal-length runs, one
+    /// detector reading per frame across the channels, one gain applied to
+    /// every channel of that frame.
+    fn process_planar(&mut self, planar: &mut [f32], channels: u16);
+}
+
+/// Adapts a [`LinkedDsp`] to the [`Stage`] interface. `process` copies the
+/// input into `out` then filters it in place at the block's own channel
+/// count, so the output length equals the input length; `flush` keeps the
+/// [`Stage`] default no-op. The wrapped engine holds one detector and one
+/// gain whatever the count, so no per-instance count is stored; the chain's
+/// resolved-count assertions in the walks hold the count steady.
+struct Linked<T: LinkedDsp>(T);
+
+impl<T: LinkedDsp> Stage for Linked<T> {
+    fn process(&mut self, input: Block<'_>, out: &mut Vec<f32>) -> Result<(), DecibriError> {
+        out.extend_from_slice(input.samples());
+        self.0.process_planar(out, input.channels());
         Ok(())
     }
 }
@@ -859,7 +1049,8 @@ impl<T: InPlaceDsp> Stage for InPlace<T> {
 /// below 1 so the corner sits close to DC.
 ///
 /// Same-length and sample-by-sample (one input sample yields one output sample),
-/// so it is an [`InPlaceDsp`] driven through [`InPlace`]. The filter memory
+/// so it is an [`InPlaceDsp`] driven through [`PerChannel`], one instance per
+/// carried channel. The filter memory
 /// (`x_prev`, `y_prev`) carries across blocks, so the response is continuous at
 /// chunk boundaries; it holds no end-of-stream tail, so it keeps the default
 /// no-op flush.
@@ -903,7 +1094,7 @@ impl InPlaceDsp for DcBlocker {
 /// higher-cornered filter than the always-near-DC [`DcBlocker`].
 ///
 /// Same-length and sample-by-sample (one input sample yields one output
-/// sample), so it is an [`InPlaceDsp`] driven through [`InPlace`], the same
+/// sample), so it is an [`InPlaceDsp`] driven through [`PerChannel`], the same
 /// wrapper the [`DcBlocker`] uses. It runs as a Direct Form II Transposed
 /// section carrying two state samples (`z1`, `z2`) across blocks, so the
 /// response is continuous at chunk boundaries; it holds no end-of-stream tail,
@@ -1038,7 +1229,7 @@ impl CaptureStage {
     /// nothing), and only the conditioned path pays for it: an unconditioned capture
     /// has no chain, so it keeps its zero-cost direct delivery.
     pub(crate) fn run(&mut self, input: &[f32]) -> Result<&[f32], DecibriError> {
-        self.run_normalize(input)?;
+        self.run_normalize_planar(input)?;
         self.capture_tap();
         let mut channels = self.tap_channels;
         Self::run_segment(
@@ -1052,11 +1243,12 @@ impl CaptureStage {
             "the chain walk ended at {} channels but the chain declares {}",
             channels, self.output_channels
         );
+        self.reinterleave_work(self.output_channels);
         Ok(&self.work)
     }
 
     /// Run one native block through the `normalize` segment alone, returning
-    /// the post-`normalize`, pre-`transform` signal.
+    /// the post-`normalize`, pre-`transform` signal, interleaved.
     ///
     /// Seeds and sanitizes `work` exactly as [`run`](Self::run) does, then
     /// ping-pongs it across the `normalize` stages only. The returned slice is
@@ -1064,6 +1256,16 @@ impl CaptureStage {
     /// caller that reads the pre-`transform` signal and never delivers the
     /// conditioned output takes this instead of a full [`run`](Self::run).
     pub(crate) fn run_normalize(&mut self, input: &[f32]) -> Result<&[f32], DecibriError> {
+        self.run_normalize_planar(input)?;
+        self.reinterleave_work(self.tap_channels);
+        Ok(&self.work)
+    }
+
+    /// The shared body of [`run`](Self::run) and
+    /// [`run_normalize`](Self::run_normalize): seed and sanitize `work`, then
+    /// walk the `normalize` stages, leaving `work` in the chain's internal
+    /// layout at [`tap_channels`](Self::tap_channels).
+    fn run_normalize_planar(&mut self, input: &[f32]) -> Result<(), DecibriError> {
         self.work.clear();
         self.work.extend_from_slice(input);
         for sample in self.work.iter_mut() {
@@ -1083,17 +1285,38 @@ impl CaptureStage {
             "the normalize walk ended at {} channels but the chain declares {}",
             channels, self.tap_channels
         );
-        Ok(&self.work)
+        Ok(())
+    }
+
+    /// Convert `work` from the chain's internal planar layout back to
+    /// interleaved frames at `channels`, via `scratch`. A no-op at one
+    /// channel, where the two layouts are the same arrangement. Every signal
+    /// that leaves the chain passes through this: the delivered output, the
+    /// post-`normalize` return, and (through [`capture_tap`](Self::capture_tap))
+    /// the detector tap.
+    fn reinterleave_work(&mut self, channels: u16) {
+        if channels > 1 {
+            self.scratch.clear();
+            interleave_into(&self.work, channels, &mut self.scratch);
+            std::mem::swap(&mut self.work, &mut self.scratch);
+        }
     }
 
     /// Snapshot `work` (the post-`normalize`, pre-`transform` signal) into `tap`,
     /// but only when `transform` is non-empty. With no transform the delivered
     /// output already is this signal, so nothing is captured and `tap` stays empty
-    /// (zero overhead on the no-transform path).
+    /// (zero overhead on the no-transform path). The tap crosses the chain
+    /// boundary to the detector, so it is interleaved like every delivery;
+    /// `MicrophoneStream::detector_feed` collapses it as interleaved frames at
+    /// [`tap_channels`](Self::tap_channels).
     fn capture_tap(&mut self) {
         if !self.transform.is_empty() {
             self.tap.clear();
-            self.tap.extend_from_slice(&self.work);
+            if self.tap_channels > 1 {
+                interleave_into(&self.work, self.tap_channels, &mut self.tap);
+            } else {
+                self.tap.extend_from_slice(&self.work);
+            }
         }
     }
 
@@ -1135,7 +1358,7 @@ impl CaptureStage {
     pub(crate) fn flush(&mut self, out: &mut Vec<f32>) -> Result<(), DecibriError> {
         // `work` is carried unbroken from the `normalize` walk into the
         // `transform` walk.
-        self.flush_normalize()?;
+        self.flush_normalize_planar()?;
         // Capture the post-`normalize` tail (the resampler's group-delay tail)
         // before it passes through `transform`, so the tap stays aligned with the
         // delivered output across the close path too.
@@ -1152,17 +1375,29 @@ impl CaptureStage {
             "the chain flush ended at {} channels but the chain declares {}",
             channels, self.output_channels
         );
+        self.reinterleave_work(self.output_channels);
         out.extend_from_slice(&self.work);
         Ok(())
     }
 
-    /// Drain the `normalize` segment's end-of-stream tail alone, returning it.
+    /// Drain the `normalize` segment's end-of-stream tail alone, returning it
+    /// interleaved.
     ///
     /// The counterpart of [`run_normalize`](Self::run_normalize) on the close
     /// path: the resampler's group-delay tail, before it passes through
-    /// `transform`. `work` starts empty because there is no new input at end of
-    /// stream, only each stage's drained tail.
+    /// `transform`.
     pub(crate) fn flush_normalize(&mut self) -> Result<&[f32], DecibriError> {
+        self.flush_normalize_planar()?;
+        self.reinterleave_work(self.tap_channels);
+        Ok(&self.work)
+    }
+
+    /// The shared body of [`flush`](Self::flush) and
+    /// [`flush_normalize`](Self::flush_normalize): walk the `normalize`
+    /// stages' tails, leaving `work` in the chain's internal layout at
+    /// [`tap_channels`](Self::tap_channels). `work` starts empty because there
+    /// is no new input at end of stream, only each stage's drained tail.
+    fn flush_normalize_planar(&mut self) -> Result<(), DecibriError> {
         self.work.clear();
         let mut channels = self.input_channels;
         Self::flush_segment(
@@ -1176,7 +1411,7 @@ impl CaptureStage {
             "the normalize flush ended at {} channels but the chain declares {}",
             channels, self.tap_channels
         );
-        Ok(&self.work)
+        Ok(())
     }
 
     /// The post-`normalize`, pre-`transform` signal captured by the most recent
@@ -1243,8 +1478,16 @@ impl CaptureStage {
     ///
     /// `channels` is the running channel count, advanced past each stage exactly
     /// as [`run_segment`](Self::run_segment) advances it. A stage's drained tail
-    /// is interleaved at that stage's OUTPUT count, so the count advances once
+    /// is laid out at that stage's OUTPUT count, so the count advances once
     /// per stage, after both the carried block and the tail have been written.
+    ///
+    /// At one emitted channel a stage's own tail is appended directly after the
+    /// processed carry, which continues the one run. Above one, the tail
+    /// continues EACH channel's run, so the two planar buffers are spliced run
+    /// by run instead of appended whole; an appended whole tail would land
+    /// channel 0's tail inside channel 0's neighbour and shift every later run.
+    /// The splice allocates, which the close path (this walk's only caller)
+    /// pays once per stream.
     fn flush_segment(
         work: &mut Vec<f32>,
         scratch: &mut Vec<f32>,
@@ -1257,7 +1500,15 @@ impl CaptureStage {
             if !work.is_empty() {
                 stage.process(Block::new(work, *channels), scratch)?;
             }
-            stage.flush(scratch)?;
+            if emitted > 1 {
+                let mut tail = Vec::new();
+                stage.flush(&mut tail)?;
+                if !tail.is_empty() {
+                    splice_planar_tail(scratch, &tail, emitted);
+                }
+            } else {
+                stage.flush(scratch)?;
+            }
             *channels = emitted;
             std::mem::swap(work, scratch);
         }
@@ -1315,9 +1566,12 @@ pub(crate) struct Transforms<'a> {
 /// Pushes [`Select`] when `channel_map` names a map (gathering the named
 /// device channels, in the order given), otherwise [`Downmix`] when the device
 /// delivers more channels than the output target (averaging down to the
-/// target, which is mono here), then
+/// target, which is mono here), then [`Deinterleave`] when more than one
+/// channel continues past that point (rearranging the block into the planar
+/// layout the rest of the chain runs in), then
 /// [`ResampleStage`] when the device's `native_rate` differs from `target_rate`
-/// (converting the captured audio to the requested rate), then the
+/// (converting the captured audio to the requested rate, one engine per
+/// carried channel), then the
 /// [`AecStage`] when `aec` names settings (and the `aec` feature is compiled
 /// in), last in the `normalize` segment so the canceller receives mono at the
 /// target rate and the VAD tap carries the echo-removed signal. When `dc_removal` is
@@ -1333,7 +1587,10 @@ pub(crate) struct Transforms<'a> {
 /// [`crate::gain::Limiter`] stage last, immediately after the level control
 /// (also when the `gain` feature is compiled in), so it catches any peak the
 /// upstream level control would let through. All transform stages run after
-/// `normalize` on the mono signal at the target rate.
+/// `normalize` on the delivered channels at the target rate: the two filters
+/// through [`PerChannel`] with one instance per channel, the denoise stage
+/// with one cache set per channel, and the two gain stages through [`Linked`]
+/// with one detector across the channels and one gain applied to all.
 /// Returns `Some(chain)` when at least one stage is needed and `None` when no
 /// segment has any (a mono device already at the target rate with no enhancement
 /// enabled), leaving the capture path on its direct, zero-cost reblock.
@@ -1385,13 +1642,28 @@ pub(crate) fn build_capture_stage(
         None => {}
     }
 
+    // The count carried past the channel stage, resolved by walking what was
+    // actually built, exactly as the segment counts below are. When it is
+    // above one, the block is rearranged into the planar layout here, once,
+    // at the head of the chain; at one channel the two layouts coincide and
+    // no stage is built.
+    let chain_channels = normalize.iter().fold(device_channels, |channels, stage| {
+        stage.output_channels(channels)
+    });
+    if chain_channels > 1 {
+        normalize.push(Box::new(Deinterleave));
+    }
+
     if native_rate != target_rate {
-        // The channel stage (Select or Downmix, if any) ran first, so the
-        // resampler receives mono.
+        // The channel stage (Select or Downmix, if any) ran first, so each
+        // engine receives one channel's run.
         // Construction validates the rate pair; the `?` bridges a failure to
         // DecibriError::ResampleConfigInvalid via From<ResamplerError>.
-        let resampler = PolyphaseResampler::new(native_rate, target_rate)?;
-        normalize.push(Box::new(ResampleStage(resampler)));
+        normalize.push(Box::new(ResampleStage::new(
+            native_rate,
+            target_rate,
+            chain_channels,
+        )?));
     }
 
     // Echo cancellation runs LAST in the normalize segment, after the downmix
@@ -1405,15 +1677,25 @@ pub(crate) fn build_capture_stage(
         normalize.push(Box::new(AecStage::new(settings, target_rate)?));
     }
 
+    // Resolve the channel count the `normalize` segment ends at by asking the
+    // stages that were actually built, in the order they run. Named nowhere: a
+    // count written here as a literal would agree with the stages today and
+    // stop agreeing the moment a stage that changes the count is added or
+    // removed. The transform stages below are built at this count.
+    let tap_channels = normalize.iter().fold(device_channels, |channels, stage| {
+        stage.output_channels(channels)
+    });
+
     let mut transform: Vec<Box<dyn Stage>> = Vec::new();
 
     if dc_removal {
-        // Runs after `normalize`, on the mono signal at the target rate.
-        transform.push(Box::new(InPlace(DcBlocker::new())));
+        // Runs after `normalize`, on the delivered channels at the target
+        // rate: one filter instance per channel, each over its own run.
+        transform.push(Box::new(PerChannel::new(tap_channels, DcBlocker::new)));
     }
 
     // Denoise runs immediately AFTER DC removal (chain order: DcRemoval ->
-    // Denoise), on the DC-blocked mono signal at the target rate. The order is
+    // Denoise), on the DC-blocked signal at the target rate. The order is
     // load-bearing (denoise wants a clean-rate, DC-free input) and is pinned by
     // this push order and `build_orders_denoise_after_dc`. Unlike the same-length
     // DcBlocker, denoise is framed and latency-introducing, so it sits in the
@@ -1424,6 +1706,7 @@ pub(crate) fn build_capture_stage(
             model,
             path,
             ort_library_path,
+            tap_channels,
         )?));
     }
     // Without the `denoise` feature the parameter is accepted but unused.
@@ -1432,25 +1715,25 @@ pub(crate) fn build_capture_stage(
 
     // High-pass (user rumble cut) runs immediately AFTER denoise (chain order:
     // Denoise -> HighPass), so the denoise model receives near-full-band input.
-    // It is a same-length, sample-in-sample-out biquad, so it wraps via `InPlace`
-    // exactly like the DC blocker and adds no latency. The cutoff comes from the
-    // named variant, not a magic number here.
+    // It is a same-length, sample-in-sample-out biquad, so it wraps via
+    // `PerChannel` exactly like the DC blocker and adds no latency. The cutoff
+    // comes from the named variant, not a magic number here.
     if let Some(filter) = highpass {
-        transform.push(Box::new(InPlace(Biquad::highpass(
-            filter.cutoff_hz(),
-            target_rate as f32,
-        ))));
+        transform.push(Box::new(PerChannel::new(tap_channels, || {
+            Biquad::highpass(filter.cutoff_hz(), target_rate as f32)
+        })));
     }
 
     // Level control (AGC) runs after high-pass, reserving the slot that sits
-    // before the limiter in the full chain order. It is a same-length,
-    // sample-in-sample-out engine, so it wraps via `InPlace` like the DC blocker
-    // and high-pass and adds no latency. Gated on the `gain` feature, like
+    // before the limiter in the full chain order. It is a same-length engine
+    // whose detection runs linked across the channels (one detector, one gain
+    // applied to all, so the inter-channel balance is preserved), so it wraps
+    // via `Linked` and adds no latency. Gated on the `gain` feature, like
     // denoise is gated on `denoise`; without the feature the target is accepted
     // but unused.
     #[cfg(feature = "gain")]
     if let Some(target_db) = agc {
-        transform.push(Box::new(InPlace(crate::gain::LevelControl::agc(
+        transform.push(Box::new(Linked(crate::gain::LevelControl::agc(
             target_db,
             target_rate,
         ))));
@@ -1460,13 +1743,14 @@ pub(crate) fn build_capture_stage(
 
     // The limiter runs LAST in the transform tier, immediately after the level
     // control, so it catches any peak the upstream gain would let exceed the
-    // ceiling. It is a same-length, sample-in-sample-out stage, so it wraps via
-    // `InPlace` like the level control and adds no latency. Gated on the same
-    // `gain` feature as the level-control engine (the pair); without the feature
-    // the ceiling is accepted but unused. Nothing runs after it.
+    // ceiling. It is a same-length stage detecting linked across the channels
+    // like the level control, so it wraps via `Linked` and adds no latency.
+    // Gated on the same `gain` feature as the level-control engine (the pair);
+    // without the feature the ceiling is accepted but unused. Nothing runs
+    // after it.
     #[cfg(feature = "gain")]
     if let Some(ceiling_db) = limiter {
-        transform.push(Box::new(InPlace(crate::gain::Limiter::new(
+        transform.push(Box::new(Linked(crate::gain::Limiter::new(
             ceiling_db,
             target_rate,
         ))));
@@ -1474,13 +1758,6 @@ pub(crate) fn build_capture_stage(
     #[cfg(not(feature = "gain"))]
     let _ = limiter;
 
-    // Resolve the channel count each segment ends at by asking the stages that
-    // were actually built, in the order they run. Named nowhere: a count written
-    // here as a literal would agree with the stages today and stop agreeing the
-    // moment a stage that changes the count is added or removed.
-    let tap_channels = normalize.iter().fold(device_channels, |channels, stage| {
-        stage.output_channels(channels)
-    });
     let output_channels = transform.iter().fold(tap_channels, |channels, stage| {
         stage.output_channels(channels)
     });
@@ -1933,6 +2210,420 @@ mod tests {
             out, expected,
             "the chain equals resampling the selected channel alone"
         );
+    }
+
+    // ── The planar carriage (multichannel through the chain) ────────────
+    //
+    // No production configuration reaches these paths while the accepted
+    // channel count is 1, so these tests are the only thing exercising them:
+    // the planar rearrangement pair, the per-channel and linked wrappers, the
+    // per-channel resampler engines, and the flush splice. Each drives the
+    // machinery directly or through `build_capture_stage` with a target above
+    // one.
+
+    /// The rearrangement pair is exact: deinterleave then interleave returns
+    /// the original buffer bit for bit, at counts that do not divide common
+    /// block sizes and at `u16::MAX`. A trailing partial frame is truncated by
+    /// the deinterleave, matching `Block::frames` and the downmix.
+    #[test]
+    fn deinterleave_and_interleave_round_trip_exactly() {
+        for (channels, frames) in [(2u16, 53usize), (3, 53), (5, 7), (7, 160), (48, 3)] {
+            let interleaved: Vec<f32> = (0..frames)
+                .flat_map(|frame| {
+                    (0..channels).map(move |channel| channel as f32 + frame as f32 * 0.001)
+                })
+                .collect();
+            let mut planar = Vec::new();
+            deinterleave_into(&interleaved, channels, &mut planar);
+            assert_eq!(planar.len(), interleaved.len());
+            // Run i holds channel i's samples in frame order.
+            for channel in 0..channels as usize {
+                for frame in 0..frames {
+                    assert_eq!(
+                        planar[channel * frames + frame],
+                        interleaved[frame * channels as usize + channel],
+                        "channel {channel} frame {frame} lands in its run"
+                    );
+                }
+            }
+            let mut back = Vec::new();
+            interleave_into(&planar, channels, &mut back);
+            assert_eq!(
+                back, interleaved,
+                "the round trip is exact at {channels} channels"
+            );
+        }
+
+        // The count is bounded only by its type: the pair round-trips at
+        // `u16::MAX`. A fixed maximum added to either function fails here.
+        let channels = u16::MAX;
+        let interleaved: Vec<f32> = (0..2usize)
+            .flat_map(|frame| (0..channels).map(move |channel| channel as f32 + frame as f32 * 0.5))
+            .collect();
+        let mut planar = Vec::new();
+        deinterleave_into(&interleaved, channels, &mut planar);
+        let mut back = Vec::new();
+        interleave_into(&planar, channels, &mut back);
+        assert_eq!(
+            back, interleaved,
+            "the round trip is exact at u16::MAX channels"
+        );
+
+        // A trailing partial frame is dropped, not misread as a whole one.
+        let mut truncated = Vec::new();
+        deinterleave_into(&[1.0, 2.0, 3.0, 4.0, 5.0], 2, &mut truncated);
+        assert_eq!(
+            truncated,
+            &[1.0, 3.0, 2.0, 4.0],
+            "the partial frame is truncated, matching Block::frames"
+        );
+    }
+
+    /// `PerChannel` applies the wrapped stage to every channel independently:
+    /// each channel's output equals a fresh single-channel engine run over
+    /// that channel alone, bit for bit, across block boundaries. The channels
+    /// carry unmistakably different content (a sine, exact silence, a
+    /// constant offset), so a stride or offset error that mixes recursive
+    /// state across channels breaks the equality rather than passing
+    /// plausibly.
+    #[test]
+    fn per_channel_runs_the_wrapped_stage_independently() {
+        let frames = 480;
+        let sine: Vec<f32> = (0..2 * frames).map(|n| (n as f32 * 0.05).sin()).collect();
+        let silence = vec![0.0f32; 2 * frames];
+        let offset = vec![0.5f32; 2 * frames];
+
+        // Two consecutive planar blocks, so the per-channel state must carry
+        // across the boundary along each channel.
+        let mut stage = PerChannel::new(3, DcBlocker::new);
+        let mut delivered = Vec::new();
+        for range in [0..frames, frames..2 * frames] {
+            let planar: Vec<f32> = sine[range.clone()]
+                .iter()
+                .chain(&silence[range.clone()])
+                .chain(&offset[range.clone()])
+                .copied()
+                .collect();
+            let mut out = Vec::new();
+            stage
+                .process(Block::new(&planar, 3), &mut out)
+                .expect("the wrapper processes a planar block");
+            assert_eq!(out.len(), planar.len(), "same-length per block");
+            delivered.push(out);
+        }
+
+        // Reference: one fresh engine per channel over that channel alone.
+        for (channel, input) in [(0usize, &sine), (1, &silence), (2, &offset)] {
+            let mut engine = DcBlocker::new();
+            let mut expected = input.to_vec();
+            engine.process_in_place(&mut expected);
+            for (block_index, range) in [0..frames, frames..2 * frames].into_iter().enumerate() {
+                let run = &delivered[block_index][channel * frames..(channel + 1) * frames];
+                assert_eq!(
+                    run, &expected[range],
+                    "channel {channel} equals its own engine, bit for bit (block {block_index})"
+                );
+            }
+        }
+    }
+
+    /// A silent channel stays exactly silent through a full multichannel
+    /// chain (rearrangement, per-channel resampling, per-channel filters,
+    /// flush splice), and the sounding channel is bit-identical to the mono
+    /// chain over its signal alone. This is the per-channel independence
+    /// property at chain scope: a stride bug leaks the sine into the silence
+    /// or the recursive state across the boundary, and either breaks an exact
+    /// assertion here.
+    #[test]
+    fn a_silent_channel_stays_silent_through_the_chain() {
+        let frames = 24_000;
+        let sine: Vec<f32> = (0..frames).map(|n| (n as f32 * 0.01).sin()).collect();
+        let transforms = || Transforms {
+            dc_removal: true,
+            highpass: Some(HighpassFilter::Hz80),
+            ..Default::default()
+        };
+
+        // Stereo device, stereo target: no channel stage, so the chain is
+        // Deinterleave, the two resampler engines, then the per-channel
+        // filters, with the flush splicing each engine's tail onto its own
+        // run.
+        let interleaved: Vec<f32> = sine.iter().flat_map(|&s| [s, 0.0]).collect();
+        let mut chain = build_capture_stage(2, 2, 48_000, 16_000, transforms())
+            .unwrap()
+            .expect("a rate change builds a chain");
+        assert_eq!(chain.output_channels(), 2);
+        let mut delivered = chain.run(&interleaved).expect("the chain runs").to_vec();
+        chain.flush(&mut delivered).expect("the chain flushes");
+
+        // The mono reference: the identical configuration over the sine alone.
+        let mut mono = build_capture_stage(1, 1, 48_000, 16_000, transforms())
+            .unwrap()
+            .expect("the mono chain builds");
+        let mut expected = mono.run(&sine).expect("the mono chain runs").to_vec();
+        mono.flush(&mut expected).expect("the mono chain flushes");
+
+        assert_eq!(
+            delivered.len(),
+            2 * expected.len(),
+            "two delivered channels, one frame per mono sample"
+        );
+        for (frame, &value) in expected.iter().enumerate() {
+            assert_eq!(
+                delivered[2 * frame],
+                value,
+                "frame {frame}: the sounding channel equals the mono chain bit for bit"
+            );
+            assert_eq!(
+                delivered[2 * frame + 1],
+                0.0,
+                "frame {frame}: the silent channel stays exactly silent"
+            );
+        }
+    }
+
+    /// The chain resolves K device channels to a smaller delivered count
+    /// through the gather: each delivered channel equals resampling the
+    /// mapped device channel alone, bit for bit, through run and flush.
+    #[test]
+    fn the_chain_resolves_k_in_to_target_out_through_the_walk() {
+        let frames = 24_000;
+        let a: Vec<f32> = (0..frames).map(|n| (n as f32 * 0.01).sin()).collect();
+        let b: Vec<f32> = (0..frames).map(|n| (n as f32 * 0.02).cos()).collect();
+        // Four device channels; channel 3 carries `a`, channel 0 carries `b`,
+        // the middle two carry distinct decoys.
+        let interleaved: Vec<f32> = (0..frames)
+            .flat_map(|n| [b[n], 0.25, -0.75, a[n]])
+            .collect();
+
+        let map = [3u16, 0];
+        let mut chain = build_capture_stage(
+            4,
+            2,
+            48_000,
+            16_000,
+            Transforms {
+                channel_map: Some(&map),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .expect("a mapped multichannel gather builds a chain");
+        assert_eq!(
+            chain.output_channels(),
+            2,
+            "the map's two delivered channels"
+        );
+        let mut delivered = chain.run(&interleaved).expect("the chain runs").to_vec();
+        chain.flush(&mut delivered).expect("the chain flushes");
+
+        for (channel, source) in [(0usize, &a), (1, &b)] {
+            let mut resampler = PolyphaseResampler::new(48_000, 16_000).unwrap();
+            let mut expected = Vec::new();
+            resampler.process(source, &mut expected).unwrap();
+            resampler.flush(&mut expected);
+            assert_eq!(delivered.len(), 2 * expected.len());
+            for (frame, &value) in expected.iter().enumerate() {
+                assert_eq!(
+                    delivered[2 * frame + channel],
+                    value,
+                    "delivered channel {channel} equals resampling its mapped device channel"
+                );
+            }
+        }
+    }
+
+    /// The tap is interleaved at the post-`normalize` count: with a transform
+    /// present and nothing in `normalize` but the rearrangement, the tap
+    /// equals the original interleaved input bit for bit, which is the layout
+    /// `detector_feed` collapses at `tap_channels`.
+    #[test]
+    fn the_tap_is_interleaved_at_the_post_normalize_count() {
+        let interleaved = [0.1f32, -0.4, 0.2, -0.3, 0.3, -0.2, 0.4, -0.1];
+        let mut chain = build_capture_stage(
+            2,
+            2,
+            16_000,
+            16_000,
+            Transforms {
+                dc_removal: true,
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .expect("a transform builds a chain");
+        assert_eq!(chain.tap_channels(), 2);
+        chain.run(&interleaved).expect("the chain runs");
+        assert_eq!(
+            chain.tap(),
+            &interleaved,
+            "the tap crosses the boundary interleaved, so the pre-transform \
+             snapshot equals the input here"
+        );
+        assert_eq!(
+            sample::downmix_to_mono(chain.tap(), 2),
+            &[
+                (0.1 + -0.4) / 2.0,
+                (0.2 + -0.3) / 2.0,
+                (0.3 + -0.2) / 2.0,
+                (0.4 + -0.1) / 2.0
+            ],
+            "the tap collapses as interleaved frames"
+        );
+    }
+
+    /// The gain tier the builder wires detects across channels: driving a
+    /// stereo chain with one channel at exactly half the other's amplitude
+    /// delivers outputs whose ratio is still exactly one half, sample for
+    /// sample, while the level control materially raises the quiet signal.
+    /// Detection per channel would drive both channels toward the same
+    /// target, erasing the ratio, so this pins the linked wiring.
+    #[cfg(feature = "gain")]
+    #[test]
+    fn the_chain_gain_tier_preserves_inter_channel_balance() {
+        let frames = 16_000;
+        // A quiet but present tone (above the noise floor, below the target).
+        let loud: Vec<f32> = (0..frames)
+            .map(|n| 0.02 * (n as f32 * 0.09).sin())
+            .collect();
+        let interleaved: Vec<f32> = loud.iter().flat_map(|&s| [s, 0.5 * s]).collect();
+
+        let mut chain = build_capture_stage(
+            2,
+            2,
+            16_000,
+            16_000,
+            Transforms {
+                agc: Some(-18),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .expect("a gain chain builds");
+        let delivered = chain.run(&interleaved).expect("the chain runs").to_vec();
+
+        for frame in 0..frames {
+            assert_eq!(
+                delivered[2 * frame + 1],
+                0.5 * delivered[2 * frame],
+                "frame {frame}: one shared gain keeps the exact inter-channel ratio"
+            );
+        }
+        // Not vacuous: the level control moved the quiet signal toward the
+        // target rather than leaving the gain at unity.
+        let tail = &delivered[delivered.len() - 4000..];
+        let input_tail = &interleaved[interleaved.len() - 4000..];
+        let rms = |s: &[f32]| (s.iter().map(|x| x * x).sum::<f32>() / s.len() as f32).sqrt();
+        assert!(
+            rms(tail) > 2.0 * rms(input_tail),
+            "the level control raised the quiet signal materially"
+        );
+    }
+
+    /// The mono chain is byte-identical to composing the engines directly:
+    /// the delivered output of a DC + high-pass + AGC + limiter chain equals
+    /// running the four unchanged engines in sequence over the same blocks.
+    /// The wrappers the builder installs are exactly transparent at one
+    /// channel, which is this change set's safety property on the reachable
+    /// path.
+    #[cfg(feature = "gain")]
+    #[test]
+    fn the_mono_chain_is_byte_identical_to_the_primitive_composition() {
+        let input: Vec<f32> = (0..12_000)
+            .map(|n| 0.3 * (n as f32 * 0.03).sin() + 0.05)
+            .collect();
+        let blocks = [
+            &input[..1000],
+            &input[1000..1001],
+            &input[1001..7321],
+            &input[7321..],
+        ];
+
+        let mut chain = build_capture_stage(
+            1,
+            1,
+            16_000,
+            16_000,
+            Transforms {
+                dc_removal: true,
+                highpass: Some(HighpassFilter::Hz80),
+                agc: Some(-18),
+                limiter: Some(-1.0),
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .expect("a transform chain builds");
+        let mut delivered = Vec::new();
+        for block in blocks {
+            delivered.extend_from_slice(chain.run(block).expect("the chain runs"));
+        }
+        chain.flush(&mut delivered).expect("the chain flushes");
+
+        // The reference composition: the same four engines, driven directly.
+        let mut dc = DcBlocker::new();
+        let mut highpass = Biquad::highpass(HighpassFilter::Hz80.cutoff_hz(), 16_000.0);
+        let mut agc = crate::gain::LevelControl::agc(-18, 16_000);
+        let mut limiter = crate::gain::Limiter::new(-1.0, 16_000);
+        let mut expected = Vec::new();
+        for block in blocks {
+            let mut buf = block.to_vec();
+            dc.process_in_place(&mut buf);
+            highpass.process_in_place(&mut buf);
+            agc.process_in_place(&mut buf);
+            limiter.process_in_place(&mut buf);
+            expected.extend_from_slice(&buf);
+        }
+
+        assert_eq!(
+            delivered, expected,
+            "the chain equals the engine composition, bit for bit"
+        );
+    }
+
+    /// Every piece of the planar carriage serves `u16::MAX` channels: the
+    /// negative control for the no-fixed-maximum rule on the paths this
+    /// change adds. A constant, an array-sized state, or a `1..=N` bound
+    /// added to the rearrangement, the per-channel wrapper, or the builder
+    /// fails loudly here.
+    #[test]
+    fn the_planar_carriage_serves_u16_max_channels() {
+        const CHANNELS: u16 = u16::MAX;
+        let frames = 2usize;
+        // Channel c carries [c, c + 0.25]: distinct per channel and per frame.
+        let interleaved: Vec<f32> = (0..frames)
+            .flat_map(|frame| (0..CHANNELS).map(move |c| c as f32 + frame as f32 * 0.25))
+            .collect();
+
+        let mut chain = build_capture_stage(
+            CHANNELS,
+            CHANNELS,
+            16_000,
+            16_000,
+            Transforms {
+                dc_removal: true,
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .expect("a transform chain builds at the type's full width");
+        assert_eq!(chain.output_channels(), CHANNELS);
+        let delivered = chain.run(&interleaved).expect("the chain runs").to_vec();
+
+        // Each channel equals its own fresh engine, at the top of the range
+        // as at the bottom.
+        for channel in [0u16, 1, 32_767, CHANNELS - 2, CHANNELS - 1] {
+            let mut engine = DcBlocker::new();
+            let mut expected = vec![channel as f32, channel as f32 + 0.25];
+            engine.process_in_place(&mut expected);
+            for frame in 0..frames {
+                assert_eq!(
+                    delivered[frame * CHANNELS as usize + channel as usize],
+                    expected[frame],
+                    "channel {channel} frame {frame} is served at full width"
+                );
+            }
+        }
     }
 
     /// A non-target native rate yields a resample chain whose output tracks the
@@ -2395,7 +3086,7 @@ mod tests {
     #[test]
     fn dc_stage_is_send() {
         fn assert_send<T: Send>() {}
-        assert_send::<InPlace<DcBlocker>>();
+        assert_send::<PerChannel<DcBlocker>>();
     }
 
     // ── Denoise (framed transform) ──────────────────────────────────────
@@ -2727,7 +3418,7 @@ mod tests {
             expected > 0,
             "downsampling 48k -> 16k has a nonzero group delay"
         );
-        let stage = ResampleStage(PolyphaseResampler::new(48_000, 16_000).unwrap());
+        let stage = ResampleStage::new(48_000, 16_000, 1).unwrap();
         assert_eq!(
             stage.latency_samples(),
             expected,
@@ -2735,7 +3426,7 @@ mod tests {
         );
 
         // An identity resampler forwards zero.
-        let identity = ResampleStage(PolyphaseResampler::new(16_000, 16_000).unwrap());
+        let identity = ResampleStage::new(16_000, 16_000, 1).unwrap();
         assert_eq!(
             identity.latency_samples(),
             0,
@@ -2793,7 +3484,7 @@ mod tests {
     // ── High-pass (same-length biquad transform) ────────────────────────
     //
     // The high-pass is a second-order Butterworth biquad: a same-length,
-    // sample-in-sample-out `InPlace` stage (like the DC blocker) that runs after
+    // sample-in-sample-out `PerChannel` stage (like the DC blocker) that runs after
     // denoise in the transform segment. These cover its magnitude response, its
     // cross-block state continuity, that it builds no stage when off, its chain
     // placement, and its zero latency.
@@ -3100,13 +3791,13 @@ mod tests {
         );
     }
 
-    /// `InPlace<Biquad>` is `Send`, so a chain carrying the high-pass in its
+    /// `PerChannel<Biquad>` is `Send`, so a chain carrying the high-pass in its
     /// `transform` segment stays `Send` and can live behind the stream's `Mutex`,
     /// matching the DC blocker.
     #[test]
     fn highpass_stage_is_send() {
         fn assert_send<T: Send>() {}
-        assert_send::<InPlace<Biquad>>();
+        assert_send::<PerChannel<Biquad>>();
     }
 
     /// Chain placement with denoise present: DC removal, then the framed denoise
@@ -3148,8 +3839,8 @@ mod tests {
 
     // ── Level control (AGC, same-length transform) ──────────────────────
     //
-    // AGC is the LevelControl engine driven through `InPlace`, a same-length,
-    // sample-in-sample-out stage like the DC blocker and high-pass. These cover
+    // AGC is the LevelControl engine driven through `Linked`, a same-length
+    // stage whose detection runs across the delivered channels. These cover
     // its chain placement (after high-pass), that it builds no stage when off,
     // that it adds no latency, and that it conditions delivered audio. The
     // engine's temporal behaviour (cold start, convergence, gating) is covered by
@@ -3311,20 +4002,20 @@ mod tests {
         );
     }
 
-    /// `InPlace<LevelControl>` is `Send`, so a chain carrying AGC in its
+    /// `Linked<LevelControl>` is `Send`, so a chain carrying AGC in its
     /// `transform` segment stays `Send` and can live behind the stream's `Mutex`,
     /// matching the DC blocker and high-pass.
     #[cfg(feature = "gain")]
     #[test]
     fn agc_stage_is_send() {
         fn assert_send<T: Send>() {}
-        assert_send::<InPlace<crate::gain::LevelControl>>();
+        assert_send::<Linked<crate::gain::LevelControl>>();
     }
 
     // ── Limiter (same-length transform, last in the chain) ──────────────
     //
-    // The limiter is the Limiter stage driven through `InPlace`, a same-length,
-    // sample-in-sample-out stage like AGC. These cover its chain placement (last,
+    // The limiter is the Limiter stage driven through `Linked`, a same-length
+    // stage detecting across the delivered channels like AGC. These cover its chain placement (last,
     // after AGC), that it builds no stage when off, that it adds no latency, that
     // it caps delivered audio at the ceiling end to end, and that it builds
     // standalone (with AGC off). The stage's own guarantees (the absolute ceiling,
@@ -3491,14 +4182,14 @@ mod tests {
         );
     }
 
-    /// `InPlace<Limiter>` is `Send`, so a chain carrying the limiter in its
+    /// `Linked<Limiter>` is `Send`, so a chain carrying the limiter in its
     /// `transform` segment stays `Send` and can live behind the stream's `Mutex`,
     /// matching the DC blocker, high-pass, and AGC.
     #[cfg(feature = "gain")]
     #[test]
     fn limiter_stage_is_send() {
         fn assert_send<T: Send>() {}
-        assert_send::<InPlace<crate::gain::Limiter>>();
+        assert_send::<Linked<crate::gain::Limiter>>();
     }
 
     // ── Non-finite input guard ──────────────────────────────────────────


### PR DESCRIPTION
- The capture chain deinterleaves after the collapse and re-interleaves at delivery, so every stage between them runs over planar per-channel runs. The detector tap is re-interleaved where it is taken, since it is a delivery.
- PerChannel wraps a per-channel filter with one instance per channel and asserts that the instance count matches the channel count. It replaces InPlace, which is removed.
- ResampleStage holds one engine per channel, sized from the channel count resolved when the chain is built, and asserts equal run lengths.
- Denoise holds one session with one cache set per channel, and applies to every channel of a capture or to none of them.
- The gain tier detects across channels rather than within one: the level control from the frame's mean square, the limiter from the frame's sample peak, with one gain applied to every channel. The hard clamp stays per sample.
- Flush splices run by run, so a drained tail continues the channel it belongs to.
- The chain's delivered channel count is read from the configuration.
- Tests cover rearrangement round trips at counts that do not divide the block size, per-channel independence through run and flush, the chain resolving several channel counts to a target, and the equality of the linked and per-sample gain forms at one channel.