### PR TITLE
docs: document echo cancellation and file writing on npm and Python

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,6 +1,6 @@
 # Decibri
 
-Cross-platform audio capture, playback, and processing for Python.
+Cross-platform audio capture, conditioning, and playback for Python, with voice activity detection on live and recorded audio.
 
 [![PyPI version](https://img.shields.io/pypi/v/decibri.svg)](https://pypi.org/project/decibri/)
 [![Python versions](https://img.shields.io/pypi/pyversions/decibri.svg)](https://pypi.org/project/decibri/)
@@ -102,7 +102,7 @@ with decibri.Speaker(sample_rate=24000, channels=1) as spk:
 
 - `Microphone`: synchronous audio capture
 - `Speaker`: synchronous audio output
-- `File`: offline source; conditions a recording or in-memory samples and analyzes it for speech
+- `File`: offline source; conditions a recording or in-memory samples, analyzes it for speech, or writes it back out
 - `AsyncMicrophone`: async-await audio capture
 - `AsyncSpeaker`: async-await audio output
 - `AsyncFile`: async-await offline source
@@ -117,7 +117,7 @@ with decibri.Speaker(sample_rate=24000, channels=1) as spk:
 
 ### Value types
 
-`MicrophoneInfo`, `SpeakerInfo`, `VersionInfo`, `Chunk`, `VadReport`, `VadWindow`, `Segment`.
+`MicrophoneInfo`, `SpeakerInfo`, `VersionInfo`, `Chunk`, `VadReport`, `VadWindow`, `Segment`, `AecMetrics`, `AecChannelMetrics`, `SaveReport`, and the config objects `Vad` and `Aec`.
 
 ### Exceptions
 
@@ -175,6 +175,38 @@ with decibri.Microphone(
 
 The denoise model is bundled in the wheel (the same way the Silero VAD model is), so `denoise="fastenhancer-t"` needs no download. VAD reads the signal before the chain, so `mic.vad_score` and `mic.is_speaking` are unaffected by which conditioning stages you enable. The same options are available on `AsyncMicrophone`.
 
+## Echo cancellation
+
+Acoustic echo cancellation removes the echo of far-end audio (what your application is playing out) from the captured audio. It is opt-in: pass `aec="tau"` on the `Microphone` constructor and push the far-end audio through `push_aec_reference()` as it is played, in played order. Leave `aec` unset and the capture path is unchanged; with no reference pushed the captured audio passes through unchanged. The canceller runs before voice activity detection, so `mic.vad_score` and `mic.is_speaking` read the echo-removed signal and playback stops triggering detection. It requires `sample_rate` in 8000 to 48000; a rate outside that raises `AecSampleRateUnsupported` at construction.
+
+`aec="tau"` selects the model with its defaults; an `Aec` config object tunes it:
+
+| Field | Default | Value |
+| --- | --- | --- |
+| `model` | `"tau"` | `"tau"`, the one model |
+| `tail_ms` | `None` (the canceller's 200) | int ms, 16 to 500 |
+| `suppression` | `None` (the canceller's `"conservative"`) | `"conservative"` or `"off"` |
+| `reference_sample_rate` | `None` (the capture `sample_rate`) | int Hz, 1000 to 384000 |
+| `reference_channels` | `1` | int, at least 1 |
+
+```python
+import decibri
+
+with decibri.Microphone(sample_rate=16000, aec="tau") as mic:
+    # Push the far-end audio as it is played, in played order: the same
+    # input shapes Speaker.write accepts, in the microphone's dtype.
+    mic.push_aec_reference(far_end_pcm)
+    for chunk in mic:
+        handle(chunk)                  # echo-cancelled int16 PCM bytes
+        metrics = mic.aec_metrics()    # AecMetrics while capture runs
+```
+
+`push_aec_reference()` never blocks and never raises on a full queue: samples that do not fit are discarded and counted by `aec_metrics().reference_dropped`. Silence between played audio need not be pushed. The canceller reads one mono reference: a reference at a `reference_sample_rate` other than the capture rate is converted before the canceller sees it, and with `reference_channels` above 1 each frame is averaged to one mono sample. With `channels` above 1, one canceller runs per delivered channel, each fed the same pushed reference, so one push serves every channel.
+
+`aec_metrics()` returns an `AecMetrics` dataclass, the canceller's report merged with the reference queue's counters (`delay_samples`, `erle_db`, `double_talk`, `reference_starved`, `acquisition_parked`, `reference_reanchors`, `reference_dropped`, `reference_silence`), or `None` when `aec` is unset or capture is not running. Its `channels` tuple holds one `AecChannelMetrics` per delivered channel, in delivered order; the top-level fields report the first delivered channel's. `erle_db` is not a quality ranking across channels: it rises with echo distance, so a far microphone reports a higher figure than a near one while removing less echo in absolute terms.
+
+The same `aec` parameter is available on `AsyncMicrophone`. `push_aec_reference()` is a plain method there too, so a renderer callback calls it without awaiting; `aec_metrics()` is awaited.
+
 ## Files
 
 Everything a `Microphone` does to live audio, `File` does to audio you already have: the same conditioning options (`dc_removal`, `denoise`, `highpass`, `agc`, `limiter`), the same iteration, the same conditioned chunks out, and the same opt-in `vad=`. A `File` reads WAV, AIFF, AIFF-C and FLAC (`File("clip.wav")`, or the identical `File.open("clip.wav")`; the container is identified from the file's own bytes rather than its extension) or wraps in-memory samples (`File.buffer(samples, input_rate=48000)`; raw samples carry no header, so their native rate is explicit). `sample_rate` stays the target output rate, the same meaning it has on `Microphone`, so a 44.1 kHz recording comes out at 16 kHz unless you set it.
@@ -189,7 +221,18 @@ for segment in report.segments:
     print(segment.start, segment.end)                 # merged speech regions
 ```
 
-`analyze()` requires VAD: a `File` built without `vad=` raises `VadNotConfigured` rather than constructing a detector silently. With `vad=` set, metadata iteration (`iter_with_metadata()`) carries per-chunk `vad_score` and `is_speaking` exactly as the microphone does, with one deliberate difference: on a `File`, the speaking holdoff and the `Chunk.timestamp` are measured in FILE time (sample positions in seconds), never wall-clock time, so a file processed faster than real time still reports correct speech timing. Iteration and analysis are separate single passes; construct one `File` per operation. `AsyncFile` mirrors the whole surface with `async` semantics.
+`analyze()` requires VAD: a `File` built without `vad=` raises `VadNotConfigured` rather than constructing a detector silently. With `vad=` set, metadata iteration (`iter_with_metadata()`) carries per-chunk `vad_score` and `is_speaking` exactly as the microphone does, with one deliberate difference: on a `File`, the speaking holdoff and the `Chunk.timestamp` are measured in FILE time (sample positions in seconds), never wall-clock time, so a file processed faster than real time still reports correct speech timing.
+
+A `File` can also be written back out. `save(path, format=None, compression=None)` runs the recording once through the same conditioning pass iteration delivers and writes it as 16-bit PCM at `sample_rate`, at the delivered channel count, in WAV, AIFF or FLAC:
+
+```python
+report = decibri.File("noisy.wav", denoise="fastenhancer-t").save("clean.flac")
+print(report.clipped_samples, report.non_finite_samples)
+```
+
+The container comes from the path's extension (`.wav`, `.aiff`, `.aif`, `.aifc` or `.flac`) or from `format`; an extension it does not recognise raises `AudioFormatUnsupported` rather than defaulting. `compression` sets the FLAC compression level, 0 to 8 with 5 the default. The returned `SaveReport` says what the write did to the samples: `clipped_samples` counts finite samples outside full scale clamped to `[-1.0, 1.0]`, and `non_finite_samples` counts non-finite samples that never reach the file (NaN is written as silence, an infinity as full scale). Saving consumes the source and raises `FileEngaged` once iteration has begun, exactly as `analyze()` does.
+
+Iteration, analysis and saving are separate single passes; construct one `File` per operation. `AsyncFile` mirrors the whole surface with `async` semantics, `await file.save(...)` included.
 
 ## Compatibility
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "decibri"
 version = "0.12.0"
-description = "Cross-platform audio capture, playback, and voice activity detection"
+description = "Cross-platform audio capture, conditioning, and playback for Python, with voice activity detection on live and recorded audio"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }

--- a/bindings/python/python/decibri/__init__.py
+++ b/bindings/python/python/decibri/__init__.py
@@ -1,6 +1,7 @@
 """decibri Python bindings.
 
-Cross-platform audio capture, output, and voice activity detection.
+Cross-platform audio capture, conditioning, and playback for Python, with
+voice activity detection on live and recorded audio.
 
 Public surface: ``Microphone`` and ``Speaker`` (sync), ``AsyncMicrophone``
 and ``AsyncSpeaker`` (async). Construct directly via the class

--- a/bindings/python/python/decibri/_classes.py
+++ b/bindings/python/python/decibri/_classes.py
@@ -2302,9 +2302,10 @@ class File:
         """Write the conditioned recording to ``path`` as an audio file.
 
         Runs the recording once through the same conditioning pass
-        iteration delivers, whole, and writes it as 16-bit PCM mono at
-        ``sample_rate``. Consumes the source: a save is a single pass,
-        separate from iteration and analysis.
+        iteration delivers, whole, and writes it as 16-bit PCM at
+        ``sample_rate``, frame-interleaved at the delivered channel count.
+        Consumes the source: a save is a single pass, separate from
+        iteration and analysis.
 
         The container comes from the path's extension (``.wav``, ``.aiff``,
         ``.aif``, ``.aifc`` or ``.flac``), or from ``format``: decibri

--- a/crates/decibri/README.md
+++ b/crates/decibri/README.md
@@ -146,7 +146,7 @@ for s in &report.segments {
 
 ### Without ONNX Runtime
 
-If you do not need Silero VAD, disable the `vad` feature to drop the ONNX Runtime dependency entirely.
+If you need neither Silero VAD nor the denoise stage, disable the `vad` and `denoise` features to drop the ONNX Runtime dependency entirely.
 
 ## Feature flags
 

--- a/crates/decibri/src/lib.rs
+++ b/crates/decibri/src/lib.rs
@@ -30,13 +30,15 @@
 //! | `capture`               | on      | Microphone input stream support              |
 //! | `playback`              | on      | Speaker output stream support                |
 //! | `vad`                   | on      | Silero voice-activity detection (pulls `ort`)|
+//! | `denoise`               | on      | Capture-path single-channel speech enhancement (pulls `ort`)|
+//! | `gain`                  | on      | Capture-path AGC and peak limiter (pure DSP) |
 //! | `aec`                   | on      | Acoustic echo cancellation on the capture path|
 //! | `ort-load-dynamic`      | on      | ONNX Runtime loaded at runtime from a path   |
 //! | `ort-download-binaries` | off     | ONNX Runtime downloaded at build time        |
 //!
 //! `ort-load-dynamic` and `ort-download-binaries` are mutually exclusive;
-//! selecting both is a compile error. Disabling `vad` drops the ONNX Runtime
-//! dependency entirely.
+//! selecting both is a compile error. `vad` and `denoise` each pull in ONNX
+//! Runtime; disabling both drops the dependency entirely.
 //!
 //! Execution-provider features (`coreml`, `cuda`, `directml`, `rocm`) are off by
 //! default and opt in to GPU acceleration on specific platforms. See

--- a/docs/features.md
+++ b/docs/features.md
@@ -6,11 +6,12 @@ Reference guide to the Cargo features exposed by the `decibri` crate. Aimed at R
 
 | Flag | Default | Purpose |
 |------|---------|---------|
-| `capture` | on | Microphone input stream support (pulls in `cpal`, `crossbeam-channel`) |
+| `capture` | on | Microphone input stream support (pulls in `cpal`, `crossbeam-channel`, `decibri-resampler`, `decibri-decode`) |
 | `playback` | on | Speaker output stream support (pulls in `cpal`, `crossbeam-channel`) |
 | `vad` | on | Silero VAD ONNX inference (pulls in `ort`) |
 | `denoise` | on | On by default; no runtime cost when off |
 | `gain` | on | On by default; no runtime cost when off |
+| `aec` | on | Acoustic echo cancellation on the capture path (pulls in `decibri-aec`) |
 | `ort-load-dynamic` | **on** | ORT loaded at runtime from a user-supplied path |
 | `ort-download-binaries` | off | ORT downloaded at build time, statically embedded |
 | `coreml` | off | ORT CoreML execution provider passthrough (macOS) |
@@ -18,7 +19,7 @@ Reference guide to the Cargo features exposed by the `decibri` crate. Aimed at R
 | `directml` | off | ORT DirectML execution provider passthrough (Windows) |
 | `rocm` | off | ORT ROCm execution provider passthrough (Linux AMD) |
 
-The default feature set is `["capture", "playback", "vad", "denoise", "gain", "ort-load-dynamic"]`, giving the full decibri experience with runtime ORT loading. This is the set decibri's own Node.js and Python bindings build against.
+The default feature set is `["capture", "playback", "vad", "denoise", "gain", "aec", "ort-load-dynamic"]`, giving the full decibri experience with runtime ORT loading. This is the set decibri's own Node.js and Python bindings build against.
 
 ## Choosing an ORT distribution mode
 
@@ -71,12 +72,13 @@ To switch modes in a consumer crate, disable default features and enable the one
 ```toml
 # Cargo.toml of a consumer
 [dependencies]
-decibri = { version = "3.3", default-features = false, features = [
+decibri = { version = "6", default-features = false, features = [
     "capture",
     "playback",
     "vad",
     "denoise",
     "gain",
+    "aec",
     "ort-download-binaries",
 ] }
 ```
@@ -97,9 +99,9 @@ Internally, the ONNX session builder selects an execution provider per session, 
 ## Feature constraints
 
 - `capture` and `playback` both depend on `cpal`. Disabling both removes all cpal code. Without either you have only VAD and sample conversion, which is rarely useful on its own.
-- `vad` pulls in `ort` as an optional dependency (`dep:ort`). Without `vad`, the `ort-load-dynamic` / `ort-download-binaries` features are no-ops since the `ort` crate is not in the dependency graph.
-- Builds without `vad` compile cleanly: the `ort::Error`-carrying `DecibriError` variants are all `#[cfg(feature = "vad")]`-gated, so a build such as `--no-default-features --features capture,playback,denoise,gain` has no `ort` in its dependency graph. The CI "Feature Combinations" job checks this and the other supported combinations on every push.
-- `docs.rs` builds the published documentation with `["capture", "playback", "vad", "denoise", "gain", "ort-download-binaries"]` so docs.rs builders do not need a runtime ORT dylib. See `[package.metadata.docs.rs]` in `crates/decibri/Cargo.toml`.
+- `vad` and `denoise` each pull in `ort` as an optional dependency (`dep:ort`). Without both, the `ort-load-dynamic` / `ort-download-binaries` features are no-ops since the `ort` crate is not in the dependency graph.
+- Builds without `vad` and `denoise` compile cleanly: the ONNX Runtime error variants of `DecibriError` are all `#[cfg(any(feature = "vad", feature = "denoise"))]`-gated, so a build such as `--no-default-features --features capture,playback` has no `ort` in its dependency graph. The CI "Feature Combinations" job checks this and the other supported combinations on every push.
+- `docs.rs` builds the published documentation with `["capture", "playback", "vad", "denoise", "gain", "aec", "ort-download-binaries"]` so docs.rs builders do not need a runtime ORT dylib. See `[package.metadata.docs.rs]` in `crates/decibri/Cargo.toml`.
 
 ## Related documentation
 

--- a/npm/decibri/README.md
+++ b/npm/decibri/README.md
@@ -110,6 +110,7 @@ Creates a Readable stream that captures from the microphone.
 | `highpass` | `80` \| `100` | off | High-pass cutoff in Hz (second-order Butterworth) that removes low-frequency rumble. Runs after denoise. Out-of-set values throw a `RangeError` |
 | `agc` | number | off | AGC target level in dBFS, an integer in -40 to -3 (typical -18). Runs after the high-pass. Out-of-range throws a `RangeError` |
 | `limiter` | number | off | Peak limiter ceiling in dBFS, a number in -3.0 to 0.0 (typical -1.0). Runs last. Out-of-range throws a `RangeError` |
+| `aec` | `'tau'` \| `AecOptions` | off | Acoustic echo cancellation of the far-end audio pushed through `pushAecReference`. `'tau'` names the model; an object `{ model, tailMs, suppression, referenceSampleRate, referenceChannels }` tunes it. Runs before voice activity detection, so `vadScore` and the `'speech'` / `'silence'` events read the echo-removed signal. Requires `sampleRate` in 8000 to 48000. See [Echo cancellation](#echo-cancellation) |
 
 Standard `ReadableOptions` (e.g. `highWaterMark`) are also accepted.
 
@@ -122,6 +123,8 @@ Multichannel capture delivers interleaved frames: each chunk holds `framesPerBuf
 | Method | Description |
 | --- | --- |
 | `mic.stop()` | Stop capture and end stream. Safe to call multiple times |
+| `mic.pushAecReference(data)` | Queue far-end reference audio for the echo canceller, pushed as it is played, in played order. Accepts the same input shapes `Speaker.write` accepts. Never blocks and never throws on a full queue; a no-op when `aec` is unset. See [Echo cancellation](#echo-cancellation) |
+| `mic.aecMetrics()` | The echo canceller's metrics, or `null` when `aec` is unset or capture is not running |
 | `Microphone.open(options?)` | Construct without blocking the event loop. Returns a `Promise<Microphone>`. See [Non-blocking API](#non-blocking-api) |
 | `Microphone.devices()` | List available input devices |
 | `Microphone.version()` | Version info: `{ decibri, audioBackend, binding }` |
@@ -340,6 +343,42 @@ setTimeout(() => mic.stop(), 5000);
 
 VAD reads the signal before the chain, so `vadScore` and the `'speech'` / `'silence'` events are unaffected by which conditioning stages you enable. The conditioning chain runs in the native Node.js capture path; the browser build does not include it.
 
+## Echo cancellation
+
+Acoustic echo cancellation removes the echo of far-end audio (what your application is playing out) from the captured audio. It is opt-in: set `aec` on the `Microphone` and push the far-end audio through `pushAecReference` as it is played, in played order. With `aec` unset the capture path is unchanged, and with no reference pushed the captured audio passes through unchanged. The canceller runs before voice activity detection, so `vadScore` and the `'speech'` / `'silence'` events read the echo-removed signal and playback stops triggering detection. It requires `sampleRate` in 8000 to 48000.
+
+`aec: 'tau'` selects the model with its defaults; an `AecOptions` object tunes it:
+
+| Option | Default | Range |
+| --- | --- | --- |
+| `model` | required | `'tau'`, the one model |
+| `tailMs` | 200 | 16 to 500 ms |
+| `suppression` | `'conservative'` | `'conservative'` or `'off'` |
+| `referenceSampleRate` | the capture `sampleRate` | 1000 to 384000 Hz |
+| `referenceChannels` | 1 | 1 or more |
+
+```javascript
+const { Microphone, Speaker } = require('decibri');
+
+const mic = new Microphone({ sampleRate: 16000, aec: 'tau' });
+const speaker = new Speaker({ sampleRate: 16000, channels: 1 });
+
+// Push the far-end audio as it is played, in played order: the same
+// input shapes Speaker.write accepts, in the microphone's dtype.
+function playFarEnd(pcmBuffer) {
+  speaker.write(pcmBuffer);
+  mic.pushAecReference(pcmBuffer);
+}
+
+mic.on('data', (chunk) => { /* Buffer of echo-cancelled Int16 PCM */ });
+```
+
+`pushAecReference` never blocks and never throws on a full queue: samples that do not fit are discarded and counted by `aecMetrics().referenceDropped`. Silence between played audio need not be pushed. The canceller reads one mono reference: a reference at a `referenceSampleRate` other than the capture rate is converted before the canceller sees it, and with `referenceChannels` above 1 each frame is averaged to one mono sample. With `channels` above 1, one canceller runs per delivered channel, each fed the same pushed reference, so one push serves every channel.
+
+`aecMetrics()` returns the canceller's report merged with the reference queue's counters (`delaySamples`, `erleDb`, `doubleTalk`, `referenceStarved`, `acquisitionParked`, `referenceReanchors`, `referenceDropped`, `referenceSilence`), or `null` when `aec` is unset or capture is not running. Its `channels` array carries each delivered channel's report in delivered order; the top-level fields report the first delivered channel's. `erleDb` is not a quality ranking across channels: it rises with echo distance, so a far microphone reports a higher figure than a near one while removing less echo in absolute terms.
+
+Echo cancellation runs in the native Node.js capture path; the browser `Microphone` does not take the option, because browser capture already carries the platform's own echo cancellation through its `echoCancellation` constraint, on by default.
+
 ## ONNX Runtime telemetry
 
 Silero mode (`vad: 'silero'`) and the ACE `denoise` stage run on ONNX Runtime, which carries its own telemetry, separate from anything decibri does. Decibri disables it on the environment it commits when it initializes the runtime. Set `DECIBRI_ORT_TELEMETRY=1` in the environment before first use to leave it enabled; every other value, an empty value, and an absent variable leave it disabled.
@@ -356,9 +395,26 @@ Everything a `Microphone` does to live audio, `File` does to audio you already h
 - `new File(path, options?)`: the same result, synchronous (blocks on disk I/O; fine for scripts).
 - `File.buffer(samples, options)`: wrap a `Float32Array` of samples you already hold. `options.inputRate` is required (raw samples carry no header); a raw `Buffer` of bytes is rejected as ambiguous. `options.inputChannels` states the interleave of the samples, `1` by default, the channel counterpart of `inputRate`.
 - `await file.analyze()` (also spelled `analyse()`): consume the source and resolve to a `VadReport` of per-window `scores` (`{ start, end, vadScore, isSpeech }`) and merged speech `segments` (`{ start, end }`), in seconds of file time. Requires `vad: 'silero'`; a `File` opened without `vad` rejects with `analysis requires VAD`.
+- `await file.save(path, options?)`: write the conditioned recording to disk, off the event loop, as 16-bit PCM at `sampleRate` and at the delivered channel count, in WAV, AIFF or FLAC. The container comes from the path's extension (`.wav`, `.aiff`, `.aif`, `.aifc` or `.flac`) or from `options.format`; an extension it does not recognise rejects rather than defaulting. `options.compression` sets the FLAC compression level, 0 to 8 with 5 the default. Resolves to a `SaveReport` (`{ clippedSamples, nonFiniteSamples }`). Consumes the source, and rejects with `FILE_ENGAGED` once the stream is engaged, exactly as `analyze()` does.
 - `file.vadScore`, `'speech'` / `'silence'` events: per-chunk VAD alongside the stream, with the holdoff measured in FILE time (sample positions), never wall-clock time, so processing speed does not change the reported events.
 
-Options mirror `Microphone` (`sampleRate`, `channels`, `channelMap`, `dtype`, `vad`, `dcRemoval`, `denoise`, `highpass`, `agc`, `limiter`), with `channels` and `channelMap` read against the source's own channel count (the file's header, or `inputChannels` for `File.buffer`) where the live path reads the device's report, and the vad `source` naming a delivered channel exactly as on `Microphone`; the live-capture options (`device`, `framesPerBuffer`) do not apply. Iteration and analysis are separate single passes: construct one `File` per operation. Note: Node also has a global `File` (the web File API); import decibri's explicitly to avoid shadowing surprises.
+Options mirror `Microphone` (`sampleRate`, `channels`, `channelMap`, `dtype`, `vad`, `dcRemoval`, `denoise`, `highpass`, `agc`, `limiter`), with `channels` and `channelMap` read against the source's own channel count (the file's header, or `inputChannels` for `File.buffer`) where the live path reads the device's report, and the vad `source` naming a delivered channel exactly as on `Microphone`; the live-capture options (`device`, `framesPerBuffer`, `aec`) do not apply. A save clamps finite samples outside full scale to `[-1.0, 1.0]` and counts them in `clippedSamples`, and replaces non-finite samples before they reach the file (NaN as silence, an infinity as full scale), counted in `nonFiniteSamples`. Iteration, analysis and saving are separate single passes: construct one `File` per operation. Note: Node also has a global `File` (the web File API); import decibri's explicitly to avoid shadowing surprises.
+
+## API: AudioWriter (file sink)
+
+`AudioWriter` is a Writable file sink for PCM audio: the stream to pair with decibri's Readable sources (`File`, `Microphone`) and with any other stream of PCM bytes. It collects the whole stream, then writes it as one audio file when the stream finishes, exactly as `File.save` writes: the same containers from the same extension rule, the same 16-bit PCM encoding, the same clamp and non-finite handling, the same bytes.
+
+```javascript
+const { pipeline } = require('node:stream/promises');
+const { File, AudioWriter } = require('decibri');
+
+await pipeline(
+  new File('noisy.wav', { denoise: 'fastenhancer-t' }),
+  new AudioWriter('clean.flac', { sampleRate: 16000 }),
+);
+```
+
+`sampleRate` is required (raw audio carries no header to read a rate from). `channels` (default 1) and `dtype` (default `'int16'`) describe the incoming bytes: the stream's total sample count must be a whole number of frames at `channels`, and each container's own channel ceiling applies at the write. The `File.save` options (`format`, `compression`) are accepted as well. `'finish'` fires after the file is on disk, and `writer.report` then carries the `SaveReport`; a failure destroys the stream with the error.
 
 ## Device Selection
 

--- a/npm/decibri/package.json
+++ b/npm/decibri/package.json
@@ -1,7 +1,7 @@
 {
   "name": "decibri",
   "version": "5.7.0",
-  "description": "Cross-platform audio capture, playback, and processing for Node.js and browsers",
+  "description": "Cross-platform audio capture, conditioning, and playback for Node.js and browsers, with voice activity detection on live and recorded audio",
   "main": "src/decibri.js",
   "types": "src/decibri.d.ts",
   "browser": "./src/browser/index.js",

--- a/npm/decibri/src/decibri.d.ts
+++ b/npm/decibri/src/decibri.d.ts
@@ -828,9 +828,10 @@ export declare class File extends Readable {
 
   /**
    * Wrap in-memory samples as an offline source. `samples` must be a
-   * `Float32Array` of mono samples in [-1.0, 1.0]; a raw `Buffer` of PCM
-   * bytes is rejected as ambiguous. `inputRate` is required (raw samples
-   * carry no header). Synchronous: no I/O is involved.
+   * `Float32Array` of samples in [-1.0, 1.0], frame-interleaved at
+   * `inputChannels` (1, mono, by default); a raw `Buffer` of PCM bytes is
+   * rejected as ambiguous. `inputRate` is required (raw samples carry no
+   * header). Synchronous: no I/O is involved.
    */
   static buffer(samples: Float32Array, options: FileBufferOptions): File;
 
@@ -876,11 +877,11 @@ export declare class File extends Readable {
   /**
    * Write the conditioned recording to disk, off the event loop. Runs the
    * recording once through the same conditioning pass iteration delivers,
-   * whole, and writes it as 16-bit PCM mono at `sampleRate`. The container
-   * comes from the path's extension (`.wav`, `.aiff`, `.aif`, `.aifc` or
-   * `.flac`), or from `options.format`: decibri reads a file by its content
-   * and writes one by its name. Consumes the source (a `File` is a single
-   * pass).
+   * whole, and writes it as 16-bit PCM at `sampleRate`, frame-interleaved at
+   * the delivered channel count. The container comes from the path's
+   * extension (`.wav`, `.aiff`, `.aif`, `.aifc` or `.flac`), or from
+   * `options.format`: decibri reads a file by its content and writes one by
+   * its name. Consumes the source (a `File` is a single pass).
    *
    * Resolves to a `SaveReport`: how many samples were clamped to full scale
    * and how many non-finite samples were replaced (NaN as silence, an

--- a/npm/decibri/src/decibri.js
+++ b/npm/decibri/src/decibri.js
@@ -1423,8 +1423,9 @@ class File extends Readable {
   /**
    * Write the conditioned recording to disk, off the event loop. Runs the
    * recording once through the same conditioning pass iteration delivers,
-   * whole, and writes it as 16-bit PCM mono at `sampleRate`. Consumes the
-   * source: a save is a single pass, separate from iteration and analysis.
+   * whole, and writes it as 16-bit PCM at `sampleRate`, frame-interleaved at
+   * the delivered channel count. Consumes the source: a save is a single
+   * pass, separate from iteration and analysis.
    *
    * The container comes from the path's extension (`.wav`, `.aiff`, `.aif`,
    * `.aifc` or `.flac`), or from `options.format`: decibri reads a file by


### PR DESCRIPTION
The npm README documents the echo canceller: the aec option on Microphone, the pushAecReference and aecMetrics methods, an Echo cancellation section with the AecOptions table and a usage example, and the per-channel metrics. It also documents File.save and AudioWriter, and names aec among the options that do not apply to a File.

The Python README documents the same surface in its own form: the aec parameter on Microphone and AsyncMicrophone, push_aec_reference and aec_metrics, an Echo cancellation section with the Aec field table and a usage example, File.save and AsyncFile.save with SaveReport, and the Aec, AecMetrics, AecChannelMetrics and SaveReport types in its public API list. Its summary line and the package's module docstring match the pyproject description.

docs/features.md lists the aec feature, names it in the default and docs.rs feature sets and in its dependency example, carries a current version in that example, and names every crate the capture feature pulls in. The crate-level feature table in lib.rs lists denoise and gain.

The crate's lib.rs, README and docs/features.md state that vad and denoise each pull in ONNX Runtime and that disabling both removes it; they said disabling vad alone did.

The File.save docstrings in the Node type definitions, the Node source and the Python source state that a save writes the delivered channel count; they said mono. The File.buffer type definition states that the samples are interleaved at inputChannels.

The npm and Python package descriptions match the crate's: audio capture, conditioning, and playback, with voice activity detection on live and recorded audio.