### PR TITLE
fix: recover a poisoned stream lock and remove the audio-thread prints

### DIFF
--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -1310,7 +1310,10 @@ impl DecibriOutputBridge {
             SampleFormat::Float32 => sample::f32_le_bytes_to_f32(&buffer),
         };
 
-        let stream = self.stream.as_ref().unwrap();
+        let stream = self
+            .stream
+            .as_ref()
+            .ok_or_else(|| Error::new(Status::GenericFailure, "Output stream not started"))?;
         stream
             .send(samples)
             .map_err(|e| to_napi_error(speaker_failure_cause(e, || stream.take_last_error())))
@@ -1541,6 +1544,9 @@ pub struct SaveOptions {
 /// What a save did to the samples on their way into the file: finite
 /// samples outside full scale clamped and counted, non-finite samples
 /// replaced (NaN with silence, an infinity with full scale) and counted.
+/// When the conditioning chain runs it has already replaced every
+/// non-finite sample with silence at its entry, so the non-finite count is
+/// what the save's own repair saw, not what the source carried.
 #[napi(object)]
 pub struct SaveReport {
     pub clipped_samples: f64,

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 
 - `File.save` and `AsyncFile.save` refuse an AIFF above 32767 channels with `AudioFormatUnsupported` carrying the container layer's own text, the refusal a FLAC above 8 channels and a WAV above 32767 already receive: an AIFF `COMM` chunk's `numChannels` is a signed 16-bit field, so 32767 is the format's own maximum. There is nothing a caller needs to do, because no container decibri writes accepts more. Reading an AIFF, every count up to 32767, WAV, FLAC and `File.buffer` and `AsyncFile.buffer` delivery at any count are unchanged.
+- A device failure during capture or playback is no longer written to stderr. The failure reaches the consumer as before, raised as `DeviceFailed` from the next `read`, `write` or `drain`.
 
 ### Fixed
 

--- a/crates/decibri/CHANGELOG.md
+++ b/crates/decibri/CHANGELOG.md
@@ -14,10 +14,12 @@ For other decibri packages, see:
 ### Changed
 
 - `File::save` refuses an AIFF above 32767 channels with `DecibriError::AudioFormatUnsupported` carrying the container layer's own text, the refusal a FLAC above 8 channels and a WAV above 32767 already receive: an AIFF `COMM` chunk's `numChannels` is a signed 16-bit field, so 32767 is the format's own maximum. There is nothing a caller needs to do, because no container decibri writes accepts more. Reading an AIFF, every count up to 32767, WAV, FLAC and `File::buffer` delivery at any count are unchanged.
+- A device failure during capture or playback is no longer written to stderr. The failure reaches the consumer as before: the stream closes, and `MicrophoneStream::take_last_error` or `SpeakerStream::take_last_error` returns the `DecibriError::DeviceFailed` that caused it.
 
 ### Fixed
 
 - The capture stream's pre-transform detector tap (`vad_input` / `detector_feed`) holds two seconds of frames at every channel count and evicts whole frames. The bound was sized in samples, so a multichannel tap held `2 / channels` seconds, and at a channel count that does not divide the bound's sample count (3 at 16 kHz, for example) an eviction left a partial frame at the front of the tap and every later drain read frames shifted by that offset: a `DetectorSource::Channel` feed carried a channel other than the one named, and an `Average` feed averaged across frame boundaries. Only a tap that passes its bound is affected, which is a consumer that does not drain it once per delivered block, or a delivered block larger than the bound at that channel count. Mono streams, streams with no enhancement step and `File` are unchanged.
+- The `File::save` documentation describes the non-finite repair on a conditioned source. The conditioning chain replaces every non-finite sample with silence at its entry, so the save's own replacement (NaN with silence, an infinity with full scale) and the `SaveReport::non_finite_samples` count cover the direct path only, a mono source already at the target rate with no conditioning enabled. The behaviour is unchanged.
 
 ## [6.3.0] - 2026-08-21
 

--- a/crates/decibri/src/backend.rs
+++ b/crates/decibri/src/backend.rs
@@ -9,7 +9,7 @@
 //! decibri-owned types ([`DecibriError`], [`DeviceSelector`], [`MicrophoneInfo`],
 //! [`SpeakerInfo`], and the small support types defined below).
 
-use std::sync::Mutex;
+use std::sync::{Mutex, PoisonError};
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 
@@ -42,9 +42,8 @@ impl BackendStream {
     /// drop. Idempotent and poison-tolerant: a poisoned lock still clears the
     /// slot rather than panicking.
     pub(crate) fn stop(&self) {
-        if let Ok(mut guard) = self.inner.lock() {
-            *guard = None;
-        }
+        let mut guard = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        *guard = None;
     }
 
     /// Whether the stream is still held (not yet dropped by [`stop`](Self::stop)).
@@ -539,23 +538,24 @@ fn resolve_device_generic<D: DeviceDirection>(
                 }
             }
 
-            match matches.len() {
-                0 => Err(D::not_found_error(query.clone())),
-                1 => Ok(matches.into_iter().next().unwrap().2),
-                _ => {
-                    let match_list = matches
-                        .iter()
-                        .map(|(idx, name, _)| format!("  [{idx}] {name}"))
-                        .collect::<Vec<_>>()
-                        .join("\n");
-                    Err(DecibriError::MultipleDevicesMatch {
-                        name: query.clone(),
-                        matches: format!(
-                            "{match_list}\nUse a more specific name or pass the device index directly."
-                        ),
-                    })
-                }
+            if matches.len() > 1 {
+                let match_list = matches
+                    .iter()
+                    .map(|(idx, name, _)| format!("  [{idx}] {name}"))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                return Err(DecibriError::MultipleDevicesMatch {
+                    name: query.clone(),
+                    matches: format!(
+                        "{match_list}\nUse a more specific name or pass the device index directly."
+                    ),
+                });
             }
+            matches
+                .into_iter()
+                .next()
+                .map(|(_, _, device)| device)
+                .ok_or_else(|| D::not_found_error(query.clone()))
         }
 
         DeviceSelector::Id(query) => {

--- a/crates/decibri/src/file.rs
+++ b/crates/decibri/src/file.rs
@@ -891,9 +891,13 @@ impl File {
     ///
     /// A finite sample outside `[-1.0, 1.0]`, which AGC or AEC without a
     /// limiter can produce, is clamped to full scale and counted in the
-    /// returned [`SaveReport`]. A non-finite sample never reaches the file:
-    /// NaN becomes silence and an infinity becomes full scale, the same on
-    /// every format, counted separately in the report.
+    /// returned [`SaveReport`]. A non-finite sample never reaches the file.
+    /// On the direct path (a mono source already at the target rate with no
+    /// conditioning enabled) the save replaces it, NaN with silence and an
+    /// infinity with full scale, and counts it separately in the report.
+    /// When the conditioning chain runs it has already replaced every
+    /// non-finite sample with silence at its entry, so the count reports
+    /// what the save's repair saw, not what the source carried.
     ///
     /// Runs only on a source still at its start. Once iteration has pulled
     /// from the `File`, saving reports [`DecibriError::FileEngaged`].

--- a/crates/decibri/src/microphone.rs
+++ b/crates/decibri/src/microphone.rs
@@ -1650,7 +1650,6 @@ impl Microphone {
         // consumer that sees the stream close can distinguish a driver failure
         // from stop(). The backend builds the typed `DeviceFailed`.
         let on_error: StreamErrorCallback = Box::new(move |err: DecibriError| {
-            eprintln!("{err}");
             if let Ok(mut slot) = err_last_error.lock() {
                 *slot = Some(err);
             }

--- a/crates/decibri/src/speaker.rs
+++ b/crates/decibri/src/speaker.rs
@@ -525,7 +525,6 @@ impl Speaker {
         // a consumer that sees the stream close can distinguish a driver failure
         // from stop(). The backend builds the typed `DeviceFailed`.
         let on_error: StreamErrorCallback = Box::new(move |err: DecibriError| {
-            eprintln!("{err}");
             if let Ok(mut slot) = err_last_error.lock() {
                 *slot = Some(err);
             }

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -14,6 +14,7 @@ For other decibri packages, see:
 ### Changed
 
 - `File.save` and `AudioWriter` refuse an AIFF above 32767 channels, reported as a `DecibriError` with code `AUDIO_FORMAT_UNSUPPORTED` carrying the container layer's own text (`File.save` rejects with it; `AudioWriter` destroys the stream with it when the stream finishes), the refusal a FLAC above 8 channels and a WAV above 32767 already receive: an AIFF `COMM` chunk's `numChannels` is a signed 16-bit field, so 32767 is the format's own maximum. There is nothing a caller needs to do, because no container decibri writes accepts more. Reading an AIFF, every count up to 32767, WAV, FLAC and `File.buffer` delivery at any count are unchanged.
+- A device failure during capture or playback is no longer written to stderr. The failure reaches the consumer as before: `Microphone` emits it on `'error'` with code `DEVICE_FAILED`, and `Speaker` reports it from the next `write` or `drain`.
 
 ### Fixed
 


### PR DESCRIPTION
BackendStream::stop recovers a poisoned lock and clears the slot.

The capture and playback error callbacks no longer write to stderr. A device failure closes the stream, take_last_error returns DeviceFailed, the Node Microphone emits it on 'error', the Node Speaker reports it from the next write or drain, and the Python binding raises DeviceFailed from the next read, write or drain.

The File::save documentation states that the conditioning chain replaces every non-finite sample with silence at its entry, so the save's own replacement and the report's non_finite_samples count cover the direct path only. The Node SaveReport documentation carries the same statement.

The name selector in the backend returns its not-found error from the empty match case. The Node speaker bridge returns a typed error from an empty stream slot.