### PR TITLE
docs(python): state that a device string selects by name only

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `File.save` and `AsyncFile.save` refuse an AIFF above 32767 channels with `AudioFormatUnsupported` carrying the container layer's own text, the refusal a FLAC above 8 channels and a WAV above 32767 already receive: an AIFF `COMM` chunk's `numChannels` is a signed 16-bit field, so 32767 is the format's own maximum. There is nothing a caller needs to do, because no container decibri writes accepts more. Reading an AIFF, every count up to 32767, WAV, FLAC and `File.buffer` and `AsyncFile.buffer` delivery at any count are unchanged.
 - A device failure during capture or playback is no longer written to stderr. The failure reaches the consumer as before, raised as `DeviceFailed` from the next `read`, `write` or `drain`.
 - The `File.save` and `SaveReport.non_finite_samples` documentation states that when the conditioning chain runs it has already replaced every non-finite sample with silence at its entry, so the save's own replacement (NaN with silence, an infinity with full scale) and the `non_finite_samples` count cover the direct path only, a mono source already at `sample_rate` with no conditioning enabled. The behaviour is unchanged.
+- The `MultipleDevicesMatch` docstring states that the message lists the matching devices and suggests a more specific name or the device index. The message itself is unchanged.
 
 ### Fixed
 

--- a/bindings/python/python/decibri/exceptions.py
+++ b/bindings/python/python/decibri/exceptions.py
@@ -115,7 +115,11 @@ class SpeakerNotFound(DeviceError):
 
 
 class MultipleDevicesMatch(DeviceError):
-    """Raised when device name is ambiguous; suggests using device ID."""
+    """Raised when a device name substring matches more than one device.
+
+    The message lists the matching devices and suggests a more specific
+    name or the device index.
+    """
 
 
 class DeviceIndexOutOfRange(DeviceError):

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -460,8 +460,9 @@ impl From<CoreOutputDeviceInfo> for OutputDeviceInfo {
 // ---------------------------------------------------------------------------
 // Device selector helper: translates Python-side device parameter into the
 // core's DeviceSelector enum. Accepts None (Default), int (Index), or str
-// (Name). The string form does not attempt id/name disambiguation; the core
-// resolves both.
+// (Name). A string is always a name selector, which the core matches as a
+// case-insensitive substring of the display name; nothing here produces
+// DeviceSelector::Id.
 // ---------------------------------------------------------------------------
 
 fn build_device_selector(device: Option<&Bound<'_, PyAny>>) -> PyResult<DeviceSelector> {


### PR DESCRIPTION
The comment above the Python bridge's device selector helper states that a string is always a name selector, matched by the core as a case-insensitive substring of the display name, and that the helper never produces DeviceSelector::Id. The MultipleDevicesMatch docstring states that the message lists the matching devices and suggests a more specific name or the device index. The Python changelog carries the docstring change under Unreleased. No code path, error message or type annotation changes.
