### PR TITLE
build(deps): bump eight cargo dependencies, decibri-decode to 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "decibri-decode"
-version = "0.1.2"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322a328dfb6a3c57f2790a71b3b66423a02850adfb8a248fd15735ec0f8eb3ba"
+checksum = "785556f9c41ee9126329eec985e7e8274879fbe81dca551cd9afa77b094f9585"
 dependencies = [
  "decibri-resampler",
 ]
@@ -632,13 +632,14 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "napi"
-version = "3.9.0"
+version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d395473824516f38dd1071a1a37bc57daa7be65b293ebba4ead5f7abb017a2"
+checksum = "459197f1592f4c3dbbf9c1b13f5a4599a343e4ef66b96bc340e2a518b36a6662"
 dependencies = [
  "bitflags",
  "ctor",
  "futures",
+ "libc",
  "napi-build",
  "napi-sys",
  "nohash-hasher",
@@ -649,15 +650,15 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.3.2"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9c366d2c8c60b86fa632df75f745509b52f9128f91a6bad4c796e44abb505e1"
+checksum = "60fdf9b392c50e7c4170fa633bd909490ed7835cea4c046776d1a4dd8d2ae0ab"
 
 [[package]]
 name = "napi-derive"
-version = "3.5.6"
+version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b3f766e04667e6da0e181e2da4f85475d5a6513b7cf6a80bea184e224a5b42"
+checksum = "0fa55ea69990c90b888e9e77044410e304ce7f35de599dc6d0b5c1923d2e59af"
 dependencies = [
  "convert_case",
  "ctor",
@@ -669,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "5.0.4"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5af30503edf933ce7377cf6d4c877a62b0f1107ea05585f1b5e430e88d5baf"
+checksum = "df4056ac7c18e4438ccf0edaed4340ca0d269278c8ec19284f7b23cb039fd0ae"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -682,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "napi-sys"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb602b84d7c1edae45e50bbf1374696548f36ae179dfa667f577e384bb90c2b"
+checksum = "85fbf1fa9f1babfe396d74bbbf52b3643770243e8f5b0b46715d4caf7f0dfc9a"
 dependencies = [
  "libloading",
 ]
@@ -1067,9 +1068,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
+checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
 dependencies = [
  "libc",
  "once_cell",
@@ -1107,18 +1108,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
+checksum = "f41027e41b4bd03f6e60f9f417fe24a6341a6bb744edd62b6f709f2a52ea30e9"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
+checksum = "e591a95526fead067432c3b3a33fc74770b87b1e04e73671090d9c2055a2b327"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1126,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
+checksum = "73225868fc1cd84eef2c3c230ddb91273bf1de46aeb8a4248da76d32a0924a1c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1138,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.29.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
+checksum = "571575aa3749fa6216757dd47d2a3e7ef360f329a40f0666a9fbd14889024952"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1281,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1393,9 +1394,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "pin-project-lite",
  "tokio-macros",

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- `File.save` and `AsyncFile.save` refuse an AIFF above 32767 channels with `AudioFormatUnsupported` carrying the container layer's own text, the refusal a FLAC above 8 channels and a WAV above 32767 already receive: an AIFF `COMM` chunk's `numChannels` is a signed 16-bit field, so 32767 is the format's own maximum. There is nothing a caller needs to do, because no container decibri writes accepts more. Reading an AIFF, every count up to 32767, WAV, FLAC and `File.buffer` and `AsyncFile.buffer` delivery at any count are unchanged.
+
 ### Fixed
 
 - With a VAD active on a multichannel stream that has an enhancement step enabled, the detector feed holds two seconds of frames at every channel count and evicts whole frames. A stream whose delivered block exceeded the feed's bound (more than 20 channels at 16 kHz, or 60 at 48 kHz, at the default `frames_per_buffer` of 1600; fewer channels with a larger `frames_per_buffer`) lost feed frames on every block, and at a channel count that does not divide the bound also fed the detector a channel other than the one `detector_source` named. Mono streams and streams with no enhancement step are unchanged.

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -11,6 +11,10 @@ For other decibri packages, see:
 
 ## [Unreleased]
 
+### Changed
+
+- `File::save` refuses an AIFF above 32767 channels with `DecibriError::AudioFormatUnsupported` carrying the container layer's own text, the refusal a FLAC above 8 channels and a WAV above 32767 already receive: an AIFF `COMM` chunk's `numChannels` is a signed 16-bit field, so 32767 is the format's own maximum. There is nothing a caller needs to do, because no container decibri writes accepts more. Reading an AIFF, every count up to 32767, WAV, FLAC and `File::buffer` delivery at any count are unchanged.
+
 ### Fixed
 
 - The capture stream's pre-transform detector tap (`vad_input` / `detector_feed`) holds two seconds of frames at every channel count and evicts whole frames. The bound was sized in samples, so a multichannel tap held `2 / channels` seconds, and at a channel count that does not divide the bound's sample count (3 at 16 kHz, for example) an eviction left a partial frame at the front of the tap and every later drain read frames shifted by that offset: a `DetectorSource::Channel` feed carried a channel other than the one named, and an `Average` feed averaged across frame boundaries. Only a tap that passes its bound is affected, which is a consumer that does not drain it once per delivered block, or a delivered block larger than the bound at that channel count. Mono streams, streams with no enhancement step and `File` are unchanged.

--- a/crates/decibri/src/file.rs
+++ b/crates/decibri/src/file.rs
@@ -882,10 +882,12 @@ impl File {
     ///
     /// Each container's own channel ceiling applies, reported as
     /// [`DecibriError::AudioFormatUnsupported`] carrying the container
-    /// layer's own text: a FLAC frame carries at most 8 channels, and a WAV
+    /// layer's own text: a FLAC frame carries at most 8 channels, a WAV
     /// `fmt ` chunk's `nBlockAlign` is a 16-bit field, so at the 16-bit
-    /// samples decibri writes a WAV holds at most 32767 channels. decibri
-    /// enforces no ceiling of its own on any format.
+    /// samples decibri writes a WAV holds at most 32767 channels, and an
+    /// AIFF `COMM` chunk's `numChannels` is a signed 16-bit field, so an
+    /// AIFF holds at most 32767 channels. decibri enforces no ceiling of
+    /// its own on any format.
     ///
     /// A finite sample outside `[-1.0, 1.0]`, which AGC or AEC without a
     /// limiter can produce, is clamped to full scale and counted in the
@@ -3876,10 +3878,46 @@ mod tests {
         });
     }
 
-    /// The negative control on the channel count: where no container limit
-    /// applies, the whole path serves `u16::MAX` channels, delivery and AIFF
-    /// save alike. An invented decibri-side maximum added anywhere on the
-    /// file path fails here loudly.
+    /// AIFF's ceiling is `numChannels`, the signed 16-bit field of the
+    /// `COMM` chunk: 32767 channels are written and read back exactly, and
+    /// 32768 are refused with the container layer's exact text forwarded.
+    /// Both sides of the boundary are the container layer's answer, not
+    /// decibri's.
+    #[test]
+    fn aiff_limit_is_the_signed_comm_field_not_decibris() {
+        with_save_path("over.aiff", |path| {
+            let file =
+                File::buffer(vec![0.0; 32768], 16000, 32768, channels_config(32768)).unwrap();
+            let err = file
+                .save(path, SaveOptions::default())
+                .expect_err("the save should be refused");
+            match &err {
+                DecibriError::AudioFormatUnsupported { reason } => {
+                    assert_eq!(
+                        reason, "32768-channel audio is not a supported layout",
+                        "the refusal is the container layer's own text"
+                    );
+                }
+                other => panic!("expected AudioFormatUnsupported, got {other:?}"),
+            }
+        });
+
+        let source = grid_samples(32767);
+        with_save_path("wide.aiff", |path| {
+            let file = File::buffer(source.clone(), 16000, 32767, channels_config(32767)).unwrap();
+            file.save(path, SaveOptions::default()).unwrap();
+            let back = collect_at(File::open(path, channels_config(32767)).unwrap(), 32767);
+            assert_eq!(back, source, "the boundary itself is accepted");
+        });
+    }
+
+    /// The negative control on the channel count: decibri invents no
+    /// maximum of its own on the file path. Delivery serves `u16::MAX`
+    /// channels, the widest count a `FileConfig` can name, and the only
+    /// ceiling a save meets is each container's own, pinned at its boundary
+    /// by the three container tests above. An invented decibri-side maximum
+    /// on delivery fails here loudly; one on the save path fails the
+    /// container test it undercuts.
     #[test]
     fn no_invented_channel_maximum_on_the_file_path() {
         let channels = u16::MAX;
@@ -3889,16 +3927,5 @@ mod tests {
             channels,
         );
         assert_eq!(delivered, source, "delivery serves u16::MAX channels");
-
-        with_save_path("widest.aiff", |path| {
-            let file =
-                File::buffer(source.clone(), 16000, channels, channels_config(channels)).unwrap();
-            file.save(path, SaveOptions::default()).unwrap();
-            let back = collect_at(
-                File::open(path, channels_config(channels)).unwrap(),
-                channels,
-            );
-            assert_eq!(back, source, "AIFF carries the count unbounded");
-        });
     }
 }

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -11,6 +11,10 @@ For other decibri packages, see:
 
 ## [Unreleased]
 
+### Changed
+
+- `File.save` and `AudioWriter` refuse an AIFF above 32767 channels, reported as a `DecibriError` with code `AUDIO_FORMAT_UNSUPPORTED` carrying the container layer's own text (`File.save` rejects with it; `AudioWriter` destroys the stream with it when the stream finishes), the refusal a FLAC above 8 channels and a WAV above 32767 already receive: an AIFF `COMM` chunk's `numChannels` is a signed 16-bit field, so 32767 is the format's own maximum. There is nothing a caller needs to do, because no container decibri writes accepts more. Reading an AIFF, every count up to 32767, WAV, FLAC and `File.buffer` delivery at any count are unchanged.
+
 ### Fixed
 
 - With a VAD active on a multichannel stream that has an enhancement step enabled, the detector feed holds two seconds of frames at every channel count and evicts whole frames. A stream whose delivered block exceeded the feed's bound (more than 20 channels at 16 kHz, or 60 at 48 kHz, at the default `framesPerBuffer` of 1600; fewer channels with a larger `framesPerBuffer`) lost feed frames on every block, and at a channel count that does not divide the bound also fed the detector a channel other than the one `vad: { source }` named. Mono streams and streams with no enhancement step are unchanged.

--- a/npm/decibri/src/decibri.d.ts
+++ b/npm/decibri/src/decibri.d.ts
@@ -928,9 +928,10 @@ export interface AudioWriterOptions extends SaveOptions, WritableOptions {
    * number of frames at this count. Bounded below at `1` (the default);
    * above it, each container's own ceiling applies (a FLAC frame carries at
    * most 8 channels; a WAV `fmt ` chunk's `nBlockAlign` is a 16-bit field,
-   * so 16-bit samples allow at most 32767), reported when the stream
-   * finishes as the container layer's own refusal. decibri enforces no
-   * ceiling of its own.
+   * so 16-bit samples allow at most 32767; an AIFF `COMM` chunk's
+   * `numChannels` is a signed 16-bit field, so at most 32767), reported
+   * when the stream finishes as the container layer's own refusal. decibri
+   * enforces no ceiling of its own.
    * @default 1
    */
   channels?: number;


### PR DESCRIPTION
Lockfile-only for seven of the eight: every manifest requirement already admits these versions, so only Cargo.lock moves and no crate enters or leaves the graph. The eighth, decibri-decode, carries a behaviour change on File::save that this commit documents and tests.

Moved:

- napi 3.9.0 to 3.12.1, with napi-sys 3.2.1 to 3.3.0
- napi-derive 3.5.6 to 3.6.3, with napi-derive-backend 5.0.4 to 6.1.2
- napi-build 2.3.2 to 2.4.1
- pyo3 0.29.0 to 0.29.2, with pyo3-build-config, pyo3-ffi, pyo3-macros and pyo3-macros-backend
- tokio 1.52.3 to 1.53.1
- serde_json 1.0.150 to 1.0.151
- crossbeam-channel 0.5.15 to 0.5.16
- decibri-decode 0.1.2 to 0.1.5. An AIFF COMM chunk's numChannels is a signed 16-bit field, so 0.1.5's AIFF writer refuses a channel count above 32767 with its own UnsupportedChannelLayout text, which File::save reports as AudioFormatUnsupported through the existing bridge, the same refusal a FLAC above 8 channels and a WAV above 32767 already receive. The file test that saved an AIFF at 65535 channels is split: the negative control keeps File::buffer delivery at u16::MAX, and a new container test pins 32767 written and read back exactly and 32768 refused with the container's text. The File::save rustdoc and the AudioWriter channels doc name AIFF's ceiling beside FLAC's and WAV's, and each artifact's changelog carries a Changed entry. Reading an AIFF, every count up to 32767, WAV, FLAC and buffer delivery at any count are unchanged.

Held:

- cpal stays at 0.17.3. 0.18 is a breaking API change that moves on its own.
- decibri-resampler 0.4.0 and decibri-aec 0.2.0 are already the newest published versions.
- thiserror stays at 2.0.18. 2.0.19 and later depend on syn 3, which would place a second syn in the graph next to the syn 2 every other proc-macro dependency uses, and the dependency policy rejects duplicate versions.

The regenerated napi loader and type definitions are unchanged.