### PR TITLE
fix(core): evict whole frames from the multichannel detector tap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ All commits, tags, and registry publishes are performed manually. If a task appe
 
 ## Code Quality
 
-- Run `cargo clippy --workspace -- -D warnings` before committing Rust changes. Fix all warnings. Do not suppress with `#[allow]`.
+- Run `cargo clippy --workspace --all-targets -- -D warnings` before committing Rust changes. Fix all warnings. Do not suppress with `#[allow]`.
 - Run `cargo fmt --all -- --check` before committing. If it reports formatting drift, run `cargo fmt --all` and stage the result.
 - Run `cargo test-decibri` after any Rust changes to verify no regressions. This alias (defined in `.cargo/config.toml`) builds with `ort-download-binaries` so VAD tests run without a pre-staged ORT dylib; plain `cargo test -p decibri` hangs on VAD tests in a fresh workspace.
 - Run `node tests/test-capture.js`, `node tests/test-api.js`, `node tests/test-output.js`, `node tests/test-vad-silero.js` after JS or napi binding changes.
@@ -29,7 +29,6 @@ All commits, tags, and registry publishes are performed manually. If a task appe
 ## API Compatibility
 
 - The Node.js `Decibri` class API is frozen. Do not change constructor options, event names, method signatures, or error messages without explicit approval.
-- Downstream consumers (mcp-listen, voxagent, Wake Word) depend on exact API compatibility. Any change must be tested against all three.
 - Error messages are exact string matches. Do not rephrase them.
 
 ## CI
@@ -43,5 +42,5 @@ All commits, tags, and registry publishes are performed manually. If a task appe
 ## Changelog
 
 - Update `CHANGELOG.md` when adding features, fixing bugs, or making breaking changes.
-- Add entries under the `## [<next-version>] - Unreleased` section in the appropriate subsection (Added, Changed, Fixed, Removed).
+- Add entries under the `## [Unreleased]` section in the appropriate subsection (Added, Changed, Fixed, Removed). At a release that heading becomes `## [X.Y.Z] - YYYY-MM-DD`.
 - Use [Keep a Changelog](https://keepachangelog.com) format. One bullet per change, concise. A version section that contains breaking changes opens with a `### Breaking changes` heading above those subsections; the heading groups the breaking entries and replaces none of the named types.

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -8,6 +8,12 @@ For Rust core (`crates/decibri`) and npm package (`npm/decibri`) changes, see [t
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- With a VAD active on a multichannel stream that has an enhancement step enabled, the detector feed holds two seconds of frames at every channel count and evicts whole frames. A stream whose delivered block exceeded the feed's bound (more than 20 channels at 16 kHz, or 60 at 48 kHz, at the default `frames_per_buffer` of 1600; fewer channels with a larger `frames_per_buffer`) lost feed frames on every block, and at a channel count that does not divide the bound also fed the detector a channel other than the one `detector_source` named. Mono streams and streams with no enhancement step are unchanged.
+
 ## [0.12.0] - 2026-08-21
 
 ### Added

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -9,6 +9,12 @@ For other decibri packages, see:
 - npm package: [npm/decibri/CHANGELOG.md](../../npm/decibri/CHANGELOG.md)
 - Python package: [bindings/python/CHANGELOG.md](../../bindings/python/CHANGELOG.md)
 
+## [Unreleased]
+
+### Fixed
+
+- The capture stream's pre-transform detector tap (`vad_input` / `detector_feed`) holds two seconds of frames at every channel count and evicts whole frames. The bound was sized in samples, so a multichannel tap held `2 / channels` seconds, and at a channel count that does not divide the bound's sample count (3 at 16 kHz, for example) an eviction left a partial frame at the front of the tap and every later drain read frames shifted by that offset: a `DetectorSource::Channel` feed carried a channel other than the one named, and an `Average` feed averaged across frame boundaries. Only a tap that passes its bound is affected, which is a consumer that does not drain it once per delivered block, or a delivered block larger than the bound at that channel count. Mono streams, streams with no enhancement step and `File` are unchanged.
+
 ## [6.3.0] - 2026-08-21
 
 ### Added

--- a/crates/decibri/src/microphone.rs
+++ b/crates/decibri/src/microphone.rs
@@ -489,14 +489,16 @@ pub struct AudioChunk {
 #[cfg(feature = "capture")]
 const CAPTURE_CHANNEL_CAPACITY: usize = 64;
 
-/// Memory bound for the pre-transform VAD tap, in seconds of audio at the target
+/// Memory bound for the pre-transform VAD tap, in seconds of frames at the target
 /// rate. The tap accumulates the post-normalize signal in lockstep with the
 /// delivered output and is drained by [`MicrophoneStream::vad_input`]. A consumer
 /// that enables an enhancement step but never drains the tap would otherwise grow
-/// memory without limit; beyond this many seconds the oldest tapped samples are
-/// dropped. Sized far above the in-flight reblock depth and any transform
-/// latency, so an actively draining VAD never reaches it even when the tap leads
-/// the delivered output (as it does once a length-changing denoise stage runs).
+/// memory without limit; beyond this many seconds the oldest tapped frames are
+/// dropped, whole frames at a time, so the tap holds the same duration at every
+/// channel count and stays on its frame boundary. Sized far above the in-flight
+/// reblock depth and any transform latency, so an actively draining VAD never
+/// reaches it even when the tap leads the delivered output (as it does once a
+/// length-changing denoise stage runs).
 #[cfg(feature = "capture")]
 const VAD_TAP_BOUND_SECS: usize = 2;
 
@@ -625,8 +627,10 @@ pub struct MicrophoneStream {
     // Copied from the configuration at start and fixed for the stream's
     // lifetime.
     detector_source: DetectorSource,
-    // Memory bound (in samples) for `vad_tap`, computed from the target rate at
-    // construction (see `VAD_TAP_BOUND_SECS`). Oldest tapped samples are dropped
+    // Memory bound for `vad_tap`, in interleaved samples: `VAD_TAP_BOUND_SECS`
+    // seconds of frames at the target rate, multiplied by `tap_channels`, so it
+    // is always a whole number of frames and holds the same duration at every
+    // channel count. Computed at construction. Oldest tapped frames are dropped
     // beyond this so a consumer that enables an enhancement step but never drains
     // `vad_input` cannot grow memory without limit. Never reached while a VAD
     // actively drains the tap, so it does not perturb alignment.
@@ -993,14 +997,27 @@ impl MicrophoneStream {
     /// the [`VAD_TAP_BOUND_SECS`] memory bound. A no-op when the tap is inactive
     /// (no transform). The bound only trips when a transform is enabled but the
     /// tap is not being drained, so it never perturbs an actively draining VAD.
+    ///
+    /// The eviction drains whole frames at `tap_channels`: every push is a whole
+    /// number of frames, so the tap stays on its frame boundary and a later
+    /// [`detector_feed`](Self::detector_feed) collapses real frames rather than
+    /// a run shifted by a partial one. The excess rounds up to the frame, which
+    /// keeps the tap at or under the bound.
     fn push_vad_tap(&self, samples: Vec<f32>) {
         if let Some(tap) = &self.vad_tap {
             let mut tap = tap.lock().unwrap_or_else(PoisonError::into_inner);
             tap.extend(samples);
             if tap.len() > self.vad_tap_cap {
-                let excess = tap.len() - self.vad_tap_cap;
+                let frame = usize::from(self.tap_channels);
+                let excess = (tap.len() - self.vad_tap_cap)
+                    .next_multiple_of(frame)
+                    .min(tap.len());
                 tap.drain(..excess);
             }
+            debug_assert!(
+                tap.len().is_multiple_of(usize::from(self.tap_channels)),
+                "the VAD tap holds a whole number of frames after eviction"
+            );
         }
     }
 
@@ -1091,6 +1108,10 @@ impl MicrophoneStream {
     pub fn vad_input(&self, samples: usize) -> Option<Vec<f32>> {
         let tap = self.vad_tap.as_ref()?;
         let mut tap = tap.lock().unwrap_or_else(PoisonError::into_inner);
+        debug_assert!(
+            tap.len().is_multiple_of(usize::from(self.tap_channels)),
+            "the VAD tap holds a whole number of frames before a drain"
+        );
         let take = samples.min(tap.len());
         Some(tap.drain(..take).collect())
     }
@@ -1660,17 +1681,21 @@ impl Microphone {
         let tap_channels = capture_stage
             .as_ref()
             .map_or(native_channels, CaptureStage::tap_channels);
-        let vad_tap_cap = target_rate as usize * VAD_TAP_BOUND_SECS;
+        // The bound is sized in frames and held in interleaved samples at the
+        // tap count, so it is a whole number of frames at every channel count.
+        let vad_tap_cap_frames = target_rate as usize * VAD_TAP_BOUND_SECS;
+        let vad_tap_cap = vad_tap_cap_frames * usize::from(tap_channels);
         // The tap memory bound must sit far above the chain's conditioning
         // latency, so an actively draining detector never reaches it even when a
         // length-changing stage leaves the tap leading the delivered output.
         // Checked once here, not per block, since the latency is fixed when the
-        // chain is built.
+        // chain is built. The latency is a per-channel figure, so it is checked
+        // against the bound in frames.
         debug_assert!(
             capture_stage
                 .as_ref()
                 .map_or(0, CaptureStage::transform_latency)
-                < vad_tap_cap,
+                < vad_tap_cap_frames,
             "the VAD tap memory bound must exceed the chain's transform latency"
         );
 
@@ -1753,7 +1778,7 @@ mod tests {
             vad_tap,
             tap_channels,
             detector_source: DetectorSource::Average,
-            vad_tap_cap: 16000 * VAD_TAP_BOUND_SECS,
+            vad_tap_cap: 16000 * VAD_TAP_BOUND_SECS * usize::from(tap_channels),
             chain_flushed: AtomicBool::new(false),
             #[cfg(feature = "aec")]
             aec_reference: None,
@@ -2765,6 +2790,95 @@ mod tests {
                 .expect("a multichannel delivered chunk is collapsed");
             assert_eq!(feed, expected, "the delivered path feeds {source:?} alone");
         }
+    }
+
+    /// Past its memory bound the tap evicts whole frames. Exercised at a
+    /// channel count that does not divide the bound's frame count (3 at
+    /// 16 kHz: two seconds is 32 000 frames), where an eviction that drains a
+    /// raw sample count leaves a partial frame at the front and every later
+    /// frame reads shifted by that offset. Each sample encodes its channel and
+    /// frame (`channel * 1e6 + frame`), so a shift is visible: a `Channel`
+    /// source returns another channel's values while every length still
+    /// agrees. Regression: an eviction that leaves the tap off its frame
+    /// boundary for the rest of the stream.
+    fn assert_tap_evicts_whole_frames(channels: u16) {
+        let stage = build_capture_stage(
+            channels,
+            channels,
+            16_000,
+            16_000,
+            Transforms {
+                dc_removal: true,
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .expect("a transform builds a chain");
+        let (stream, _sender, _running) =
+            test_stream_with_source(Some(stage), channels, DetectorSource::Channel(1));
+        assert_eq!(
+            stream.tap_channels, channels,
+            "the chain taps at the device count"
+        );
+
+        // Push well past the bound in whole-frame blocks, every sample naming
+        // its channel and frame.
+        let block_frames = 400;
+        let blocks = 100;
+        for b in 0..blocks {
+            let block: Vec<f32> = (0..block_frames)
+                .flat_map(|f| {
+                    let frame = (b * block_frames + f) as f32;
+                    (0..channels).map(move |c| f32::from(c) * 1e6 + frame)
+                })
+                .collect();
+            stream.push_vad_tap(block);
+        }
+        assert!(
+            blocks * block_frames * channels as usize > stream.vad_tap_cap,
+            "the pushes cross the bound"
+        );
+        let len = stream
+            .vad_tap
+            .as_ref()
+            .expect("a transform keeps the tap active")
+            .lock()
+            .unwrap()
+            .len();
+        assert!(len <= stream.vad_tap_cap, "the tap holds at most its bound");
+
+        // One delivered block's feed reads channel 1 alone, frame after frame.
+        let delivered = vec![0.0_f32; block_frames * channels as usize];
+        let feed = stream
+            .detector_feed(&delivered)
+            .expect("a transform keeps the tap active");
+        assert_eq!(feed.len(), block_frames, "the feed is one sample per frame");
+        for (i, &s) in feed.iter().enumerate() {
+            let channel = (s / 1e6).floor();
+            assert!(
+                channel == 1.0,
+                "feed sample {i} reads channel {channel}, not channel 1 \
+                 (the tap held {len} samples at {channels} channels before the drain)"
+            );
+        }
+        for (i, pair) in feed.windows(2).enumerate() {
+            assert!(
+                (pair[1] - pair[0] - 1.0).abs() < 1e-6,
+                "feed frames are consecutive at {i} ({} then {})",
+                pair[0],
+                pair[1]
+            );
+        }
+        assert!(
+            len.is_multiple_of(channels as usize),
+            "the tap holds a whole number of frames after eviction \
+             ({len} samples at {channels} channels)"
+        );
+    }
+
+    #[test]
+    fn the_tap_evicts_whole_frames_past_its_bound() {
+        assert_tap_evicts_whole_frames(3);
     }
 
     /// `validate` refuses a detector source at or above the configured

--- a/crates/decibri/src/speaker.rs
+++ b/crates/decibri/src/speaker.rs
@@ -111,7 +111,12 @@ fn render_output(
 
     let mut written = 0;
 
-    // First, play any leftover from the accumulator.
+    // First, play any leftover from the accumulator. `data` is a whole number
+    // of frames (asserted in `Speaker::start`), so the accumulator's front
+    // always lands on a frame boundary, and this drain removes exactly the
+    // count it copied, so the played stream is the sent samples in order.
+    // Removing any other count here would rotate the channels of everything
+    // queued behind it.
     if !accum.is_empty() {
         let take = accum.len().min(data.len());
         data[..take].copy_from_slice(&accum[..take]);
@@ -499,6 +504,13 @@ impl Speaker {
         // Realtime render callback: fill the buffer from the playback queue.
         // Identical work as before; the seam wraps only stream construction.
         let on_data: OutputDataCallback = Box::new(move |data: &mut [f32]| {
+            // The backend fills whole frames: the buffer length is a multiple
+            // of the channel count, which keeps the accumulator drain in
+            // `render_output` on a frame boundary.
+            debug_assert!(
+                data.len().is_multiple_of(usize::from(channels)),
+                "the output buffer holds a whole number of frames"
+            );
             render_output(
                 data,
                 &mut accum,

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -9,6 +9,12 @@ For other decibri packages, see:
 - Rust core: [crates/decibri/CHANGELOG.md](../../crates/decibri/CHANGELOG.md)
 - Python package: [bindings/python/CHANGELOG.md](../../bindings/python/CHANGELOG.md)
 
+## [Unreleased]
+
+### Fixed
+
+- With a VAD active on a multichannel stream that has an enhancement step enabled, the detector feed holds two seconds of frames at every channel count and evicts whole frames. A stream whose delivered block exceeded the feed's bound (more than 20 channels at 16 kHz, or 60 at 48 kHz, at the default `framesPerBuffer` of 1600; fewer channels with a larger `framesPerBuffer`) lost feed frames on every block, and at a channel count that does not divide the bound also fed the detector a channel other than the one `vad: { source }` named. Mono streams and streams with no enhancement step are unchanged.
+
 ## [5.7.0] - 2026-08-21
 
 ### Added


### PR DESCRIPTION
The capture stream's pre-transform detector tap is bounded in frames rather than samples: VAD_TAP_BOUND_SECS seconds of frames at the target rate, multiplied by the tap's channel count, so it holds two seconds at every channel count. The eviction drains a whole number of frames, rounded up so the tap stays at or under its bound, and debug assertions check that the tap is frame-aligned after every eviction and before every drain. The construction-time check of the transform latency against the bound now compares frames with frames.

A multichannel tap was bounded in samples, so it held 2 / channels seconds, and at a channel count that does not divide the bound's sample count an eviction left a partial frame at the front and every later vad_input or detector_feed drain read frames shifted by that offset, so a DetectorSource::Channel feed carried a channel other than the one named. Only a tap that passed its bound was affected: a consumer not draining it once per delivered block, or, through the bindings, a delivered block larger than the bound at that channel count (more than 20 channels at 16 kHz at the default 1600 frames per buffer). Mono streams, streams with no enhancement step and File are unchanged.

A regression test at 3 channels, a count that does not divide the bound, pushes channel-encoded frames past the bound and checks that a Channel(1) feed reads only channel 1 and that the tap holds a whole number of frames. The three changelogs carry the entry.

The playback accumulator in speaker.rs is documented at its drain: the output buffer is a whole number of frames and the drain removes exactly the count it copies, so the played stream is the sent samples in order, and a debug assertion in Speaker::start checks that the backend hands the callback a whole number of frames. Playback behaviour is unchanged.