### PR TITLE
fix: stop the Python build script rerunning and gate dead stage items

### DIFF
--- a/bindings/python/build.rs
+++ b/bindings/python/build.rs
@@ -19,6 +19,11 @@
 //! Exactly one `pyproject.toml` is tracked, so the two paths never both
 //! resolve within a single build.
 //!
+//! The change-tracking directive (`cargo:rerun-if-changed`) names a candidate
+//! only when it exists. Cargo treats a named path that is absent as always
+//! stale, so naming the other layout's candidate would rerun this script, and
+//! relink the extension, on every build.
+//!
 //! # Parsing
 //!
 //! The parse is anchored to the `[project]` table and to the `version` key
@@ -45,7 +50,10 @@ fn main() {
     }
 
     println!("cargo:rerun-if-changed=build.rs");
-    for candidate in &candidates {
+    // Only a candidate present on disk is named: cargo treats an absent
+    // `rerun-if-changed` path as always stale, which would rerun this script
+    // on every build in the layout that lacks it.
+    for candidate in candidates.iter().filter(|c| c.exists()) {
         println!("cargo:rerun-if-changed={}", candidate.display());
     }
 

--- a/crates/decibri/src/stage.rs
+++ b/crates/decibri/src/stage.rs
@@ -119,6 +119,10 @@ impl<'a> Block<'a> {
     }
 
     /// Whether the block carries no samples.
+    ///
+    /// Read by the denoise and echo-cancellation stages and by the descriptor
+    /// tests, so it is compiled only where one of those is.
+    #[cfg(any(feature = "aec", feature = "denoise", test))]
     pub(crate) fn is_empty(&self) -> bool {
         self.samples.is_empty()
     }
@@ -1180,6 +1184,7 @@ impl<T: InPlaceDsp> Stage for PerChannel<T> {
 ///
 /// `Send` for the same reason as [`InPlaceDsp`]; `pub(crate)` so the engines
 /// authored in [`crate::gain`] can implement it.
+#[cfg(feature = "gain")]
 pub(crate) trait LinkedDsp: Send {
     /// Filter `planar` in place: `channels` contiguous equal-length runs, one
     /// detector reading per frame across the channels, one gain applied to
@@ -1193,8 +1198,10 @@ pub(crate) trait LinkedDsp: Send {
 /// [`Stage`] default no-op. The wrapped engine holds one detector and one
 /// gain whatever the count, so no per-instance count is stored; the chain's
 /// resolved-count assertions in the walks hold the count steady.
+#[cfg(feature = "gain")]
 struct Linked<T: LinkedDsp>(T);
 
+#[cfg(feature = "gain")]
 impl<T: LinkedDsp> Stage for Linked<T> {
     fn process(&mut self, input: Block<'_>, out: &mut Vec<f32>) -> Result<(), DecibriError> {
         out.extend_from_slice(input.samples());
@@ -1415,6 +1422,7 @@ impl CaptureStage {
     /// the signal [`run`](Self::run) snapshots into [`tap`](Self::tap), so a
     /// caller that reads the pre-`transform` signal and never delivers the
     /// conditioned output takes this instead of a full [`run`](Self::run).
+    #[cfg(feature = "vad")]
     pub(crate) fn run_normalize(&mut self, input: &[f32]) -> Result<&[f32], DecibriError> {
         self.run_normalize_planar(input)?;
         self.reinterleave_work(self.tap_channels);
@@ -1546,6 +1554,7 @@ impl CaptureStage {
     /// The counterpart of [`run_normalize`](Self::run_normalize) on the close
     /// path: the resampler's group-delay tail, before it passes through
     /// `transform`.
+    #[cfg(feature = "vad")]
     pub(crate) fn flush_normalize(&mut self) -> Result<&[f32], DecibriError> {
         self.flush_normalize_planar()?;
         self.reinterleave_work(self.tap_channels);


### PR DESCRIPTION
The decibri-python build script names a pyproject.toml candidate in its cargo:rerun-if-changed output only when that candidate exists. It searches two layouts, the repository's bindings/python/pyproject.toml and the source distribution's root pyproject.toml, and it named both. Cargo treats a named path that is absent as always stale, so the script ran and the extension relinked on every workspace build, and cargo build --workspace never finished without compiling. A no-change build now finishes with nothing to compile. The source-distribution layout still resolves its root pyproject.toml, and that is the file it watches.

Four items in stage.rs are compiled only under the features that reach them: Block::is_empty under aec or denoise (and in the crate's own tests), the LinkedDsp trait and its Linked adapter under gain, and CaptureStage::run_normalize and flush_normalize under vad. Each was a dead_code warning in every feature selection that lacks its feature, including the capture and capture+playback cells CI runs as cargo test. The items are pub(crate) or private, and behaviour is unchanged in every configuration.

No changelog entry: the build script change is build-time only, and the gated items are not part of the public surface.