### PR TITLE
chore(deps): bump the bundled ONNX Runtime to 1.28.1 and ort to 2.0.0-rc.13

### DIFF
--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -192,14 +192,15 @@ jobs:
       - name: Get decibri's ort crate api-N baseline
         id: baseline
         run: |
-          # ort 2.0.0-rc.12 defaults to api-24. Hardcoded here to avoid
-          # a second Cargo.toml parse.
+          # ort 2.0.0-rc.13 is pinned with api-28 (the feature list in the
+          # workspace Cargo.toml). Hardcoded here to avoid a second
+          # Cargo.toml parse.
           #
           # IMPORTANT: when upgrading the ort crate, update this number to
           # match the new crate's target api-N. See the maintainer comment
           # in the workspace root Cargo.toml for the full upgrade procedure
           # (step 4 of that comment lists this file explicitly).
-          echo "api_n=24" >> "$GITHUB_OUTPUT"
+          echo "api_n=28" >> "$GITHUB_OUTPUT"
 
       - name: Create or update issue if upstream advanced
         if: steps.pinned.outputs.version != steps.latest.outputs.version
@@ -230,7 +231,7 @@ jobs:
 
           **Review upgrade path:**
           1. Check that the current \`ort\` crate version still supports \`api-${LATEST_MINOR}\` (compare against [ort.pyke.io/setup/multiversion](https://ort.pyke.io/setup/multiversion)).
-          2. Update \`ORT_VERSION\` in \`.github/workflows/publish-npm.yml\`.
+          2. Update \`ORT_VERSION\` and the four \`ORT_SHA256_*\` archive digests in \`.github/workflows/publish-npm.yml\`, \`publish-pypi.yml\` and \`python-ci.yml\`.
           3. Update the \`api_n\` baseline in \`.github/workflows/check-upstream.yml\` if the ort crate was also upgraded.
           4. Trigger \`publish-npm.yml\` manually via workflow_dispatch with \`publish\` left unticked to confirm the new tarball URLs resolve and the bundled dylib loads across all four platforms.${ABI_WARNING}"
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -172,11 +172,12 @@ jobs:
           echo "OK: tarball is available"
 
       - name: Resolve the ONNX Runtime archive digest
-        id: ort-digest
         shell: bash
         # Selects the workflow-level ORT_SHA256_* digest for this platform's
         # archive. Each download step below compares the archive against it
-        # before extracting anything.
+        # before extracting anything. The digest travels to those steps as a
+        # plain environment variable via GITHUB_ENV, not as a step output,
+        # so no run block expands it through the template layer.
         run: |
           case "${{ matrix.ort_platform_slug }}" in
             linux-x64)     SHA256="$ORT_SHA256_LINUX_X64" ;;
@@ -192,7 +193,7 @@ jobs:
             echo "ERROR: the ORT_SHA256_* digest for ${{ matrix.ort_platform_slug }} is empty"
             exit 1
           fi
-          echo "sha256=${SHA256}" >> "$GITHUB_OUTPUT"
+          echo "ORT_SHA256=${SHA256}" >> "$GITHUB_ENV"
           echo "Expected SHA-256: ${SHA256}"
 
       - name: Download and extract ONNX Runtime (macOS)
@@ -202,9 +203,9 @@ jobs:
           URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}.tgz"
           curl -sL --retry 3 --retry-delay 2 -o ort.tgz "$URL"
           ACTUAL=$(shasum -a 256 ort.tgz | cut -d' ' -f1)
-          if [ "$ACTUAL" != "${{ steps.ort-digest.outputs.sha256 }}" ]; then
+          if [ "$ACTUAL" != "$ORT_SHA256" ]; then
             echo "ERROR: SHA-256 mismatch for $URL"
-            echo "  expected: ${{ steps.ort-digest.outputs.sha256 }}"
+            echo "  expected: $ORT_SHA256"
             echo "  actual:   $ACTUAL"
             exit 1
           fi
@@ -231,9 +232,9 @@ jobs:
           URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}.tgz"
           curl -sL --retry 3 --retry-delay 2 -o ort.tgz "$URL"
           ACTUAL=$(sha256sum ort.tgz | cut -d' ' -f1)
-          if [ "$ACTUAL" != "${{ steps.ort-digest.outputs.sha256 }}" ]; then
+          if [ "$ACTUAL" != "$ORT_SHA256" ]; then
             echo "ERROR: SHA-256 mismatch for $URL"
-            echo "  expected: ${{ steps.ort-digest.outputs.sha256 }}"
+            echo "  expected: $ORT_SHA256"
             echo "  actual:   $ACTUAL"
             exit 1
           fi
@@ -254,7 +255,7 @@ jobs:
           $ProgressPreference = 'SilentlyContinue'  # speeds up Invoke-WebRequest
           $url = "https://github.com/microsoft/onnxruntime/releases/download/v$env:ORT_VERSION/onnxruntime-${{ matrix.ort_platform_slug }}-$env:ORT_VERSION.zip"
           Invoke-WebRequest -Uri $url -OutFile ort.zip -MaximumRetryCount 3 -RetryIntervalSec 2
-          $expected = "${{ steps.ort-digest.outputs.sha256 }}"
+          $expected = $env:ORT_SHA256
           $actual = (Get-FileHash -Path ort.zip -Algorithm SHA256).Hash.ToLowerInvariant()
           if ($actual -ne $expected) {
             Write-Host "ERROR: SHA-256 mismatch for $url"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -23,7 +23,17 @@ permissions:
 # Updating this value is step 3 of the ort-crate upgrade procedure
 # documented in the workspace Cargo.toml maintainer comment.
 env:
-  ORT_VERSION: 1.24.4
+  ORT_VERSION: 1.28.1
+  # SHA-256 of each ONNX Runtime release archive downloaded below, as
+  # published beside the asset on its GitHub release page. Every download
+  # step checks its archive against the matching digest before extracting
+  # it and fails on a mismatch. tests/test-ci.js (Group 8g) holds the four
+  # digests in lockstep across publish-npm.yml, publish-pypi.yml and
+  # python-ci.yml.
+  ORT_SHA256_LINUX_X64: 2529aef968d0ad0603365054bc46ebefa7f0fe3bc12f28c5f729c99ddffe2a81
+  ORT_SHA256_LINUX_AARCH64: 53bab9a5c6ae198b7be75663b780c64caa388d30257fac458c71fbff0a82e98e
+  ORT_SHA256_OSX_ARM64: 18c853e5c5deba90e244e1b953a65121f23747ba2c04e6743885caa6ce1ea12f
+  ORT_SHA256_WIN_X64: e46ac7652def5da0e5223372be21185ffff553e0419459f66e0114d460c38162
 
 jobs:
   preflight:
@@ -161,12 +171,43 @@ jobs:
           fi
           echo "OK: tarball is available"
 
+      - name: Resolve the ONNX Runtime archive digest
+        id: ort-digest
+        shell: bash
+        # Selects the workflow-level ORT_SHA256_* digest for this platform's
+        # archive. Each download step below compares the archive against it
+        # before extracting anything.
+        run: |
+          case "${{ matrix.ort_platform_slug }}" in
+            linux-x64)     SHA256="$ORT_SHA256_LINUX_X64" ;;
+            linux-aarch64) SHA256="$ORT_SHA256_LINUX_AARCH64" ;;
+            osx-arm64)     SHA256="$ORT_SHA256_OSX_ARM64" ;;
+            win-x64)       SHA256="$ORT_SHA256_WIN_X64" ;;
+            *)
+              echo "ERROR: no ORT_SHA256_* digest is declared for ${{ matrix.ort_platform_slug }}"
+              exit 1
+              ;;
+          esac
+          if [ -z "$SHA256" ]; then
+            echo "ERROR: the ORT_SHA256_* digest for ${{ matrix.ort_platform_slug }} is empty"
+            exit 1
+          fi
+          echo "sha256=${SHA256}" >> "$GITHUB_OUTPUT"
+          echo "Expected SHA-256: ${SHA256}"
+
       - name: Download and extract ONNX Runtime (macOS)
         if: runner.os == 'macOS'
         shell: bash
         run: |
           URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}.tgz"
           curl -sL --retry 3 --retry-delay 2 -o ort.tgz "$URL"
+          ACTUAL=$(shasum -a 256 ort.tgz | cut -d' ' -f1)
+          if [ "$ACTUAL" != "${{ steps.ort-digest.outputs.sha256 }}" ]; then
+            echo "ERROR: SHA-256 mismatch for $URL"
+            echo "  expected: ${{ steps.ort-digest.outputs.sha256 }}"
+            echo "  actual:   $ACTUAL"
+            exit 1
+          fi
           tar -xzf ort.tgz
           SRC="onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}"
           # Upstream ships libonnxruntime.<version>.dylib; rename to unversioned
@@ -189,10 +230,17 @@ jobs:
         run: |
           URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}.tgz"
           curl -sL --retry 3 --retry-delay 2 -o ort.tgz "$URL"
+          ACTUAL=$(sha256sum ort.tgz | cut -d' ' -f1)
+          if [ "$ACTUAL" != "${{ steps.ort-digest.outputs.sha256 }}" ]; then
+            echo "ERROR: SHA-256 mismatch for $URL"
+            echo "  expected: ${{ steps.ort-digest.outputs.sha256 }}"
+            echo "  actual:   $ACTUAL"
+            exit 1
+          fi
           tar -xzf ort.tgz
           SRC="onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}"
           # cp -L follows the symlink chain (libonnxruntime.so -> .so.1 ->
-          # .so.1.24.4) and copies the real file as libonnxruntime.so. This
+          # .so.1.28.1) and copies the real file as libonnxruntime.so. This
           # avoids repeating the version in the filename. libonnxruntime_
           # providers_shared.so keeps its exact upstream name. The main
           # dylib dlopens it by that basename via $ORIGIN RUNPATH.
@@ -206,6 +254,14 @@ jobs:
           $ProgressPreference = 'SilentlyContinue'  # speeds up Invoke-WebRequest
           $url = "https://github.com/microsoft/onnxruntime/releases/download/v$env:ORT_VERSION/onnxruntime-${{ matrix.ort_platform_slug }}-$env:ORT_VERSION.zip"
           Invoke-WebRequest -Uri $url -OutFile ort.zip -MaximumRetryCount 3 -RetryIntervalSec 2
+          $expected = "${{ steps.ort-digest.outputs.sha256 }}"
+          $actual = (Get-FileHash -Path ort.zip -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actual -ne $expected) {
+            Write-Host "ERROR: SHA-256 mismatch for $url"
+            Write-Host "  expected: $expected"
+            Write-Host "  actual:   $actual"
+            exit 1
+          }
           Expand-Archive -Path ort.zip -DestinationPath .
           $src = "onnxruntime-${{ matrix.ort_platform_slug }}-$env:ORT_VERSION"
           # Upstream DLL is already named onnxruntime.dll. No rename.

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -150,8 +150,10 @@ jobs:
       # Mirrors python-ci.yml lines 178-305 for the host-build paths.
       - name: Compute ORT URL and archive digest
         if: runner.os != 'Linux'
-        id: ort-meta
         shell: bash
+        # The URL and digest travel to the download steps below as plain
+        # environment variables via GITHUB_ENV, not as step outputs, so no
+        # run block expands them through the template layer.
         run: |
           URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}.${{ matrix.ort_ext }}"
           case "${{ matrix.ort_platform_slug }}" in
@@ -166,8 +168,8 @@ jobs:
             echo "ERROR: the ORT_SHA256_* digest for ${{ matrix.ort_platform_slug }} is empty"
             exit 1
           fi
-          echo "url=${URL}" >> "$GITHUB_OUTPUT"
-          echo "sha256=${SHA256}" >> "$GITHUB_OUTPUT"
+          echo "ORT_URL=${URL}" >> "$GITHUB_ENV"
+          echo "ORT_SHA256=${SHA256}" >> "$GITHUB_ENV"
           echo "Resolved: ${URL}"
           echo "Expected SHA-256: ${SHA256}"
 
@@ -179,11 +181,11 @@ jobs:
         # unversioned to match what _ort_resolver.py looks for.
         run: |
           mkdir -p bindings/python/python/decibri/_ort
-          curl -sL --retry 3 --retry-delay 2 -o ort.tgz "${{ steps.ort-meta.outputs.url }}"
+          curl -sL --retry 3 --retry-delay 2 -o ort.tgz "$ORT_URL"
           ACTUAL=$(shasum -a 256 ort.tgz | cut -d' ' -f1)
-          if [ "$ACTUAL" != "${{ steps.ort-meta.outputs.sha256 }}" ]; then
-            echo "ERROR: SHA-256 mismatch for ${{ steps.ort-meta.outputs.url }}"
-            echo "  expected: ${{ steps.ort-meta.outputs.sha256 }}"
+          if [ "$ACTUAL" != "$ORT_SHA256" ]; then
+            echo "ERROR: SHA-256 mismatch for $ORT_URL"
+            echo "  expected: $ORT_SHA256"
             echo "  actual:   $ACTUAL"
             exit 1
           fi
@@ -197,11 +199,11 @@ jobs:
         run: |
           $ProgressPreference = 'SilentlyContinue'
           New-Item -ItemType Directory -Force -Path bindings/python/python/decibri/_ort | Out-Null
-          Invoke-WebRequest -Uri "${{ steps.ort-meta.outputs.url }}" -OutFile ort.zip -MaximumRetryCount 3 -RetryIntervalSec 2
-          $expected = "${{ steps.ort-meta.outputs.sha256 }}"
+          Invoke-WebRequest -Uri $env:ORT_URL -OutFile ort.zip -MaximumRetryCount 3 -RetryIntervalSec 2
+          $expected = $env:ORT_SHA256
           $actual = (Get-FileHash -Path ort.zip -Algorithm SHA256).Hash.ToLowerInvariant()
           if ($actual -ne $expected) {
-            Write-Host "ERROR: SHA-256 mismatch for ${{ steps.ort-meta.outputs.url }}"
+            Write-Host "ERROR: SHA-256 mismatch for $env:ORT_URL"
             Write-Host "  expected: $expected"
             Write-Host "  actual:   $actual"
             exit 1

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -53,7 +53,17 @@ env:
   # .github/workflows/publish-npm.yml (their workflow-level env blocks).
   # Updating ORT requires bumping all three workflows in lockstep per
   # the workspace Cargo.toml maintainer comment.
-  ORT_VERSION: 1.24.4
+  ORT_VERSION: 1.28.1
+  # SHA-256 of each ONNX Runtime release archive downloaded below, as
+  # published beside the asset on its GitHub release page. Every download
+  # step checks its archive against the matching digest before extracting
+  # it and fails on a mismatch. tests/test-ci.js (Group 8g) holds the four
+  # digests in lockstep across publish-npm.yml, publish-pypi.yml and
+  # python-ci.yml.
+  ORT_SHA256_LINUX_X64: 2529aef968d0ad0603365054bc46ebefa7f0fe3bc12f28c5f729c99ddffe2a81
+  ORT_SHA256_LINUX_AARCH64: 53bab9a5c6ae198b7be75663b780c64caa388d30257fac458c71fbff0a82e98e
+  ORT_SHA256_OSX_ARM64: 18c853e5c5deba90e244e1b953a65121f23747ba2c04e6743885caa6ce1ea12f
+  ORT_SHA256_WIN_X64: e46ac7652def5da0e5223372be21185ffff553e0419459f66e0114d460c38162
   # Required for maturin abi3 builds on Python 3.14 hosts targeting py310
   # abi3. See PyO3 issue #5505. Workflow-level setting applies to every
   # matrix entry; no-op on Python 3.10-3.13 hosts.
@@ -138,14 +148,28 @@ jobs:
       # on the host and stage into bindings/python/python/decibri/_ort/
       # before maturin packages it via the [tool.maturin] include directive.
       # Mirrors python-ci.yml lines 178-305 for the host-build paths.
-      - name: Compute ORT URL
+      - name: Compute ORT URL and archive digest
         if: runner.os != 'Linux'
         id: ort-meta
         shell: bash
         run: |
           URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}.${{ matrix.ort_ext }}"
+          case "${{ matrix.ort_platform_slug }}" in
+            osx-arm64) SHA256="$ORT_SHA256_OSX_ARM64" ;;
+            win-x64)   SHA256="$ORT_SHA256_WIN_X64" ;;
+            *)
+              echo "ERROR: no ORT_SHA256_* digest is declared for ${{ matrix.ort_platform_slug }}"
+              exit 1
+              ;;
+          esac
+          if [ -z "$SHA256" ]; then
+            echo "ERROR: the ORT_SHA256_* digest for ${{ matrix.ort_platform_slug }} is empty"
+            exit 1
+          fi
           echo "url=${URL}" >> "$GITHUB_OUTPUT"
+          echo "sha256=${SHA256}" >> "$GITHUB_OUTPUT"
           echo "Resolved: ${URL}"
+          echo "Expected SHA-256: ${SHA256}"
 
       - name: Download and extract ONNX Runtime (macOS)
         if: runner.os == 'macOS'
@@ -156,6 +180,13 @@ jobs:
         run: |
           mkdir -p bindings/python/python/decibri/_ort
           curl -sL --retry 3 --retry-delay 2 -o ort.tgz "${{ steps.ort-meta.outputs.url }}"
+          ACTUAL=$(shasum -a 256 ort.tgz | cut -d' ' -f1)
+          if [ "$ACTUAL" != "${{ steps.ort-meta.outputs.sha256 }}" ]; then
+            echo "ERROR: SHA-256 mismatch for ${{ steps.ort-meta.outputs.url }}"
+            echo "  expected: ${{ steps.ort-meta.outputs.sha256 }}"
+            echo "  actual:   $ACTUAL"
+            exit 1
+          fi
           tar -xzf ort.tgz
           SRC="onnxruntime-${{ matrix.ort_platform_slug }}-${ORT_VERSION}"
           cp -L "$SRC/lib/libonnxruntime.${ORT_VERSION}.dylib" bindings/python/python/decibri/_ort/libonnxruntime.dylib
@@ -167,6 +198,14 @@ jobs:
           $ProgressPreference = 'SilentlyContinue'
           New-Item -ItemType Directory -Force -Path bindings/python/python/decibri/_ort | Out-Null
           Invoke-WebRequest -Uri "${{ steps.ort-meta.outputs.url }}" -OutFile ort.zip -MaximumRetryCount 3 -RetryIntervalSec 2
+          $expected = "${{ steps.ort-meta.outputs.sha256 }}"
+          $actual = (Get-FileHash -Path ort.zip -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actual -ne $expected) {
+            Write-Host "ERROR: SHA-256 mismatch for ${{ steps.ort-meta.outputs.url }}"
+            Write-Host "  expected: $expected"
+            Write-Host "  actual:   $actual"
+            exit 1
+          }
           Expand-Archive -Path ort.zip -DestinationPath .
           $src = "onnxruntime-${{ matrix.ort_platform_slug }}-$env:ORT_VERSION"
           Copy-Item "$src/lib/onnxruntime.dll" bindings/python/python/decibri/_ort/
@@ -193,7 +232,7 @@ jobs:
       - name: Build Linux wheel in manylinux_2_28 container
         if: runner.os == 'Linux'
         # Mirrors python-ci.yml lines 393-472. manylinux_2_28 is the glibc
-        # floor compatible with ONNX Runtime 1.24's documented requirements.
+        # floor compatible with ONNX Runtime 1.28's documented requirements.
         # PyO3/maturin-action provides the container; before-script-linux
         # installs alsa-lib-devel + downloads + stages the ORT dylib before
         # maturin runs.
@@ -209,8 +248,8 @@ jobs:
             ORT_VERSION="${{ env.ORT_VERSION }}"
             ARCH=$(uname -m)
             case "$ARCH" in
-              x86_64)  ORT_ARCH="linux-x64"     ;;
-              aarch64) ORT_ARCH="linux-aarch64" ;;
+              x86_64)  ORT_ARCH="linux-x64";     ORT_SHA256="${{ env.ORT_SHA256_LINUX_X64 }}" ;;
+              aarch64) ORT_ARCH="linux-aarch64"; ORT_SHA256="${{ env.ORT_SHA256_LINUX_AARCH64 }}" ;;
               *)
                 echo "ERROR: unsupported container architecture: $ARCH"
                 exit 1
@@ -221,6 +260,13 @@ jobs:
             echo "Downloading ORT inside container: $ORT_URL"
             mkdir -p bindings/python/python/decibri/_ort
             curl -sL --retry 3 --retry-delay 2 -o /tmp/ort.tgz "$ORT_URL"
+            ACTUAL=$(sha256sum /tmp/ort.tgz | cut -d' ' -f1)
+            if [ -z "$ORT_SHA256" ] || [ "$ACTUAL" != "$ORT_SHA256" ]; then
+              echo "ERROR: SHA-256 mismatch for $ORT_URL"
+              echo "  expected: $ORT_SHA256"
+              echo "  actual:   $ACTUAL"
+              exit 1
+            fi
             tar -xzf /tmp/ort.tgz -C /tmp
             SRC="/tmp/onnxruntime-${ORT_ARCH}-${ORT_VERSION}"
             cp -L "$SRC/lib/libonnxruntime.so" bindings/python/python/decibri/_ort/libonnxruntime.so

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -56,7 +56,17 @@ env:
   # publish-npm.yml for ORT_VERSION; the wheel pipeline pins to the same
   # value here). Update in lockstep with publish-npm.yml at every ort-crate
   # upgrade per the workspace Cargo.toml maintainer comment (steps 2 and 3).
-  ORT_VERSION: 1.24.4
+  ORT_VERSION: 1.28.1
+  # SHA-256 of each ONNX Runtime release archive downloaded below, as
+  # published beside the asset on its GitHub release page. Every download
+  # step checks its archive against the matching digest before extracting
+  # it and fails on a mismatch. tests/test-ci.js (Group 8g) holds the four
+  # digests in lockstep across publish-npm.yml, publish-pypi.yml and
+  # python-ci.yml.
+  ORT_SHA256_LINUX_X64: 2529aef968d0ad0603365054bc46ebefa7f0fe3bc12f28c5f729c99ddffe2a81
+  ORT_SHA256_LINUX_AARCH64: 53bab9a5c6ae198b7be75663b780c64caa388d30257fac458c71fbff0a82e98e
+  ORT_SHA256_OSX_ARM64: 18c853e5c5deba90e244e1b953a65121f23747ba2c04e6743885caa6ce1ea12f
+  ORT_SHA256_WIN_X64: e46ac7652def5da0e5223372be21185ffff553e0419459f66e0114d460c38162
   # Phase 7 wheel size thresholds. Soft warning continues the Phase 3
   # alarm (150 MB; today's bundled wheel is ~30 to 50 MB). Hard fail at
   # 200 MB catches pathological regressions (e.g., accidentally bundling
@@ -190,23 +200,29 @@ jobs:
         # matrix is conditional (sized by trigger) so the slug cannot be
         # carried as a matrix dimension; computing it here keeps a single
         # source of truth and lets the preflight + download steps below
-        # share one URL.
+        # share one URL and one archive digest.
         run: |
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
-            Linux-X64)    SLUG="linux-x64";     EXT="tgz" ;;
-            Linux-ARM64)  SLUG="linux-aarch64"; EXT="tgz" ;;
-            macOS-ARM64)  SLUG="osx-arm64";     EXT="tgz" ;;
-            Windows-X64)  SLUG="win-x64";       EXT="zip" ;;
+            Linux-X64)    SLUG="linux-x64";     EXT="tgz"; SHA256="$ORT_SHA256_LINUX_X64" ;;
+            Linux-ARM64)  SLUG="linux-aarch64"; EXT="tgz"; SHA256="$ORT_SHA256_LINUX_AARCH64" ;;
+            macOS-ARM64)  SLUG="osx-arm64";     EXT="tgz"; SHA256="$ORT_SHA256_OSX_ARM64" ;;
+            Windows-X64)  SLUG="win-x64";       EXT="zip"; SHA256="$ORT_SHA256_WIN_X64" ;;
             *)
               echo "ERROR: unsupported runner OS+arch combination: ${RUNNER_OS}-${RUNNER_ARCH}"
               exit 1
               ;;
           esac
+          if [ -z "$SHA256" ]; then
+            echo "ERROR: the ORT_SHA256_* digest for ${SLUG} is empty"
+            exit 1
+          fi
           URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-${SLUG}-${ORT_VERSION}.${EXT}"
           echo "slug=${SLUG}" >> "$GITHUB_OUTPUT"
           echo "ext=${EXT}" >> "$GITHUB_OUTPUT"
           echo "url=${URL}" >> "$GITHUB_OUTPUT"
+          echo "sha256=${SHA256}" >> "$GITHUB_OUTPUT"
           echo "Resolved: ${URL}"
+          echo "Expected SHA-256: ${SHA256}"
 
       - name: Verify ONNX Runtime tarball availability
         shell: bash
@@ -240,6 +256,13 @@ jobs:
           URL="${{ steps.ort-meta.outputs.url }}"
           mkdir -p bindings/python/python/decibri/_ort
           curl -sL --retry 3 --retry-delay 2 -o ort.tgz "$URL"
+          ACTUAL=$(shasum -a 256 ort.tgz | cut -d' ' -f1)
+          if [ "$ACTUAL" != "${{ steps.ort-meta.outputs.sha256 }}" ]; then
+            echo "ERROR: SHA-256 mismatch for $URL"
+            echo "  expected: ${{ steps.ort-meta.outputs.sha256 }}"
+            echo "  actual:   $ACTUAL"
+            exit 1
+          fi
           tar -xzf ort.tgz
           SRC="onnxruntime-${SLUG}-${ORT_VERSION}"
           cp -L "$SRC/lib/libonnxruntime.${ORT_VERSION}.dylib" bindings/python/python/decibri/_ort/libonnxruntime.dylib
@@ -286,6 +309,14 @@ jobs:
           $url = "${{ steps.ort-meta.outputs.url }}"
           New-Item -ItemType Directory -Force -Path bindings/python/python/decibri/_ort | Out-Null
           Invoke-WebRequest -Uri $url -OutFile ort.zip -MaximumRetryCount 3 -RetryIntervalSec 2
+          $expected = "${{ steps.ort-meta.outputs.sha256 }}"
+          $actual = (Get-FileHash -Path ort.zip -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actual -ne $expected) {
+            Write-Host "ERROR: SHA-256 mismatch for $url"
+            Write-Host "  expected: $expected"
+            Write-Host "  actual:   $actual"
+            exit 1
+          }
           Expand-Archive -Path ort.zip -DestinationPath .
           $src = "onnxruntime-${{ steps.ort-meta.outputs.slug }}-$env:ORT_VERSION"
           Copy-Item "$src/lib/onnxruntime.dll" bindings/python/python/decibri/_ort/
@@ -406,7 +437,7 @@ jobs:
         # wheels with too-recent symbols (libc/libstdc++/libgcc_s) that
         # auditwheel refuses to repair.
         #
-        # Manylinux profile choice: 2_28 (matches ONNX Runtime 1.24's
+        # Manylinux profile choice: 2_28 (matches ONNX Runtime 1.28's
         # documented glibc floor; targeting 2_17 would waste audit headroom).
         #
         # Target derivation: matrix.os carries the runner OS; for Linux
@@ -454,11 +485,12 @@ jobs:
             # before the script reaches the container, so the script that
             # actually runs inside the container sees a literal version
             # string and the downstream ORT_TARBALL / ORT_URL lines work.
+            # The two Linux archive digests reach the container the same way.
             ORT_VERSION="${{ env.ORT_VERSION }}"
             ARCH=$(uname -m)
             case "$ARCH" in
-              x86_64)  ORT_ARCH="linux-x64"     ;;
-              aarch64) ORT_ARCH="linux-aarch64" ;;
+              x86_64)  ORT_ARCH="linux-x64";     ORT_SHA256="${{ env.ORT_SHA256_LINUX_X64 }}" ;;
+              aarch64) ORT_ARCH="linux-aarch64"; ORT_SHA256="${{ env.ORT_SHA256_LINUX_AARCH64 }}" ;;
               *)
                 echo "ERROR: unsupported container architecture: $ARCH"
                 exit 1
@@ -470,6 +502,13 @@ jobs:
 
             mkdir -p bindings/python/python/decibri/_ort
             curl -sL --retry 3 --retry-delay 2 -o /tmp/ort.tgz "$ORT_URL"
+            ACTUAL=$(sha256sum /tmp/ort.tgz | cut -d' ' -f1)
+            if [ -z "$ORT_SHA256" ] || [ "$ACTUAL" != "$ORT_SHA256" ]; then
+              echo "ERROR: SHA-256 mismatch for $ORT_URL"
+              echo "  expected: $ORT_SHA256"
+              echo "  actual:   $ACTUAL"
+              exit 1
+            fi
             tar -xzf /tmp/ort.tgz -C /tmp
             SRC="/tmp/onnxruntime-${ORT_ARCH}-${ORT_VERSION}"
             cp -L "$SRC/lib/libonnxruntime.so" bindings/python/python/decibri/_ort/libonnxruntime.so

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -191,7 +191,6 @@ jobs:
         run: uv sync --dev --locked
 
       - name: Compute ORT platform metadata
-        id: ort-meta
         shell: bash
         # Maps RUNNER_OS + RUNNER_ARCH to the upstream ONNX Runtime
         # tarball naming convention. The four expected combinations
@@ -200,7 +199,9 @@ jobs:
         # matrix is conditional (sized by trigger) so the slug cannot be
         # carried as a matrix dimension; computing it here keeps a single
         # source of truth and lets the preflight + download steps below
-        # share one URL and one archive digest.
+        # share one URL and one archive digest. The values travel to those
+        # steps as plain environment variables via GITHUB_ENV, not as step
+        # outputs, so no run block expands them through the template layer.
         run: |
           case "${RUNNER_OS}-${RUNNER_ARCH}" in
             Linux-X64)    SLUG="linux-x64";     EXT="tgz"; SHA256="$ORT_SHA256_LINUX_X64" ;;
@@ -217,10 +218,10 @@ jobs:
             exit 1
           fi
           URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-${SLUG}-${ORT_VERSION}.${EXT}"
-          echo "slug=${SLUG}" >> "$GITHUB_OUTPUT"
-          echo "ext=${EXT}" >> "$GITHUB_OUTPUT"
-          echo "url=${URL}" >> "$GITHUB_OUTPUT"
-          echo "sha256=${SHA256}" >> "$GITHUB_OUTPUT"
+          echo "ORT_SLUG=${SLUG}" >> "$GITHUB_ENV"
+          echo "ORT_EXT=${EXT}" >> "$GITHUB_ENV"
+          echo "ORT_URL=${URL}" >> "$GITHUB_ENV"
+          echo "ORT_SHA256=${SHA256}" >> "$GITHUB_ENV"
           echo "Resolved: ${URL}"
           echo "Expected SHA-256: ${SHA256}"
 
@@ -232,7 +233,7 @@ jobs:
         # an opaque mid-build failure. Same pattern in production for the
         # Node release pipeline since 3.0.
         run: |
-          URL="${{ steps.ort-meta.outputs.url }}"
+          URL="$ORT_URL"
           echo "Verifying: $URL"
           if ! curl -sIfL --retry 3 --retry-delay 2 -o /dev/null "$URL"; then
             echo "ERROR: expected ONNX Runtime tarball not available at $URL"
@@ -252,14 +253,14 @@ jobs:
         # post-pip-install. Renamed to unversioned to match what the Python
         # resolver looks for under python/decibri/_ort/.
         run: |
-          SLUG="${{ steps.ort-meta.outputs.slug }}"
-          URL="${{ steps.ort-meta.outputs.url }}"
+          SLUG="$ORT_SLUG"
+          URL="$ORT_URL"
           mkdir -p bindings/python/python/decibri/_ort
           curl -sL --retry 3 --retry-delay 2 -o ort.tgz "$URL"
           ACTUAL=$(shasum -a 256 ort.tgz | cut -d' ' -f1)
-          if [ "$ACTUAL" != "${{ steps.ort-meta.outputs.sha256 }}" ]; then
+          if [ "$ACTUAL" != "$ORT_SHA256" ]; then
             echo "ERROR: SHA-256 mismatch for $URL"
-            echo "  expected: ${{ steps.ort-meta.outputs.sha256 }}"
+            echo "  expected: $ORT_SHA256"
             echo "  actual:   $ACTUAL"
             exit 1
           fi
@@ -306,10 +307,10 @@ jobs:
         # future GPU EP integration needs it, revisit.
         run: |
           $ProgressPreference = 'SilentlyContinue'
-          $url = "${{ steps.ort-meta.outputs.url }}"
+          $url = $env:ORT_URL
           New-Item -ItemType Directory -Force -Path bindings/python/python/decibri/_ort | Out-Null
           Invoke-WebRequest -Uri $url -OutFile ort.zip -MaximumRetryCount 3 -RetryIntervalSec 2
-          $expected = "${{ steps.ort-meta.outputs.sha256 }}"
+          $expected = $env:ORT_SHA256
           $actual = (Get-FileHash -Path ort.zip -Algorithm SHA256).Hash.ToLowerInvariant()
           if ($actual -ne $expected) {
             Write-Host "ERROR: SHA-256 mismatch for $url"
@@ -318,7 +319,7 @@ jobs:
             exit 1
           }
           Expand-Archive -Path ort.zip -DestinationPath .
-          $src = "onnxruntime-${{ steps.ort-meta.outputs.slug }}-$env:ORT_VERSION"
+          $src = "onnxruntime-$env:ORT_SLUG-$env:ORT_VERSION"
           Copy-Item "$src/lib/onnxruntime.dll" bindings/python/python/decibri/_ort/
 
       - name: Inspect onnxruntime.dll imports (Windows, diagnostic)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,9 +972,9 @@ dependencies = [
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.12"
+version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+checksum = "4336a1e2b38848325241c72889086886004e589b7c74f335e60a8e8db5138a0b"
 dependencies = [
  "libloading",
  "ndarray",
@@ -986,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.12"
+version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+checksum = "cf211e3776eea6aec988552fa118dd746d70e1b1e5e244058d1c98015f3e5872"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ members = [
 [workspace.package]
 version = "6.2.0"
 edition = "2021"
-# MSRV empirically verified 2026-04-22: rustc 1.88 is the minimum version
-# that compiles the workspace. Floors: ort 2.0.0-rc.12 declares
+# MSRV empirically verified 2026-08-21: rustc 1.88 is the minimum version
+# that compiles the workspace. Floors: ort 2.0.0-rc.13 declares
 # `rust-version = "1.88"` and `edition = "2024"`, which dominates our own
 # MSRV. Other direct deps (napi-rs v3 ~1.74, cpal 0.17 ~1.70,
 # crossbeam-channel 0.5 ~1.60) are below this floor. Bump when dependencies
@@ -23,49 +23,53 @@ repository = "https://github.com/decibri/decibri"
 cpal = "0.17"
 thiserror = "2"
 crossbeam-channel = "0.5"
-# ort 2.0.0-rc.12 targets ONNX Runtime C API version 24 (ORT_API_VERSION = 24).
-# We bundle ONNX Runtime 1.24.4 tarballs into each npm platform package.
+# ort 2.0.0-rc.13 targets ONNX Runtime C API version 28 (ORT_API_VERSION = 28).
+# We bundle ONNX Runtime 1.28.1 archives into each npm platform package and
+# into the wheel.
 # Verified via:
-#   - https://raw.githubusercontent.com/pykeio/ort/v2.0.0-rc.12/ort-sys/src/version.rs
+#   - https://raw.githubusercontent.com/pykeio/ort/v2.0.0-rc.13/ort-sys/src/version.rs
 #   - https://ort.pyke.io/setup/multiversion
-#   - https://github.com/microsoft/onnxruntime/releases/tag/v1.24.1 (ORT_API_VERSION bump)
+#   - https://github.com/microsoft/onnxruntime/releases/tag/v1.28.1
 #
 # Feature rationale:
 #   - `std`:     required for non-no_std targets (all of ours).
-#   - `api-24`:  matches the ORT 1.24.x ABI we bundle in npm platform packages.
-#                Must be kept in sync with the bundled ORT tarball version.
-#                If omitted, ort silently falls back to api-17 (the baseline) and its
-#                own EP modules fail to compile against the older OrtApi struct.
+#   - `api-28`:  matches the ORT 1.28.x ABI we bundle. Must be kept in sync with
+#                the bundled ORT archive version. If omitted, ort silently falls
+#                back to api-17 (the baseline) and its own EP modules fail to
+#                compile against the older OrtApi struct. ort's own `default`
+#                feature set selects api-27; the explicit `api-28` here is what
+#                pairs the crate with the 1.28 runtime.
 # We deliberately exclude ort's other defaults (`download-binaries`, `tls-native`,
-# `copy-dylibs`, `tracing`) because:
+# `copy-dylibs`, `tracing`, `ndarray`) because:
 #   - `download-binaries` / `tls-native` / `copy-dylibs` are the old embedding path
 #     we're migrating away from in 3.1.0 (available opt-in via
 #     `ort-download-binaries` feature on crates/decibri for pure-Rust consumers).
-#   - `tracing` is an optional integration decibri doesn't use; ort gates it as
-#     `tracing?/std`, so leaving it off the feature list keeps it off.
-# `ndarray` cannot be excluded: ort's `std` feature lists `ndarray/std` (not
-# `ndarray?/std`), which force-enables the optional `ndarray` dependency, and
-# ort's `load-dynamic` (pulled by our `ort-load-dynamic` mode) enables `std` in
-# turn. decibri does not use the ndarray integration; it compiles unused.
+#   - `tracing` and `ndarray` are optional integrations decibri doesn't use; ort
+#     gates them as `tracing?/std` and `ndarray?/std`, so leaving them off the
+#     feature list keeps them off.
 #
 # Distribution mode (load-dynamic vs download-binaries) is selected by crates/decibri
 # via the `ort-load-dynamic` / `ort-download-binaries` features.
 #
-# When upgrading the ort crate (e.g. 2.0.0-rc.12 -> 2.0.0 stable -> future versions):
-#   1. Inspect the new ort's Cargo.toml `description` and `default` features for the
-#      new api-N (pyke bumps the default with each minor ORT target). Update the
-#      `api-24` in the `features = [...]` list below to match the new api-N.
-#   2. Update the bundled ORT version to match (e.g. api-25 -> ORT 1.25.x).
-#   3. Update the single `env.ORT_VERSION` declaration in .github/workflows/publish-npm.yml
-#      (workflow-level env block, not a per-job bash assignment: one source of truth).
+# When upgrading the ort crate (e.g. 2.0.0-rc.13 -> 2.0.0 stable -> future versions):
+#   1. Inspect the new ort's `api-*` features (ort-sys/Cargo.toml) for the highest
+#      api-N it provides; its `default` set can trail that (rc.13 defaults to
+#      api-27 while providing api-28). Update the `api-28` in the
+#      `features = [...]` list below to match the new api-N.
+#   2. Update the bundled ORT version to match (api-N -> ORT 1.N.x).
+#   3. Update `env.ORT_VERSION` and the four `env.ORT_SHA256_*` archive digests in
+#      .github/workflows/publish-npm.yml, publish-pypi.yml and python-ci.yml
+#      (workflow-level env blocks; tests/test-ci.js Group 8g holds them in
+#      lockstep).
 #   4. Update the `api_n` baseline in .github/workflows/check-upstream.yml.
-#   5. Trigger publish-npm.yml manually via workflow_dispatch with `publish` unticked
-#      to confirm the tarball URL pattern still resolves.
+#   5. Trigger publish-npm.yml and publish-pypi.yml manually via workflow_dispatch
+#      with `publish` unticked to confirm the archive URLs resolve, the digests
+#      match and the packaged runtime loads.
 # Steps 1-4 MUST move together. Leaving any one out produces an ABI mismatch that
 # either fails to compile (step 1 skipped) or fails at runtime dylib-load time
 # (step 2 skipped, because pyke/ort performs a version-string check in load_dylib_from_path
 # and returns Err for too-old ORT minors).
-ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "api-24"] }
+ort = { version = "=2.0.0-rc.13", default-features = false, features = ["std", "api-28"] }
 
 [profile.release]
 lto = true

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -8,6 +8,12 @@ For Rust core (`crates/decibri`) and npm package (`npm/decibri`) changes, see [t
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- The wheel bundles ONNX Runtime 1.28.1 under `decibri/_ort/`, and the extension is built against `ort` 2.0.0-rc.13 (`api-28`). A `DECIBRI_ORT_DYLIB_PATH` or `ORT_DYLIB_PATH` override must point at ONNX Runtime 1.28 or newer.
+
 ## [0.11.0] - 2026-08-16
 
 ### Breaking changes

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - The wheel bundles ONNX Runtime 1.28.1 under `decibri/_ort/`, and the extension is built against `ort` 2.0.0-rc.13 (`api-28`). A `DECIBRI_ORT_DYLIB_PATH` or `ORT_DYLIB_PATH` override must point at ONNX Runtime 1.28 or newer.
 
+### Fixed
+
+- An `ort_library_path`, `DECIBRI_ORT_DYLIB_PATH`, `ORT_DYLIB_PATH` or bundled ONNX Runtime that cannot be used (not a loadable library, or older than 1.28) raises `OrtLoadFailed` on every attempt; a second attempt after such a failure no longer aborts the process.
+
 ## [0.11.0] - 2026-08-16
 
 ### Breaking changes

--- a/bindings/python/docs/ecosystem/docker.md
+++ b/bindings/python/docs/ecosystem/docker.md
@@ -17,7 +17,7 @@ decibri 0.1.0+ is on PyPI, so the minimal Dockerfile is a single stage that runs
 [Dockerfile.base](docker/Dockerfile.base):
 
 ```dockerfile
-ARG ORT_VERSION=1.24.4
+ARG ORT_VERSION=1.28.1
 
 FROM rust:1-bookworm AS builder
 

--- a/bindings/python/docs/ecosystem/docker/Dockerfile.audio
+++ b/bindings/python/docs/ecosystem/docker/Dockerfile.audio
@@ -33,7 +33,7 @@
 # Build context: project root.
 #   docker build -t decibri:audio -f Dockerfile.audio .
 
-ARG ORT_VERSION=1.24.4
+ARG ORT_VERSION=1.28.1
 
 # ---------- Stage 1: build the wheel ----------
 FROM rust:1-bookworm AS builder

--- a/bindings/python/docs/ecosystem/docker/Dockerfile.base
+++ b/bindings/python/docs/ecosystem/docker/Dockerfile.base
@@ -11,7 +11,7 @@
 #
 #   docker build -t decibri:base -f Dockerfile.base .
 
-ARG ORT_VERSION=1.24.4
+ARG ORT_VERSION=1.28.1
 
 # ---------- Stage 1: build the wheel ----------
 FROM rust:1-bookworm AS builder

--- a/bindings/python/docs/ecosystem/docker/Dockerfile.headless
+++ b/bindings/python/docs/ecosystem/docker/Dockerfile.headless
@@ -9,7 +9,7 @@
 # Build context: project root.
 #   docker build -t decibri:headless -f Dockerfile.headless .
 
-ARG ORT_VERSION=1.24.4
+ARG ORT_VERSION=1.28.1
 
 # ---------- Stage 1: build the wheel ----------
 FROM rust:1-bookworm AS builder

--- a/bindings/python/python/decibri/_ort/THIRD-PARTY-NOTICES.md
+++ b/bindings/python/python/decibri/_ort/THIRD-PARTY-NOTICES.md
@@ -8,9 +8,9 @@ with the files.
 ## ONNX Runtime
 
 - **Name:** ONNX Runtime
-- **Version:** 1.24.4
+- **Version:** 1.28.1
 - **License:** MIT
-- **Source:** https://github.com/microsoft/onnxruntime (release `v1.24.4`)
+- **Source:** https://github.com/microsoft/onnxruntime (release `v1.28.1`)
 - **Files covered:** the ONNX Runtime dynamic libraries distributed in this
   package: `onnxruntime.dll` on Windows, `libonnxruntime.dylib` on macOS,
   `libonnxruntime.so` and `libonnxruntime_providers_shared.so` on Linux. Each
@@ -53,11 +53,11 @@ SOFTWARE.
 ## ONNX Runtime Third-Party Notices
 
 The following section reproduces, verbatim, the `ThirdPartyNotices.txt` file
-from the ONNX Runtime `v1.24.4` release archives. It covers third-party
+from the ONNX Runtime `v1.28.1` release archives. It covers third-party
 material incorporated into the ONNX Runtime libraries named above. The text
 between the markers is upstream's, unaltered.
 
-<!-- BEGIN VERBATIM ThirdPartyNotices.txt (ONNX Runtime v1.24.4) -->
+<!-- BEGIN VERBATIM ThirdPartyNotices.txt (ONNX Runtime v1.28.1) -->
 ```text
 THIRD PARTY SOFTWARE NOTICES AND INFORMATION
 
@@ -6181,7 +6181,7 @@ Redistribution and use in source and binary forms, with or without modification,
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
-<!-- END VERBATIM ThirdPartyNotices.txt (ONNX Runtime v1.24.4) -->
+<!-- END VERBATIM ThirdPartyNotices.txt (ONNX Runtime v1.28.1) -->
 
 ## Source Availability: Eigen (MPL-2.0)
 
@@ -6191,6 +6191,6 @@ notices above. The Eigen source code for this ONNX Runtime version is
 available at:
 
 - https://github.com/eigen-mirror/eigen/archive/1d8b82b0740839c0de7f1242a3585e3390ff5f33/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip
-  (the archive ONNX Runtime `v1.24.4` builds against, per `cmake/deps.txt`
+  (the archive ONNX Runtime `v1.28.1` builds against, per `cmake/deps.txt`
   at that tag)
 - https://gitlab.com/libeigen/eigen (the Eigen project repository)

--- a/bindings/python/tests/test_ort_bundling.py
+++ b/bindings/python/tests/test_ort_bundling.py
@@ -23,6 +23,7 @@ Three tiers:
 
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 from typing import Iterator
@@ -269,3 +270,47 @@ def test_decibri_silero_construction() -> None:
     instance = decibri.Microphone(vad="silero")
     assert instance is not None
     assert isinstance(instance, decibri.Microphone)
+
+
+# ---------------------------------------------------------------------------
+# A runtime that cannot be loaded is typed on every attempt
+# ---------------------------------------------------------------------------
+
+
+def test_unusable_runtime_is_typed_on_every_attempt(tmp_path: Path) -> None:
+    """An ``ort_library_path`` that is not a loadable library raises
+    ``OrtLoadFailed`` on the first attempt and again on the second.
+
+    Runs in a child interpreter so a process abort is an exit status rather
+    than the end of this session. The first failed load must not change what
+    a later attempt in the same process reports. Needs no bundled runtime:
+    the explicit path is the whole fixture.
+    """
+    not_a_library = tmp_path / _PLATFORM_FILENAME.get(sys.platform, "onnxruntime.bin")
+    not_a_library.write_bytes(b"this is not a shared library\n")
+    script = (
+        "import sys\n"
+        "import decibri\n"
+        "outcomes = []\n"
+        "for _ in range(2):\n"
+        "    try:\n"
+        "        decibri.File.buffer([0.0] * 3200, input_rate=16000, vad='silero',\n"
+        "                            ort_library_path=sys.argv[1]).analyze()\n"
+        "        outcomes.append('ok')\n"
+        "    except decibri.OrtLoadFailed:\n"
+        "        outcomes.append('OrtLoadFailed')\n"
+        "    except BaseException as exc:  # noqa: BLE001\n"
+        "        outcomes.append(type(exc).__name__)\n"
+        "print(' '.join(outcomes))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(not_a_library)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"child exited {result.returncode}; stderr: {result.stderr.strip()[:400]}"
+    )
+    assert result.stdout.split() == ["OrtLoadFailed", "OrtLoadFailed"], result.stdout

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -14,7 +14,11 @@ For other decibri packages, see:
 ### Changed
 
 - The `ort` dependency is `2.0.0-rc.13` with the `api-28` feature, pairing the crate with the ONNX Runtime 1.28 C API. `ort-download-binaries` builds fetch ONNX Runtime 1.28.0, and `ort-load-dynamic` builds require a runtime of 1.28 or newer. The `ndarray` integration is no longer compiled in.
-- `DecibriError::OrtLoadFailed` carries the `ort::LoadDynamicError` that `ort::init_from` returns as its `source()`. The variant, its `code()` and its message template are unchanged.
+- `DecibriError::OrtLoadFailed` carries an `ort::LoadDynamicError` as its `source()`. The variant, its `code()` and its message template are unchanged.
+
+### Fixed
+
+- `ort-load-dynamic`: a runtime library that exists but cannot be used (not a loadable library, no `OrtGetApiBase`, or older than ONNX Runtime 1.28) fails with `DecibriError::OrtLoadFailed` on every attempt, for an explicit `ort_library_path`, for `ORT_DYLIB_PATH`, and for the bare platform library name. The pre-check in `init_ort_once` loads and checks the library before `ort` does; a second attempt after such a failure no longer aborts the process.
 
 ## [6.2.0] - 2026-08-16
 

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -9,6 +9,13 @@ For other decibri packages, see:
 - npm package: [npm/decibri/CHANGELOG.md](../../npm/decibri/CHANGELOG.md)
 - Python package: [bindings/python/CHANGELOG.md](../../bindings/python/CHANGELOG.md)
 
+## [Unreleased]
+
+### Changed
+
+- The `ort` dependency is `2.0.0-rc.13` with the `api-28` feature, pairing the crate with the ONNX Runtime 1.28 C API. `ort-download-binaries` builds fetch ONNX Runtime 1.28.0, and `ort-load-dynamic` builds require a runtime of 1.28 or newer. The `ndarray` integration is no longer compiled in.
+- `DecibriError::OrtLoadFailed` carries the `ort::LoadDynamicError` that `ort::init_from` returns as its `source()`. The variant, its `code()` and its message template are unchanged.
+
 ## [6.2.0] - 2026-08-16
 
 ### Breaking changes

--- a/crates/decibri/Cargo.toml
+++ b/crates/decibri/Cargo.toml
@@ -98,10 +98,12 @@ decibri-decode = { version = "0.1", optional = true }
 # `default-features` is left at its default (the crate has no default features);
 # its `tracing` and `internal-tests` features stay off.
 decibri-aec = { version = "0.2", optional = true }
-# System-loader probe for the ORT pre-check under `ort-load-dynamic`: verifies
-# the runtime library is resolvable before `ort::init()` runs, turning a
-# potential hang into a clean typed error. Already in the tree via `ort`
-# (which loads through the same crate), so this adds no new build input.
+# System-loader probe for the ORT pre-check under `ort-load-dynamic`: loads and
+# checks the runtime library (it loads, exports `OrtGetApiBase`, and reports
+# the ONNX Runtime version `ort` requires) before any `ort` call, so an
+# unusable library is a typed error rather than a hang or a panic inside
+# `ort`. Already in the tree via `ort` (which loads through the same crate),
+# so this adds no new build input.
 libloading = { version = "0.9", optional = true }
 
 # Auto-discovered example targets that use a feature-gated module must declare

--- a/crates/decibri/src/denoise.rs
+++ b/crates/decibri/src/denoise.rs
@@ -709,8 +709,10 @@ mod tests {
                 bits = read_u16(&bytes, body + 14);
             } else if id == b"data" {
                 samples = bytes[body..body + size]
-                    .chunks_exact(2)
-                    .map(|s| i16::from_le_bytes([s[0], s[1]]) as f32 / 32768.0)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
+                    .map(|s| i16::from_le_bytes(*s) as f32 / 32768.0)
                     .collect();
             }
             pos = body + size + (size & 1);

--- a/crates/decibri/src/error.rs
+++ b/crates/decibri/src/error.rs
@@ -557,9 +557,12 @@ pub enum DecibriError {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    /// The `ort_library_path` in `VadConfig` failed a pre-check before it
-    /// could be handed to `ort::init_from`. Used only by the Windows
-    /// hang-prevention pre-check in `init_ort_once`.
+    /// The `ort_library_path` in `VadConfig`, `ORT_DYLIB_PATH`, or the bare
+    /// platform library name failed the filesystem half of the pre-check in
+    /// `init_ort_once` (not a regular file, not resolvable by the system
+    /// loader, or the Windows in-box copy) before any load was attempted. A
+    /// library that is found but cannot be loaded or used is
+    /// [`Self::OrtLoadFailed`] instead.
     ///
     /// Intentionally does *not* carry an `ort::Error` source, because
     /// constructing an `ort::Error` under `ort-load-dynamic` calls into the
@@ -1083,10 +1086,12 @@ impl DecibriError {
     /// match on this rather than enumerating [`Self::OrtLoadFailed`] and
     /// [`Self::OrtPathInvalid`] separately:
     ///
-    /// - [`Self::OrtLoadFailed`] fires when ORT tried to load the path and
-    ///   failed (e.g. wrong ORT version, corrupted dylib).
+    /// - [`Self::OrtLoadFailed`] fires when the library was found but could
+    ///   not be loaded or used (not a loadable library, no `OrtGetApiBase`,
+    ///   or an ONNX Runtime older than the version this build requires),
+    ///   whether decibri's pre-check or `ort` detected it.
     /// - [`Self::OrtPathInvalid`] fires when decibri's filesystem pre-check
-    ///   rejected the path before ORT saw it (nonexistent, directory, etc).
+    ///   rejected the path before any load (nonexistent, directory, etc).
     ///
     /// Both represent the same user-facing failure mode: "this path cannot
     /// be used to load ORT." The split is a mechanical necessity (see the

--- a/crates/decibri/src/file.rs
+++ b/crates/decibri/src/file.rs
@@ -1828,8 +1828,10 @@ mod tests {
         );
         let (at, len) = data.expect("the golden recording has a data chunk");
         bytes[at..at + len]
-            .chunks_exact(2)
-            .map(|c| f32::from(i16::from_le_bytes([c[0], c[1]])) / 32768.0)
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|c| f32::from(i16::from_le_bytes(*c)) / 32768.0)
             .collect()
     }
 
@@ -2681,7 +2683,8 @@ mod tests {
         // the cursor without the caller ever seeing a delivery.
         assert!(
             refuses_after(|f| {
-                let _ = f.by_ref().peekable().peek().is_some();
+                let mut lookahead = f.by_ref().peekable();
+                let _ = lookahead.peek().is_some();
             }),
             "after peekable().peek()"
         );
@@ -2831,7 +2834,7 @@ mod tests {
         })
         .unwrap();
         let mut expected: Vec<f32> = Vec::new();
-        for window in samples.chunks_exact(512) {
+        for window in samples.as_chunks::<512>().0 {
             expected.push(detector.process(window).unwrap().probability);
         }
 

--- a/crates/decibri/src/lib.rs
+++ b/crates/decibri/src/lib.rs
@@ -117,16 +117,20 @@
 //! [`DecibriError::OrtPathInvalid`]
 //! (carries `path: PathBuf` and `reason: &'static str`, never touches ORT
 //! symbols) rather than reconstructing an `ort::Error`. decibri's internal
-//! `init_ort_once` follows this pattern: it performs a filesystem-level
-//! `Path::is_file()` check first and returns
-//! [`OrtPathInvalid`](error::DecibriError::OrtPathInvalid) on rejection,
-//! only handing the path to `ort::init_from` once the check passes.
+//! `init_ort_once` follows this pattern: it checks the filesystem first and
+//! returns [`OrtPathInvalid`](error::DecibriError::OrtPathInvalid) on
+//! rejection, then loads the library itself and checks it the way `ort` does
+//! (it exports `OrtGetApiBase` and reports the ONNX Runtime version `ort`
+//! requires), returning [`OrtLoadFailed`](error::DecibriError::OrtLoadFailed)
+//! with the `ort::LoadDynamicError` value for that condition, and only hands
+//! the path to `ort` once both checks pass. A load that fails inside `ort`
+//! cannot be retried in the process, so no library reaches `ort` unchecked.
 //!
 //! This constraint is why [`DecibriError`] splits
 //! "ORT path failure" across two variants:
-//! [`OrtLoadFailed`](error::DecibriError::OrtLoadFailed) carries the
-//! `ort::LoadDynamicError` that `ort::init_from` returned as its source (a
-//! plain value `ort` builds without calling into the runtime), and
+//! [`OrtLoadFailed`](error::DecibriError::OrtLoadFailed) carries an
+//! `ort::LoadDynamicError` as its source (a plain value built without calling
+//! into the runtime, by decibri's pre-check or by `ort::init_from`), and
 //! [`OrtPathInvalid`](error::DecibriError::OrtPathInvalid) does not
 //! (reached before any ORT symbol is touched). The
 //! [`is_ort_path_error`](error::DecibriError::is_ort_path_error) helper

--- a/crates/decibri/src/lib.rs
+++ b/crates/decibri/src/lib.rs
@@ -124,9 +124,9 @@
 //!
 //! This constraint is why [`DecibriError`] splits
 //! "ORT path failure" across two variants:
-//! [`OrtLoadFailed`](error::DecibriError::OrtLoadFailed) carries an
-//! `ort::Error` source (reached after `ort::init_from` genuinely failed,
-//! by which point ORT is loaded and constructing errors is safe), and
+//! [`OrtLoadFailed`](error::DecibriError::OrtLoadFailed) carries the
+//! `ort::LoadDynamicError` that `ort::init_from` returned as its source (a
+//! plain value `ort` builds without calling into the runtime), and
 //! [`OrtPathInvalid`](error::DecibriError::OrtPathInvalid) does not
 //! (reached before any ORT symbol is touched). The
 //! [`is_ort_path_error`](error::DecibriError::is_ort_path_error) helper

--- a/crates/decibri/src/onnx.rs
+++ b/crates/decibri/src/onnx.rs
@@ -102,6 +102,110 @@ fn exe_sibling(path: &Path) -> Option<PathBuf> {
     Some(std::env::current_exe().ok()?.parent()?.join(path))
 }
 
+/// The library `ort` loads for `path`: an absolute path as is, a relative
+/// path from the executable's directory when that placement exists, and
+/// otherwise the relative path handed to the system loader unchanged. The
+/// pre-check in [`init_ort_once`] probes exactly this candidate, so the
+/// library it validates is the one `ort` loads next.
+#[cfg(feature = "ort-load-dynamic")]
+fn ort_candidate(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    match exe_sibling(path) {
+        Some(sibling) if sibling.exists() => sibling,
+        _ => path.to_path_buf(),
+    }
+}
+
+/// The minor component of an ONNX Runtime version string, parsed as `ort`
+/// parses it: the second dotted field as a `u32`, and 0 when that field is
+/// absent or not a number. `"1.28.1"` gives 28.
+#[cfg(feature = "ort-load-dynamic")]
+fn ort_runtime_minor(version: &str) -> u32 {
+    version
+        .split('.')
+        .nth(1)
+        .map_or(0, |field| field.parse::<u32>().unwrap_or(0))
+}
+
+/// The runtime's version string read through its `OrtGetApiBase` entry
+/// point, or `None` when the library does not export the entry point or it
+/// yields no API base or no version string.
+#[cfg(feature = "ort-load-dynamic")]
+fn ort_runtime_version(library: &libloading::Library) -> Option<String> {
+    type GetApiBase = unsafe extern "system" fn() -> *const ort::sys::OrtApiBase;
+    // SAFETY: `OrtGetApiBase` is ONNX Runtime's C entry point with exactly
+    // this signature; it returns a pointer to a static table whose
+    // `GetVersionString` returns a static NUL-terminated string. Both
+    // pointers are checked for null before use, and neither is retained or
+    // freed.
+    unsafe {
+        let base_getter: libloading::Symbol<GetApiBase> = library.get(b"OrtGetApiBase").ok()?;
+        let base = base_getter();
+        if base.is_null() {
+            return None;
+        }
+        let version = ((*base).GetVersionString)();
+        if version.is_null() {
+            return None;
+        }
+        Some(
+            std::ffi::CStr::from_ptr(version)
+                .to_string_lossy()
+                .into_owned(),
+        )
+    }
+}
+
+/// Loads `candidate` and checks it the way `ort`'s own load does: it loads
+/// through the system loader, it exports `OrtGetApiBase`, and its runtime
+/// minor version is at least [`ort::MINOR_VERSION`]. The failures are the
+/// `ort::LoadDynamicError` values `ort` reports for the same conditions. On
+/// failure the library is unloaded again; on success it is returned loaded.
+///
+/// Every check `ort` performs when it loads a library has to run here first:
+/// a load that fails inside `ort` cannot be retried in the process, because
+/// `ort` completes its library cell on failure, after which `ort::init_from`
+/// returns `Ok` without loading and the first C API call panics.
+#[cfg(feature = "ort-load-dynamic")]
+fn probe_ort_library(candidate: &Path) -> Result<libloading::Library, ort::LoadDynamicError> {
+    // SAFETY: loading a library runs its initialisers. This is the same load
+    // `ort` performs for the same candidate.
+    let library = unsafe { libloading::Library::new(candidate) }.map_err(|error| {
+        ort::LoadDynamicError::Dlopen {
+            error,
+            path: candidate.to_path_buf(),
+        }
+    })?;
+    check_ort_library(library, candidate)
+}
+
+/// The entry-point and version half of [`probe_ort_library`], split out so
+/// the bare platform name can be checked for the Windows in-box copy between
+/// the load and these checks. Unloads `library` on failure.
+#[cfg(feature = "ort-load-dynamic")]
+fn check_ort_library(
+    library: libloading::Library,
+    candidate: &Path,
+) -> Result<libloading::Library, ort::LoadDynamicError> {
+    let path = candidate.to_path_buf();
+    match ort_runtime_version(&library) {
+        Some(version) if ort_runtime_minor(&version) >= ort::MINOR_VERSION => Ok(library),
+        Some(version) => {
+            drop(library);
+            Err(ort::LoadDynamicError::BadVersion {
+                version_str: version,
+                path,
+            })
+        }
+        None => {
+            drop(library);
+            Err(ort::LoadDynamicError::MissingApi { path })
+        }
+    }
+}
+
 /// The on-disk location of an already-loaded module, by its load name.
 /// Queries the loader directly (`GetModuleHandleW` does not change the
 /// module's reference count), so the probe's `Library` handle stays intact.
@@ -181,9 +285,9 @@ static ORT_INIT_PID: OnceLock<u32> = OnceLock::new();
 /// Returns one of two typed variants depending on whether a path was provided:
 /// [`DecibriError::OrtLoadFailed`] when `path.is_some()`, or
 /// [`DecibriError::OrtInitFailed`] otherwise. The inner error (the
-/// `ort::LoadDynamicError` a failed `ort::init_from` returns, or an
-/// `ort::Error`) is carried via `#[source]` so consumers can walk the error
-/// chain.
+/// `ort::LoadDynamicError` the pre-check or a failed `ort::init_from`
+/// produces, or an `ort::Error`) is carried via `#[source]` so consumers can
+/// walk the error chain.
 fn wrap_init_error<E>(path: Option<&Path>, err: E) -> DecibriError
 where
     E: std::error::Error + Send + Sync + 'static,
@@ -301,45 +405,39 @@ pub(crate) fn init_ort_once(path: Option<&Path>) -> Result<(), DecibriError> {
         return Ok(());
     }
 
-    // Defensive pre-check (load-dynamic only): verify the runtime ORT would
-    // load is actually there before handing control to ORT. A failing ORT
-    // load hangs indefinitely on Windows instead of erroring (reproduced
-    // 2026-04-22 against pyke/ort 2.0.0-rc.12 + onnxruntime 1.24.4 for an
-    // invalid `ort::init_from` path, and 2026-07-17 for `ort::init()` with
-    // no resolvable runtime at all), because constructing the failure's
-    // `ort::Error` itself re-triggers the dylib load. Failing fast here
-    // turns that hang into a clean typed error that Node, Python, and
-    // mobile consumers can surface to users.
+    // Pre-check (load-dynamic only): resolve the library exactly as `ort`
+    // resolves it and validate it the way `ort`'s own load does (it loads, it
+    // exports `OrtGetApiBase`, and it reports a runtime minor version of at
+    // least `ort::MINOR_VERSION`) before any `ort` call runs. A load that
+    // fails inside `ort` cannot be retried in this process: `ort` completes
+    // its library cell on failure, so the next `ort::init_from` returns `Ok`
+    // without loading and the first C API call panics, which aborts across an
+    // FFI boundary; `ort::init()` loads lazily at that first C API call and
+    // panics there on failure. Every check therefore runs here, for an
+    // explicit path, for `ORT_DYLIB_PATH`, and for the bare platform name,
+    // and a failure is a typed error that never touches `ort`. A probe that
+    // passes keeps the library resident, the state a successful init
+    // produces, so `ort` loads the same module next.
     //
-    // Both branches are covered:
-    // - `Some(path)`: the path must be a regular file before it reaches
-    //   `ort::init_from`.
-    // - `None`: `ort::init()` resolves the runtime itself, from the
-    //   `ORT_DYLIB_PATH` environment variable when set, otherwise from the
-    //   platform library name through the system loader. Pre-validate the
-    //   same resolution: a set `ORT_DYLIB_PATH` must point at a regular
-    //   file, and with the variable unset the system loader must actually
-    //   resolve the platform library (probed through `libloading`, the same
-    //   loader `ort` itself uses, which returns an error rather than
-    //   hanging). A successful probe keeps the library resident, the state
-    //   `ort::init()` produces anyway.
-    //
-    // The check is intentionally scoped to `load-dynamic`: under
-    // `download-binaries`, ORT is statically linked and there is nothing to
-    // pre-validate.
+    // The check is scoped to `load-dynamic`: under `download-binaries`, ORT
+    // is statically linked and there is nothing to pre-validate.
     #[cfg(feature = "ort-load-dynamic")]
     match path {
         Some(p) => {
             if !p.is_file() {
-                // Use `OrtPathInvalid`, not `OrtLoadFailed`, precisely because
-                // constructing an `ort::Error` here would call `ortsys![
-                // CreateStatus]`, which triggers the ORT dylib load that this
-                // pre-check is designed to prevent. `OrtPathInvalid` is
-                // string-only and never touches ORT symbols.
+                // `OrtPathInvalid` is string-only and never touches ORT
+                // symbols; constructing an `ort::Error` here would call
+                // `ortsys![CreateStatus]`, which triggers the ORT dylib load.
                 return Err(DecibriError::OrtPathInvalid {
                     path: p.to_path_buf(),
                     reason: "path does not exist or is not a regular file",
                 });
+            }
+            match probe_ort_library(&ort_candidate(p)) {
+                Ok(library) => std::mem::forget(library),
+                // The variant and source a failed `ort::init_from` produces
+                // for the same library.
+                Err(e) => return Err(wrap_init_error(Some(p), e)),
             }
         }
         // Mirror ort's own resolution for the no-path case so this
@@ -361,46 +459,72 @@ pub(crate) fn init_ort_once(path: Option<&Path>) -> Result<(), DecibriError> {
                         reason: "ORT_DYLIB_PATH does not point to a regular file",
                     });
                 }
+                match probe_ort_library(&ort_candidate(&env_path)) {
+                    Ok(library) => std::mem::forget(library),
+                    Err(e) => {
+                        return Err(DecibriError::OrtLoadFailed {
+                            path: env_path,
+                            source: Box::new(e),
+                        });
+                    }
+                }
             }
-            None => match unsafe { libloading::Library::new(ORT_DEFAULT_LIBRARY) } {
-                Ok(library) => {
-                    // Windows ships an in-box `onnxruntime.dll` in System32
-                    // (the Windows ML copy). The loader searches System32
-                    // before PATH, so a bare-name load resolves that copy on
-                    // any host without a runtime earlier in the search order,
-                    // and its API version is not the one `ort` requires:
-                    // proceeding hangs exactly like a missing runtime does.
-                    // decibri's documented resolution (the bundled library or
-                    // ORT_DYLIB_PATH) never means the in-box copy, so reject
-                    // it as unusable rather than letting `ort::init()` hang
-                    // on it.
-                    #[cfg(target_os = "windows")]
-                    if let Some(resolved) = windows_module_path(ORT_DEFAULT_LIBRARY) {
-                        if windows_in_box_runtime(&resolved) {
-                            drop(library);
-                            return Err(DecibriError::OrtPathInvalid {
-                                path: resolved,
-                                reason: "no usable ONNX Runtime found: \
-                                         ORT_DYLIB_PATH is not set and the \
-                                         system loader resolves only the \
-                                         Windows in-box runtime, which is not \
-                                         compatible",
-                            });
+            None => {
+                let candidate = ort_candidate(Path::new(ORT_DEFAULT_LIBRARY));
+                let bare_name = candidate == Path::new(ORT_DEFAULT_LIBRARY);
+                // SAFETY: loading a library runs its initialisers. This is
+                // the same load `ort` performs for the same candidate.
+                match unsafe { libloading::Library::new(&candidate) } {
+                    Ok(library) => {
+                        // Windows ships an in-box `onnxruntime.dll` in
+                        // System32 (the Windows ML copy). The loader searches
+                        // System32 before PATH, so a bare-name load resolves
+                        // that copy on any host without a runtime earlier in
+                        // the search order, and its API version is not the
+                        // one `ort` requires. The documented resolution (the
+                        // bundled library or ORT_DYLIB_PATH) never means the
+                        // in-box copy, so reject it as unusable.
+                        #[cfg(target_os = "windows")]
+                        if let Some(resolved) = windows_module_path(ORT_DEFAULT_LIBRARY) {
+                            if windows_in_box_runtime(&resolved) {
+                                drop(library);
+                                return Err(DecibriError::OrtPathInvalid {
+                                    path: resolved,
+                                    reason: "no usable ONNX Runtime found: \
+                                             ORT_DYLIB_PATH is not set and the \
+                                             system loader resolves only the \
+                                             Windows in-box runtime, which is not \
+                                             compatible",
+                                });
+                            }
+                        }
+                        match check_ort_library(library, &candidate) {
+                            // Keep the runtime resident rather than unloading
+                            // it: `ort` loads the same library next, so this
+                            // avoids a pointless unload/reload cycle and
+                            // matches the process state a successful init
+                            // produces.
+                            Ok(library) => std::mem::forget(library),
+                            Err(e) => {
+                                return Err(DecibriError::OrtLoadFailed {
+                                    path: candidate,
+                                    source: Box::new(e),
+                                });
+                            }
                         }
                     }
-                    // Keep the runtime resident rather than unloading it:
-                    // `ort::init()` loads the same library next, so this
-                    // avoids a pointless unload/reload cycle and matches the
-                    // process state a successful init produces.
-                    std::mem::forget(library);
-                }
-                Err(_) => {
-                    // ort also resolves the bare library name against the
-                    // executable's directory, which the system loader does
-                    // not search on Linux and macOS; accept that placement
-                    // and leave the load to `ort::init()` itself.
-                    let beside_exe = exe_sibling(Path::new(ORT_DEFAULT_LIBRARY));
-                    if !beside_exe.as_deref().is_some_and(Path::is_file) {
+                    Err(error) if !bare_name => {
+                        // The copy beside the executable, which `ort` loads
+                        // in preference to the system loader's resolution.
+                        return Err(DecibriError::OrtLoadFailed {
+                            path: candidate.clone(),
+                            source: Box::new(ort::LoadDynamicError::Dlopen {
+                                error,
+                                path: candidate,
+                            }),
+                        });
+                    }
+                    Err(_) => {
                         return Err(DecibriError::OrtPathInvalid {
                             path: PathBuf::from(ORT_DEFAULT_LIBRARY),
                             reason: "no ONNX Runtime is resolvable: ORT_DYLIB_PATH \
@@ -409,7 +533,7 @@ pub(crate) fn init_ort_once(path: Option<&Path>) -> Result<(), DecibriError> {
                         });
                     }
                 }
-            },
+            }
         },
     }
 
@@ -1021,6 +1145,54 @@ mod tests {
             "OrtPathInvalid intentionally has no source (constructing ort::Error \
              would trigger the hang the pre-check prevents)"
         );
+    }
+
+    /// The runtime minor version parse matches `ort`'s: the second dotted
+    /// field, or 0 when it is missing or not a number.
+    #[cfg(feature = "ort-load-dynamic")]
+    #[test]
+    fn ort_runtime_minor_is_the_second_dotted_field() {
+        assert_eq!(ort_runtime_minor("1.28.1"), 28);
+        assert_eq!(ort_runtime_minor("1.24.4"), 24);
+        assert_eq!(ort_runtime_minor("1.30"), 30);
+        assert_eq!(ort_runtime_minor("1"), 0);
+        assert_eq!(ort_runtime_minor(""), 0);
+        assert_eq!(ort_runtime_minor("1.x.3"), 0);
+    }
+
+    /// `ort_candidate` follows `ort`'s resolution: an absolute path passes
+    /// through, a relative path that exists beside the executable resolves
+    /// there, and any other relative path is passed on unchanged.
+    #[cfg(feature = "ort-load-dynamic")]
+    #[test]
+    fn ort_candidate_mirrors_ort_resolution() {
+        let absolute = std::env::temp_dir().join("decibri-ort-candidate-absolute");
+        assert_eq!(ort_candidate(&absolute), absolute);
+
+        let relative = Path::new("decibri-ort-candidate-does-not-exist-xyz");
+        assert_eq!(ort_candidate(relative), relative);
+
+        // The executable's own file name exists beside the executable.
+        let exe = std::env::current_exe().expect("current_exe");
+        let name = exe.file_name().expect("executable file name");
+        assert_eq!(ort_candidate(Path::new(name)), exe);
+    }
+
+    /// A regular file that is not a loadable library fails the probe with the
+    /// `Dlopen` value `ort` would report, and the probe touches no ORT symbol.
+    #[cfg(feature = "ort-load-dynamic")]
+    #[test]
+    fn probe_rejects_a_file_that_is_not_a_library() {
+        let dir = std::env::temp_dir();
+        let file = dir.join(format!("decibri-not-a-library-{}.bin", std::process::id()));
+        std::fs::write(&file, b"this is not a shared library\n").expect("write probe fixture");
+        let outcome = probe_ort_library(&file);
+        let _ = std::fs::remove_file(&file);
+        match outcome {
+            Err(ort::LoadDynamicError::Dlopen { path, .. }) => assert_eq!(path, file),
+            Err(other) => panic!("expected Dlopen, got {other:?}"),
+            Ok(_) => panic!("expected the probe to reject a non-library file"),
+        }
     }
 
     /// Trivial in-memory [`OnnxSession`] for trait-shape testing without ORT.

--- a/crates/decibri/src/onnx.rs
+++ b/crates/decibri/src/onnx.rs
@@ -180,9 +180,14 @@ static ORT_INIT_PID: OnceLock<u32> = OnceLock::new();
 ///
 /// Returns one of two typed variants depending on whether a path was provided:
 /// [`DecibriError::OrtLoadFailed`] when `path.is_some()`, or
-/// [`DecibriError::OrtInitFailed`] otherwise. The inner `ort::Error` is
-/// carried via `#[source]` so consumers can walk the error chain.
-fn wrap_init_error(path: Option<&Path>, err: ort::Error) -> DecibriError {
+/// [`DecibriError::OrtInitFailed`] otherwise. The inner error (the
+/// `ort::LoadDynamicError` a failed `ort::init_from` returns, or an
+/// `ort::Error`) is carried via `#[source]` so consumers can walk the error
+/// chain.
+fn wrap_init_error<E>(path: Option<&Path>, err: E) -> DecibriError
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
     match path {
         Some(p) => DecibriError::OrtLoadFailed {
             path: p.to_path_buf(),
@@ -234,7 +239,11 @@ fn telemetry_enabled() -> bool {
 /// so `init_ort_once` stays single-path.
 ///
 /// Under `ort-load-dynamic`: `ort::init_from(path)` is available and is
-/// fallible (validates the dylib up-front).
+/// fallible (validates the dylib up-front). Its failure is
+/// `ort::LoadDynamicError`, a plain value that touches no ORT symbol. It is
+/// boxed into the decibri variant as is and never converted to an
+/// `ort::Error`, because constructing one calls into the C API of the
+/// runtime that has just failed to load.
 ///
 /// Under `ort-download-binaries`: `ort::init_from` does NOT exist. ORT is
 /// statically linked into the binary and any path argument is meaningless.
@@ -244,7 +253,7 @@ fn telemetry_enabled() -> bool {
 /// Every chain carries [`telemetry_enabled`]; see its documentation for the
 /// default and the limits on it.
 #[cfg(feature = "ort-load-dynamic")]
-fn do_ort_init(path: Option<&Path>) -> Result<bool, ort::Error> {
+fn do_ort_init(path: Option<&Path>) -> Result<bool, ort::LoadDynamicError> {
     let telemetry = telemetry_enabled();
     match path {
         Some(p) => {
@@ -273,9 +282,10 @@ fn do_ort_init(_path: Option<&Path>) -> Result<bool, ort::Error> {
 /// - Otherwise delegates to the feature-gated `do_ort_init` helper.
 /// - On failure, the `OnceLock` is NOT set, so a subsequent caller can retry.
 ///
-/// Note: `e` in the error-wrapping path below is always an `ort::Error` (ORT's
-/// own error type), never a `DecibriError`. This function is the single place
-/// where ORT errors enter decibri's error hierarchy. Do NOT apply the same
+/// Note: `e` in the error-wrapping path below is always one of `ort`'s own
+/// error types (`ort::LoadDynamicError` under `ort-load-dynamic`,
+/// `ort::Error` otherwise), never a `DecibriError`. This function is the
+/// single place where ORT errors enter decibri's error hierarchy. Do NOT apply the same
 /// wrapping pattern elsewhere or the `decibri:` prefix and guidance string
 /// will be duplicated in the message users see.
 pub(crate) fn init_ort_once(path: Option<&Path>) -> Result<(), DecibriError> {

--- a/crates/decibri/src/sample.rs
+++ b/crates/decibri/src/sample.rs
@@ -56,9 +56,11 @@ pub fn i16_le_bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
         "i16_le_bytes_to_f32 expects an even-length buffer; a trailing odd byte is dropped"
     );
     bytes
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|c| {
-            let val = i16::from_le_bytes([c[0], c[1]]);
+            let val = i16::from_le_bytes(*c);
             val as f32 / 32768.0
         })
         .collect()
@@ -70,8 +72,10 @@ pub fn i16_le_bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
 /// Used by the output path: JS sends f32 LE bytes, Rust needs f32 for cpal.
 pub fn f32_le_bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
     bytes
-        .chunks_exact(4)
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|c| f32::from_le_bytes(*c))
         .collect()
 }
 
@@ -243,8 +247,10 @@ mod tests {
 
         // Reconstruct i16 values
         let i16_samples: Vec<i16> = bytes
-            .chunks_exact(2)
-            .map(|c| i16::from_le_bytes([c[0], c[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|c| i16::from_le_bytes(*c))
             .collect();
 
         // Convert back to f32
@@ -266,8 +272,10 @@ mod tests {
         let bytes = f32_to_f32_le_bytes(&original);
 
         let reconstructed: Vec<f32> = bytes
-            .chunks_exact(4)
-            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|c| f32::from_le_bytes(*c))
             .collect();
 
         assert_eq!(original, reconstructed);

--- a/crates/decibri/src/vad.rs
+++ b/crates/decibri/src/vad.rs
@@ -845,7 +845,7 @@ mod tests {
         // takes; it pins the entire per-window probability trajectory,
         // including LSTM state evolution across the two bursts.
         let mut actual: Vec<f32> = Vec::with_capacity(GOLDEN_WINDOWS);
-        for window in fixture.chunks_exact(GOLDEN_WINDOW_SIZE) {
+        for window in fixture.as_chunks::<GOLDEN_WINDOW_SIZE>().0 {
             let result = vad.process(window).unwrap();
             actual.push(result.probability);
         }
@@ -1216,7 +1216,7 @@ mod tests {
 
         let mut vad = SileroVad::new(default_config()).unwrap();
         let mut actual: Vec<f32> = Vec::new();
-        for window in samples.chunks_exact(GOLDEN_WINDOW_SIZE) {
+        for window in samples.as_chunks::<GOLDEN_WINDOW_SIZE>().0 {
             actual.push(vad.process(window).unwrap().probability);
         }
 
@@ -1314,7 +1314,9 @@ mod tests {
         let window_probs = |input: &[f32]| -> Vec<f32> {
             let mut vad = SileroVad::new(default_config()).unwrap();
             input
-                .chunks_exact(GOLDEN_WINDOW_SIZE)
+                .as_chunks::<GOLDEN_WINDOW_SIZE>()
+                .0
+                .iter()
                 .map(|w| vad.process(w).unwrap().probability)
                 .collect()
         };

--- a/crates/decibri/tests/vad_ort_load_failure.rs
+++ b/crates/decibri/tests/vad_ort_load_failure.rs
@@ -9,14 +9,20 @@
 //!
 //! The tests rely on the defensive pre-check in
 //! `crates/decibri/src/onnx.rs::init_ort_once`, which validates that the
-//! provided `ort_library_path` points at a regular file before handing it
-//! to `ort::init_from`. Without that pre-check, Windows hangs indefinitely
+//! provided `ort_library_path` points at a regular file, then loads it and
+//! checks it the way `ort` does (it exports `OrtGetApiBase` and reports the
+//! ONNX Runtime version `ort` requires), before handing it to
+//! `ort::init_from`. Without the filesystem check, Windows hangs indefinitely
 //! inside `ort::init_from` on a nonexistent path (reproduced 2026-04-22
-//! against pyke/ort 2.0.0-rc.12 + onnxruntime 1.24.4). The pre-check
-//! returns [`DecibriError::OrtPathInvalid`], deliberately a string-only
-//! variant that does *not* construct an `ort::Error`, because
-//! `ort::Error::new` itself calls `ortsys![CreateStatus]` and would
-//! re-trigger the very dylib load we're avoiding.
+//! against pyke/ort 2.0.0-rc.12 + onnxruntime 1.24.4). That check returns
+//! [`DecibriError::OrtPathInvalid`], deliberately a string-only variant that
+//! does *not* construct an `ort::Error`, because `ort::Error::new` itself
+//! calls `ortsys![CreateStatus]` and would re-trigger the very dylib load
+//! we're avoiding. The load check returns [`DecibriError::OrtLoadFailed`]
+//! carrying the `ort::LoadDynamicError` for the condition; a load that fails
+//! inside `ort` cannot be retried in a process, so every attempt against a
+//! file that is not a usable runtime has to fail the same typed way, which
+//! the retry tests below pin.
 //!
 //! Gated behind `feature = "ort-load-dynamic"` because the tests are
 //! meaningful only under the dynamic-load distribution mode: under
@@ -165,5 +171,148 @@ fn test_ort_load_fails_when_path_is_directory() {
             );
         }
         other => panic!("expected OrtPathInvalid, got {other:?}"),
+    }
+}
+
+/// A `VadConfig` for the bundled model with the given `ort_library_path`.
+fn config_for(ort_library_path: Option<PathBuf>) -> VadConfig {
+    let mut config = VadConfig::default();
+    config.model_path = bundled_model_path();
+    config.ort_library_path = ort_library_path;
+    config
+}
+
+/// A regular file in the temp directory that is not a shared library, named
+/// for this process so concurrent test binaries cannot collide.
+fn write_non_library(tag: &str) -> PathBuf {
+    let file = std::env::temp_dir().join(format!("decibri-{tag}-{}.bin", std::process::id()));
+    std::fs::write(&file, b"this is not a shared library\n").expect("write the fixture file");
+    file
+}
+
+/// The `ort::LoadDynamicError` an `OrtLoadFailed` carries as its source.
+fn load_dynamic_source(err: &DecibriError) -> Option<&ort::LoadDynamicError> {
+    std::error::Error::source(err).and_then(|source| source.downcast_ref::<ort::LoadDynamicError>())
+}
+
+/// A regular file that is not a loadable library fails with `OrtLoadFailed`
+/// carrying `ort::LoadDynamicError::Dlopen`, and a second attempt in the same
+/// process fails the same way: the pre-check rejects the file before `ort`
+/// loads anything, so nothing in the process changes between the attempts.
+#[test]
+fn test_ort_load_fails_the_same_way_twice_for_a_file_that_is_not_a_library() {
+    let _env = ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+    let file = write_non_library("not-a-library");
+
+    for attempt in 1..=2 {
+        let err = SileroVad::new(config_for(Some(file.clone())))
+            .err()
+            .unwrap_or_else(|| panic!("attempt {attempt}: expected OrtLoadFailed"));
+        match &err {
+            DecibriError::OrtLoadFailed { path, .. } => {
+                assert_eq!(path, &file, "attempt {attempt}: OrtLoadFailed.path");
+            }
+            other => panic!("attempt {attempt}: expected OrtLoadFailed, got {other:?}"),
+        }
+        match load_dynamic_source(&err) {
+            Some(ort::LoadDynamicError::Dlopen { path, .. }) => {
+                assert_eq!(path, &file, "attempt {attempt}: Dlopen.path");
+            }
+            Some(other) => panic!("attempt {attempt}: expected Dlopen, got {other:?}"),
+            None => {
+                panic!("attempt {attempt}: OrtLoadFailed should carry an ort::LoadDynamicError")
+            }
+        }
+    }
+
+    let _ = std::fs::remove_file(&file);
+}
+
+/// A module that loads but is not ONNX Runtime, the test executable itself
+/// where the loader accepts an executable, fails with `OrtLoadFailed` on
+/// every attempt. The source is `MissingApi` where the module loads and
+/// `Dlopen` where the loader refuses an executable; it is never anything
+/// else, and the second attempt reports what the first did.
+#[test]
+fn test_ort_load_fails_the_same_way_twice_for_a_module_without_the_entry_point() {
+    let _env = ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+    let exe = std::env::current_exe().expect("current_exe");
+
+    let mut first: Option<&'static str> = None;
+    for attempt in 1..=2 {
+        let err = SileroVad::new(config_for(Some(exe.clone())))
+            .err()
+            .unwrap_or_else(|| panic!("attempt {attempt}: expected OrtLoadFailed"));
+        match &err {
+            DecibriError::OrtLoadFailed { path, .. } => {
+                assert_eq!(path, &exe, "attempt {attempt}: OrtLoadFailed.path");
+            }
+            other => panic!("attempt {attempt}: expected OrtLoadFailed, got {other:?}"),
+        }
+        let variant = match load_dynamic_source(&err) {
+            Some(ort::LoadDynamicError::MissingApi { .. }) => "MissingApi",
+            Some(ort::LoadDynamicError::Dlopen { .. }) => "Dlopen",
+            Some(other) => {
+                panic!("attempt {attempt}: expected MissingApi or Dlopen, got {other:?}")
+            }
+            None => {
+                panic!("attempt {attempt}: OrtLoadFailed should carry an ort::LoadDynamicError")
+            }
+        };
+        #[cfg(target_os = "windows")]
+        assert_eq!(
+            variant, "MissingApi",
+            "attempt {attempt}: on Windows the executable loads as a module and lacks OrtGetApiBase"
+        );
+        match first {
+            None => first = Some(variant),
+            Some(previous) => assert_eq!(
+                variant, previous,
+                "the second attempt reports what the first did"
+            ),
+        }
+    }
+}
+
+/// With no `ort_library_path`, an `ORT_DYLIB_PATH` that names a regular file
+/// which is not a loadable library fails with `OrtLoadFailed` carrying
+/// `Dlopen`, on the first attempt and on the second. Without the load check
+/// this path reaches `ort::init()`, which loads lazily at the first C API
+/// call and panics there.
+///
+/// Environment note: sets `ORT_DYLIB_PATH` for its own scope under `ENV_LOCK`,
+/// like the bogus-path test above.
+#[test]
+fn test_ort_load_fails_the_same_way_twice_for_an_unusable_env_var_and_no_path() {
+    let _env = ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+    let file = write_non_library("not-a-library-env");
+    std::env::set_var("ORT_DYLIB_PATH", &file);
+    let results: Vec<_> = (1..=2).map(|_| SileroVad::new(config_for(None))).collect();
+    std::env::remove_var("ORT_DYLIB_PATH");
+    let _ = std::fs::remove_file(&file);
+
+    for (index, result) in results.into_iter().enumerate() {
+        let attempt = index + 1;
+        let err = result
+            .err()
+            .unwrap_or_else(|| panic!("attempt {attempt}: expected OrtLoadFailed"));
+        match &err {
+            DecibriError::OrtLoadFailed { path, .. } => {
+                assert_eq!(
+                    path, &file,
+                    "attempt {attempt}: OrtLoadFailed.path is the ORT_DYLIB_PATH value"
+                );
+            }
+            other => panic!("attempt {attempt}: expected OrtLoadFailed, got {other:?}"),
+        }
+        match load_dynamic_source(&err) {
+            Some(ort::LoadDynamicError::Dlopen { path, .. }) => {
+                assert_eq!(path, &file, "attempt {attempt}: Dlopen.path");
+            }
+            Some(other) => panic!("attempt {attempt}: expected Dlopen, got {other:?}"),
+            None => {
+                panic!("attempt {attempt}: OrtLoadFailed should carry an ort::LoadDynamicError")
+            }
+        }
     }
 }

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -15,6 +15,10 @@ For other decibri packages, see:
 
 - The bundled ONNX Runtime is 1.28.1 in every platform package, and the native addon is built against `ort` 2.0.0-rc.13 (`api-28`). An `ORT_DYLIB_PATH` override must point at ONNX Runtime 1.28 or newer.
 
+### Fixed
+
+- A bundled or `ORT_DYLIB_PATH` ONNX Runtime that cannot be used (not a loadable library, or older than 1.28) rejects with `ORT_LOAD_FAILED` on every silero or denoise attempt; a second attempt after such a failure no longer aborts the process.
+
 ## [5.6.0] - 2026-08-16
 
 ### Breaking changes

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -9,6 +9,12 @@ For other decibri packages, see:
 - Rust core: [crates/decibri/CHANGELOG.md](../../crates/decibri/CHANGELOG.md)
 - Python package: [bindings/python/CHANGELOG.md](../../bindings/python/CHANGELOG.md)
 
+## [Unreleased]
+
+### Changed
+
+- The bundled ONNX Runtime is 1.28.1 in every platform package, and the native addon is built against `ort` 2.0.0-rc.13 (`api-28`). An `ORT_DYLIB_PATH` override must point at ONNX Runtime 1.28 or newer.
+
 ## [5.6.0] - 2026-08-16
 
 ### Breaking changes

--- a/npm/decibri/src/decibri.js
+++ b/npm/decibri/src/decibri.js
@@ -26,7 +26,7 @@ const PACKAGE_VERSION = require('../package.json').version;
  *
  * Dylib filenames are unversioned across all platforms for consistency. The
  * release workflow (.github/workflows/release.yml) copies Microsoft's
- * versioned upstream tarball file (e.g. libonnxruntime.1.24.4.dylib) into the
+ * versioned upstream tarball file (e.g. libonnxruntime.1.28.1.dylib) into the
  * platform package with the unversioned name listed here.
  *
  * If you add a new platform, update this table AND the matching platform job

--- a/npm/platform-darwin-arm64/THIRD-PARTY-NOTICES.md
+++ b/npm/platform-darwin-arm64/THIRD-PARTY-NOTICES.md
@@ -8,9 +8,9 @@ with the files.
 ## ONNX Runtime
 
 - **Name:** ONNX Runtime
-- **Version:** 1.24.4
+- **Version:** 1.28.1
 - **License:** MIT
-- **Source:** https://github.com/microsoft/onnxruntime (release `v1.24.4`)
+- **Source:** https://github.com/microsoft/onnxruntime (release `v1.28.1`)
 - **Files covered:** the ONNX Runtime dynamic libraries distributed in this
   package: `onnxruntime.dll` on Windows, `libonnxruntime.dylib` on macOS,
   `libonnxruntime.so` and `libonnxruntime_providers_shared.so` on Linux. Each
@@ -53,11 +53,11 @@ SOFTWARE.
 ## ONNX Runtime Third-Party Notices
 
 The following section reproduces, verbatim, the `ThirdPartyNotices.txt` file
-from the ONNX Runtime `v1.24.4` release archives. It covers third-party
+from the ONNX Runtime `v1.28.1` release archives. It covers third-party
 material incorporated into the ONNX Runtime libraries named above. The text
 between the markers is upstream's, unaltered.
 
-<!-- BEGIN VERBATIM ThirdPartyNotices.txt (ONNX Runtime v1.24.4) -->
+<!-- BEGIN VERBATIM ThirdPartyNotices.txt (ONNX Runtime v1.28.1) -->
 ```text
 THIRD PARTY SOFTWARE NOTICES AND INFORMATION
 
@@ -6181,7 +6181,7 @@ Redistribution and use in source and binary forms, with or without modification,
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
-<!-- END VERBATIM ThirdPartyNotices.txt (ONNX Runtime v1.24.4) -->
+<!-- END VERBATIM ThirdPartyNotices.txt (ONNX Runtime v1.28.1) -->
 
 ## Source Availability: Eigen (MPL-2.0)
 
@@ -6191,6 +6191,6 @@ notices above. The Eigen source code for this ONNX Runtime version is
 available at:
 
 - https://github.com/eigen-mirror/eigen/archive/1d8b82b0740839c0de7f1242a3585e3390ff5f33/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip
-  (the archive ONNX Runtime `v1.24.4` builds against, per `cmake/deps.txt`
+  (the archive ONNX Runtime `v1.28.1` builds against, per `cmake/deps.txt`
   at that tag)
 - https://gitlab.com/libeigen/eigen (the Eigen project repository)

--- a/npm/platform-linux-arm64-gnu/THIRD-PARTY-NOTICES.md
+++ b/npm/platform-linux-arm64-gnu/THIRD-PARTY-NOTICES.md
@@ -8,9 +8,9 @@ with the files.
 ## ONNX Runtime
 
 - **Name:** ONNX Runtime
-- **Version:** 1.24.4
+- **Version:** 1.28.1
 - **License:** MIT
-- **Source:** https://github.com/microsoft/onnxruntime (release `v1.24.4`)
+- **Source:** https://github.com/microsoft/onnxruntime (release `v1.28.1`)
 - **Files covered:** the ONNX Runtime dynamic libraries distributed in this
   package: `onnxruntime.dll` on Windows, `libonnxruntime.dylib` on macOS,
   `libonnxruntime.so` and `libonnxruntime_providers_shared.so` on Linux. Each
@@ -53,11 +53,11 @@ SOFTWARE.
 ## ONNX Runtime Third-Party Notices
 
 The following section reproduces, verbatim, the `ThirdPartyNotices.txt` file
-from the ONNX Runtime `v1.24.4` release archives. It covers third-party
+from the ONNX Runtime `v1.28.1` release archives. It covers third-party
 material incorporated into the ONNX Runtime libraries named above. The text
 between the markers is upstream's, unaltered.
 
-<!-- BEGIN VERBATIM ThirdPartyNotices.txt (ONNX Runtime v1.24.4) -->
+<!-- BEGIN VERBATIM ThirdPartyNotices.txt (ONNX Runtime v1.28.1) -->
 ```text
 THIRD PARTY SOFTWARE NOTICES AND INFORMATION
 
@@ -6181,7 +6181,7 @@ Redistribution and use in source and binary forms, with or without modification,
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
-<!-- END VERBATIM ThirdPartyNotices.txt (ONNX Runtime v1.24.4) -->
+<!-- END VERBATIM ThirdPartyNotices.txt (ONNX Runtime v1.28.1) -->
 
 ## Source Availability: Eigen (MPL-2.0)
 
@@ -6191,6 +6191,6 @@ notices above. The Eigen source code for this ONNX Runtime version is
 available at:
 
 - https://github.com/eigen-mirror/eigen/archive/1d8b82b0740839c0de7f1242a3585e3390ff5f33/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip
-  (the archive ONNX Runtime `v1.24.4` builds against, per `cmake/deps.txt`
+  (the archive ONNX Runtime `v1.28.1` builds against, per `cmake/deps.txt`
   at that tag)
 - https://gitlab.com/libeigen/eigen (the Eigen project repository)

--- a/npm/platform-linux-x64-gnu/THIRD-PARTY-NOTICES.md
+++ b/npm/platform-linux-x64-gnu/THIRD-PARTY-NOTICES.md
@@ -8,9 +8,9 @@ with the files.
 ## ONNX Runtime
 
 - **Name:** ONNX Runtime
-- **Version:** 1.24.4
+- **Version:** 1.28.1
 - **License:** MIT
-- **Source:** https://github.com/microsoft/onnxruntime (release `v1.24.4`)
+- **Source:** https://github.com/microsoft/onnxruntime (release `v1.28.1`)
 - **Files covered:** the ONNX Runtime dynamic libraries distributed in this
   package: `onnxruntime.dll` on Windows, `libonnxruntime.dylib` on macOS,
   `libonnxruntime.so` and `libonnxruntime_providers_shared.so` on Linux. Each
@@ -53,11 +53,11 @@ SOFTWARE.
 ## ONNX Runtime Third-Party Notices
 
 The following section reproduces, verbatim, the `ThirdPartyNotices.txt` file
-from the ONNX Runtime `v1.24.4` release archives. It covers third-party
+from the ONNX Runtime `v1.28.1` release archives. It covers third-party
 material incorporated into the ONNX Runtime libraries named above. The text
 between the markers is upstream's, unaltered.
 
-<!-- BEGIN VERBATIM ThirdPartyNotices.txt (ONNX Runtime v1.24.4) -->
+<!-- BEGIN VERBATIM ThirdPartyNotices.txt (ONNX Runtime v1.28.1) -->
 ```text
 THIRD PARTY SOFTWARE NOTICES AND INFORMATION
 
@@ -6181,7 +6181,7 @@ Redistribution and use in source and binary forms, with or without modification,
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
-<!-- END VERBATIM ThirdPartyNotices.txt (ONNX Runtime v1.24.4) -->
+<!-- END VERBATIM ThirdPartyNotices.txt (ONNX Runtime v1.28.1) -->
 
 ## Source Availability: Eigen (MPL-2.0)
 
@@ -6191,6 +6191,6 @@ notices above. The Eigen source code for this ONNX Runtime version is
 available at:
 
 - https://github.com/eigen-mirror/eigen/archive/1d8b82b0740839c0de7f1242a3585e3390ff5f33/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip
-  (the archive ONNX Runtime `v1.24.4` builds against, per `cmake/deps.txt`
+  (the archive ONNX Runtime `v1.28.1` builds against, per `cmake/deps.txt`
   at that tag)
 - https://gitlab.com/libeigen/eigen (the Eigen project repository)

--- a/npm/platform-win32-x64-msvc/THIRD-PARTY-NOTICES.md
+++ b/npm/platform-win32-x64-msvc/THIRD-PARTY-NOTICES.md
@@ -8,9 +8,9 @@ with the files.
 ## ONNX Runtime
 
 - **Name:** ONNX Runtime
-- **Version:** 1.24.4
+- **Version:** 1.28.1
 - **License:** MIT
-- **Source:** https://github.com/microsoft/onnxruntime (release `v1.24.4`)
+- **Source:** https://github.com/microsoft/onnxruntime (release `v1.28.1`)
 - **Files covered:** the ONNX Runtime dynamic libraries distributed in this
   package: `onnxruntime.dll` on Windows, `libonnxruntime.dylib` on macOS,
   `libonnxruntime.so` and `libonnxruntime_providers_shared.so` on Linux. Each
@@ -53,11 +53,11 @@ SOFTWARE.
 ## ONNX Runtime Third-Party Notices
 
 The following section reproduces, verbatim, the `ThirdPartyNotices.txt` file
-from the ONNX Runtime `v1.24.4` release archives. It covers third-party
+from the ONNX Runtime `v1.28.1` release archives. It covers third-party
 material incorporated into the ONNX Runtime libraries named above. The text
 between the markers is upstream's, unaltered.
 
-<!-- BEGIN VERBATIM ThirdPartyNotices.txt (ONNX Runtime v1.24.4) -->
+<!-- BEGIN VERBATIM ThirdPartyNotices.txt (ONNX Runtime v1.28.1) -->
 ```text
 THIRD PARTY SOFTWARE NOTICES AND INFORMATION
 
@@ -6181,7 +6181,7 @@ Redistribution and use in source and binary forms, with or without modification,
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
-<!-- END VERBATIM ThirdPartyNotices.txt (ONNX Runtime v1.24.4) -->
+<!-- END VERBATIM ThirdPartyNotices.txt (ONNX Runtime v1.28.1) -->
 
 ## Source Availability: Eigen (MPL-2.0)
 
@@ -6191,6 +6191,6 @@ notices above. The Eigen source code for this ONNX Runtime version is
 available at:
 
 - https://github.com/eigen-mirror/eigen/archive/1d8b82b0740839c0de7f1242a3585e3390ff5f33/eigen-1d8b82b0740839c0de7f1242a3585e3390ff5f33.zip
-  (the archive ONNX Runtime `v1.24.4` builds against, per `cmake/deps.txt`
+  (the archive ONNX Runtime `v1.28.1` builds against, per `cmake/deps.txt`
   at that tag)
 - https://gitlab.com/libeigen/eigen (the Eigen project repository)

--- a/tests/test-ci.js
+++ b/tests/test-ci.js
@@ -1531,11 +1531,13 @@ console.log('  Group 8f done\n');
 // covers. Each notice also reproduces, between marker lines, the verbatim
 // ThirdPartyNotices.txt from the pinned ONNX Runtime release archives. These
 // assertions hold the pins and the notices in lockstep: the three workflow
-// pins agree, every version-shaped string in every notice equals that pin,
-// the five notice copies are byte-identical, each copy carries exactly one
-// marker-delimited verbatim section, and that section's text hashes to the
-// upstream file's SHA-256. The hash constant moves together with the
-// ORT_VERSION pins whenever the bundled ONNX Runtime version changes.
+// pins agree, the four ORT_SHA256_* archive digests declared beside each pin
+// are well-formed, agree across the three workflows and are distinct, every
+// version-shaped string in every notice equals that pin, the five notice
+// copies are byte-identical, each copy carries exactly one marker-delimited
+// verbatim section, and that section's text hashes to the upstream file's
+// SHA-256. The hash constant moves when the upstream file changes between
+// bundled versions.
 
 console.log('--- Group 8g: third-party notice version pins ---');
 
@@ -1548,15 +1550,46 @@ console.log('--- Group 8g: third-party notice version pins ---');
     path.join('.github', 'workflows', 'publish-pypi.yml'),
     path.join('.github', 'workflows', 'python-ci.yml'),
   ];
-  const pins = workflowFiles.map((rel) => {
-    const text = fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+  const workflowTexts = workflowFiles.map((rel) => fs.readFileSync(path.join(repoRoot, rel), 'utf8'));
+  const pins = workflowTexts.map((text, i) => {
     const match = text.match(/^\s+ORT_VERSION:\s*([0-9]+\.[0-9]+\.[0-9]+)\s*$/m);
-    assert(match !== null, `${rel} declares an ORT_VERSION pin`);
+    assert(match !== null, `${workflowFiles[i]} declares an ORT_VERSION pin`);
     return match ? match[1] : null;
   });
   assert(
     pins.every((pin) => pin !== null && pin === pins[0]),
     `the three workflow ORT_VERSION pins agree (${pins.join(', ')})`
+  );
+
+  // One SHA-256 per ONNX Runtime release archive the workflows download,
+  // declared beside the pin in each workflow's env block and compared against
+  // the downloaded archive before it is extracted.
+  const digestNames = [
+    'ORT_SHA256_LINUX_X64',
+    'ORT_SHA256_LINUX_AARCH64',
+    'ORT_SHA256_OSX_ARM64',
+    'ORT_SHA256_WIN_X64',
+  ];
+  const digests = workflowTexts.map((text, i) =>
+    digestNames.map((name) => {
+      const line = text.split(/\r?\n/).find((candidate) => candidate.startsWith(`  ${name}: `));
+      const value = line === undefined ? null : line.slice(`  ${name}: `.length).trim();
+      assert(
+        value !== null && /^[0-9a-f]{64}$/.test(value),
+        `${workflowFiles[i]} declares ${name} as a 64-digit lowercase hex SHA-256`
+      );
+      return value;
+    })
+  );
+  digestNames.forEach((name, j) => {
+    assert(
+      digests.every((set) => set[j] !== null && set[j] === digests[0][j]),
+      `the three workflow ${name} digests agree`
+    );
+  });
+  assert(
+    new Set(digests[0]).size === digestNames.length,
+    'the four archive digests are distinct'
   );
 
   const noticeFiles = [
@@ -1757,6 +1790,50 @@ console.log('--- Group 8h: bundled model pins ---');
 }
 
 console.log('  Group 8h done\n');
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 8i: ONNX Runtime telemetry propagation (deterministic, no hardware required)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// decibri disables ONNX Runtime telemetry by default on the environment it
+// commits, by chaining `.with_telemetry(...)` with the DECIBRI_ORT_TELEMETRY
+// switch onto every environment builder in `do_ort_init`
+// (crates/decibri/src/onnx.rs). The runtime's telemetry state is not
+// observable from a test, but the source text is: these assertions require
+// the call on every committed builder chain and require its argument to be
+// the switch, so a chain that drops the call or hardwires the value fails
+// here. Line comments are stripped first so prose naming the calls does not
+// count.
+
+console.log('--- Group 8i: ONNX Runtime telemetry propagation ---');
+
+{
+  const fs = require('fs');
+  const source = fs.readFileSync(
+    path.join(__dirname, '..', 'crates', 'decibri', 'src', 'onnx.rs'),
+    'utf8'
+  );
+  const code = source
+    .split(/\r?\n/)
+    .filter((line) => !/^\s*\/\//.test(line))
+    .join('\n');
+  const variants = (code.match(/^fn do_ort_init\(/gm) || []).length;
+  assert(variants === 2, `onnx.rs defines both do_ort_init variants (found ${variants})`);
+  const commits = (code.match(/\.commit\(\)/g) || []).length;
+  assert(commits >= 2, `onnx.rs commits at least one environment builder per variant (found ${commits})`);
+  const telemetryCalls = (code.match(/\.with_telemetry\(/g) || []).length;
+  assert(
+    telemetryCalls === commits,
+    `every committed environment builder chain carries .with_telemetry( (${telemetryCalls} of ${commits})`
+  );
+  const fromSwitch = (code.match(/\.with_telemetry\((telemetry|telemetry_enabled\(\))\)/g) || []).length;
+  assert(
+    fromSwitch === telemetryCalls,
+    `every .with_telemetry( argument is the DECIBRI_ORT_TELEMETRY switch (${fromSwitch} of ${telemetryCalls})`
+  );
+}
+
+console.log('  Group 8i done\n');
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Group 9: async open() factories (deterministic, no hardware required)

--- a/tests/test-file.js
+++ b/tests/test-file.js
@@ -491,6 +491,53 @@ async function fileTests(h) {
     `a consumed File carries the FILE_CONSUMED code (got ${consumedErr && consumedErr.code})`
   );
 
+  // The detector's runtime failing to load is a typed failure on every
+  // attempt in a process, never an abort: a second analysis after a failed
+  // load reports what the first did. Run it in a child so an abort is an
+  // exit status, not the end of this suite. With a loadable runtime both
+  // analyses succeed; without one both reject with ORT_LOAD_FAILED.
+  const retryPath = path.join(tmp, 'retry.js');
+  fs.writeFileSync(
+    retryPath,
+    [
+      "'use strict';",
+      `const { File, DecibriError } = require(${JSON.stringify(DECIBRI_ENTRY)});`,
+      'const outcomes = [];',
+      '(async () => {',
+      '  for (let i = 0; i < 2; i++) {',
+      '    try {',
+      "      await File.buffer(new Float32Array(3200), { inputRate: 16000, vad: 'silero' }).analyze();",
+      "      outcomes.push('ok');",
+      '    } catch (e) {',
+      "      outcomes.push(e instanceof DecibriError ? e.code : 'untyped');",
+      '    }',
+      '  }',
+      '  process.stdout.write(JSON.stringify(outcomes));',
+      '})();',
+      '',
+    ].join('\n')
+  );
+  const retry = spawnSync(process.execPath, [retryPath], { encoding: 'utf8' });
+  assert(
+    retry.status === 0,
+    `two silero analyses in one process leave the process alive ` +
+      `(exit ${retry.status}, signal ${retry.signal}, stderr: ${(retry.stderr || '').split('\n')[0]})`
+  );
+  let retryOutcomes = [];
+  try {
+    retryOutcomes = JSON.parse(retry.stdout);
+  } catch (_) {
+    retryOutcomes = [];
+  }
+  assert(
+    retryOutcomes.length === 2 && retryOutcomes.every((o) => o === 'ok' || o === 'ORT_LOAD_FAILED'),
+    `each silero analysis either succeeds or rejects with ORT_LOAD_FAILED (got ${retry.stdout})`
+  );
+  assert(
+    retryOutcomes.length === 2 && retryOutcomes[0] === retryOutcomes[1],
+    `a second silero analysis reports what the first did (got ${retry.stdout})`
+  );
+
   // An exhausted File yields nothing on a second pass, no error.
   const exhausted = File.buffer(sineSamples(16000, 0.2), { inputRate: 16000 });
   assert((await readAll(exhausted)).length > 0, 'first pass over a File delivers audio');


### PR DESCRIPTION
- Bundle ONNX Runtime 1.28.1 in the four npm platform packages and the wheel, and pin ort at 2.0.0-rc.13 with the api-28 feature; the three workflow ORT_VERSION pins, the check-upstream api_n baseline, the five third-party notices, the Docker
  documentation pins and the maintainer comments move with it.
- Adapt do_ort_init to ort::init_from returning ort::LoadDynamicError, boxing it as the OrtLoadFailed source; the variant, its code and its message are unchanged.
- Verify every downloaded ONNX Runtime archive against its published SHA-256 before extraction in publish-npm.yml, publish-pypi.yml and python-ci.yml; the resolved URL and digest reach each download step as environment variables via GITHUB_ENV,
  so no run block expands a step output through the template layer, and test-ci.js holds the four digests in lockstep across the three workflows.
- Assert in test-ci.js that every committed ORT environment builder in onnx.rs carries .with_telemetry( with the DECIBRI_ORT_TELEMETRY switch.
- Replace every constant-size chunks_exact with as_chunks across crates/decibri and probe post-consumption refusal through a named peekable binding in the file tests, clearing the lints Rust 1.98 adds; window sizes, iteration order and the dropped trailing remainder are unchanged at every site.
- Resolve and check the ONNX Runtime library in init_ort_once before ort loads it (it loads, exports OrtGetApiBase, and reports the runtime version ort requires), for an explicit ort_library_path, for ORT_DYLIB_PATH and for the bare platform name, so a runtime that is present but unusable is OrtLoadFailed on every attempt and a second attempt after such a failure no longer aborts the process; the retry is pinned in the Rust load-dynamic tests, in test-file.js and in the Python suite.