### PR TITLE
docs: complete the non-finite save documentation on every surface

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - `File.save` and `AsyncFile.save` refuse an AIFF above 32767 channels with `AudioFormatUnsupported` carrying the container layer's own text, the refusal a FLAC above 8 channels and a WAV above 32767 already receive: an AIFF `COMM` chunk's `numChannels` is a signed 16-bit field, so 32767 is the format's own maximum. There is nothing a caller needs to do, because no container decibri writes accepts more. Reading an AIFF, every count up to 32767, WAV, FLAC and `File.buffer` and `AsyncFile.buffer` delivery at any count are unchanged.
 - A device failure during capture or playback is no longer written to stderr. The failure reaches the consumer as before, raised as `DeviceFailed` from the next `read`, `write` or `drain`.
+- The `File.save` and `SaveReport.non_finite_samples` documentation states that when the conditioning chain runs it has already replaced every non-finite sample with silence at its entry, so the save's own replacement (NaN with silence, an infinity with full scale) and the `non_finite_samples` count cover the direct path only, a mono source already at `sample_rate` with no conditioning enabled. The behaviour is unchanged.
 
 ### Fixed
 

--- a/bindings/python/python/decibri/_classes.py
+++ b/bindings/python/python/decibri/_classes.py
@@ -1633,7 +1633,11 @@ class SaveReport:
             preserve the overshoot instead, and would report zero.
         non_finite_samples: Non-finite samples replaced before writing:
             NaN with silence, an infinity with full scale. The same
-            replacement on every format.
+            replacement on every format. When the conditioning chain runs
+            it has already replaced every non-finite sample with silence
+            at its entry, so this count covers the direct path only (a
+            mono source already at ``sample_rate`` with no conditioning
+            enabled).
     """
 
     clipped_samples: int
@@ -2319,7 +2323,11 @@ class File:
         samples outside full scale clamped to ``[-1.0, 1.0]`` (AGC or AEC
         without a limiter can overshoot, and 16-bit PCM cannot hold it),
         and ``non_finite_samples`` counts NaN samples written as silence
-        and infinite samples written as full scale.
+        and infinite samples written as full scale. When the conditioning
+        chain runs it has already replaced every non-finite sample with
+        silence at its entry, so the file carries silence where one was
+        and ``non_finite_samples`` covers the direct path only (a mono
+        source already at ``sample_rate`` with no conditioning enabled).
 
         Requires a ``File`` still at its start: once iteration has pulled
         from it, this raises ``FileEngaged``. Every failure detected

--- a/crates/decibri/src/file.rs
+++ b/crates/decibri/src/file.rs
@@ -375,6 +375,10 @@ pub struct SaveReport {
     /// Non-finite samples replaced before writing: NaN with silence, an
     /// infinity with full scale. The same replacement on every format, so the
     /// same samples produce the same audio whatever container carries them.
+    /// When the conditioning chain runs it has already replaced every
+    /// non-finite sample with silence at its entry, so this count covers the
+    /// direct path only (a mono source already at the target rate with no
+    /// conditioning enabled).
     pub non_finite_samples: u64,
 }
 

--- a/npm/decibri/CHANGELOG.md
+++ b/npm/decibri/CHANGELOG.md
@@ -15,6 +15,7 @@ For other decibri packages, see:
 
 - `File.save` and `AudioWriter` refuse an AIFF above 32767 channels, reported as a `DecibriError` with code `AUDIO_FORMAT_UNSUPPORTED` carrying the container layer's own text (`File.save` rejects with it; `AudioWriter` destroys the stream with it when the stream finishes), the refusal a FLAC above 8 channels and a WAV above 32767 already receive: an AIFF `COMM` chunk's `numChannels` is a signed 16-bit field, so 32767 is the format's own maximum. There is nothing a caller needs to do, because no container decibri writes accepts more. Reading an AIFF, every count up to 32767, WAV, FLAC and `File.buffer` delivery at any count are unchanged.
 - A device failure during capture or playback is no longer written to stderr. The failure reaches the consumer as before: `Microphone` emits it on `'error'` with code `DEVICE_FAILED`, and `Speaker` reports it from the next `write` or `drain`.
+- The `File.save` and `SaveReport.nonFiniteSamples` documentation states that when the conditioning chain runs it has already replaced every non-finite sample with silence at its entry, so the save's own replacement (NaN with silence, an infinity with full scale) and the `nonFiniteSamples` count cover the direct path only, a mono source already at `sampleRate` with no conditioning enabled. The behaviour is unchanged.
 
 ### Fixed
 

--- a/npm/decibri/src/decibri.d.ts
+++ b/npm/decibri/src/decibri.d.ts
@@ -772,7 +772,11 @@ export interface SaveReport {
   clippedSamples: number;
   /**
    * Non-finite samples replaced before writing: NaN with silence, an
-   * infinity with full scale. The same replacement on every format.
+   * infinity with full scale. The same replacement on every format. When
+   * the conditioning chain runs it has already replaced every non-finite
+   * sample with silence at its entry, so this count covers the direct path
+   * only (a mono source already at `sampleRate` with no conditioning
+   * enabled).
    */
   nonFiniteSamples: number;
 }
@@ -885,7 +889,10 @@ export declare class File extends Readable {
    *
    * Resolves to a `SaveReport`: how many samples were clamped to full scale
    * and how many non-finite samples were replaced (NaN as silence, an
-   * infinity as full scale).
+   * infinity as full scale). When the conditioning chain runs it has already
+   * replaced every non-finite sample with silence at its entry, so the file
+   * carries silence where one was and the count covers the direct path only
+   * (a mono source already at `sampleRate` with no conditioning enabled).
    *
    * Requires a File that is not already being streamed: once the stream has
    * been engaged this rejects with a `DecibriError` carrying the code

--- a/npm/decibri/src/decibri.js
+++ b/npm/decibri/src/decibri.js
@@ -1437,7 +1437,11 @@ class File extends Readable {
    * outside full scale clamped to `[-1.0, 1.0]` (AGC or AEC without a
    * limiter can overshoot, and 16-bit PCM cannot hold it), and
    * `nonFiniteSamples` counts NaN samples written as silence and infinite
-   * samples written as full scale.
+   * samples written as full scale. When the conditioning chain runs it has
+   * already replaced every non-finite sample with silence at its entry, so
+   * the file carries silence where one was and `nonFiniteSamples` covers
+   * the direct path only (a mono source already at `sampleRate` with no
+   * conditioning enabled).
    *
    * Requires a `File` that is not already being streamed: once the stream
    * has been engaged this rejects with a `DecibriError` carrying the code


### PR DESCRIPTION
The SaveReport non-finite count documentation in the core, the npm type definitions, the npm JSDoc and the Python docstrings states that when the conditioning chain runs it has already replaced every non-finite sample with silence at its entry, so the save's own replacement and the count cover the direct path only, a mono source already at the target rate with no conditioning enabled. The File.save documentation on npm and Python carries the same statement. The behaviour is unchanged.