### PR TITLE
feat(python): select a device by its stable identifier

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `Device`, a device selector object (`from decibri import Device`) carrying a device's stable per-host identifier, the `id` field `MicrophoneInfo` and `SpeakerInfo` report. Pass it on the `device` parameter of `Microphone`, `AsyncMicrophone`, `Speaker`, `AsyncSpeaker`, `record_to_file` and `async_record_to_file` (`Microphone(device=Device(id=info.id))`) to select that device by exact identifier. An identifier no device carries raises `MicrophoneNotFound` or `SpeakerNotFound` from `start()`, as a name miss does, and a non-string `id` raises `TypeError` at construction. `None`, an index and a name substring select as before; a `device` of any other type raises `ValueError` naming the four accepted forms, where it named three.
+
 ### Changed
 
 - `File.save` and `AsyncFile.save` refuse an AIFF above 32767 channels with `AudioFormatUnsupported` carrying the container layer's own text, the refusal a FLAC above 8 channels and a WAV above 32767 already receive: an AIFF `COMM` chunk's `numChannels` is a signed 16-bit field, so 32767 is the format's own maximum. There is nothing a caller needs to do, because no container decibri writes accepts more. Reading an AIFF, every count up to 32767, WAV, FLAC and `File.buffer` and `AsyncFile.buffer` delivery at any count are unchanged.

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -117,7 +117,7 @@ with decibri.Speaker(sample_rate=24000, channels=1) as spk:
 
 ### Value types
 
-`MicrophoneInfo`, `SpeakerInfo`, `VersionInfo`, `Chunk`, `VadReport`, `VadWindow`, `Segment`, `AecMetrics`, `AecChannelMetrics`, `SaveReport`, and the config objects `Vad` and `Aec`.
+`MicrophoneInfo`, `SpeakerInfo`, `VersionInfo`, `Chunk`, `VadReport`, `VadWindow`, `Segment`, `AecMetrics`, `AecChannelMetrics`, `SaveReport`, the config objects `Vad` and `Aec`, and the device selector `Device`.
 
 ### Exceptions
 
@@ -128,6 +128,27 @@ The full hierarchy lives at `decibri.exceptions`. Top-level catch-targets surfac
 - `OrtError`: ONNX Runtime issues
 - `OrtPathError`: ORT dylib path resolution issues
 - `ForkAfterOrtInit`: Linux fork-after-ORT-init detection
+
+## Device selection
+
+```python
+import decibri
+
+# System default
+mic = decibri.Microphone()
+
+# By name (case-insensitive substring match)
+mic = decibri.Microphone(device="USB")
+
+# By index
+devices = decibri.input_devices()
+mic = decibri.Microphone(device=devices[1].index)
+
+# By stable per-host identifier (exact match; survives across enumerations)
+mic = decibri.Microphone(device=decibri.Device(id=devices[1].id))
+```
+
+`Speaker`, `AsyncMicrophone`, `AsyncSpeaker`, `record_to_file` and `async_record_to_file` take the same `device` forms. The device is resolved when the stream starts: a name that matches more than one device raises `MultipleDevicesMatch`, and a selector that matches none raises `MicrophoneNotFound` or `SpeakerNotFound`.
 
 ## Voice Activity Detection
 

--- a/bindings/python/python/decibri/__init__.py
+++ b/bindings/python/python/decibri/__init__.py
@@ -14,6 +14,7 @@ from decibri._classes import (
     AecChannelMetrics,
     AecMetrics,
     Chunk,
+    Device,
     File,
     Microphone,
     SaveReport,
@@ -128,7 +129,7 @@ def record_to_file(
     duration_seconds: float,
     sample_rate: int = 16000,
     channels: int = 1,
-    device: int | str | None = None,
+    device: int | str | Device | None = None,
 ) -> None:
     """Record microphone audio to a 16-bit PCM WAV file for ``duration_seconds``.
 
@@ -152,10 +153,12 @@ def record_to_file(
         averages every device channel. A count equal to the device's own
         writes every device channel interleaved; a strict subset needs
         ``Microphone`` directly, so it can carry a ``channel_map``.
-    device : int | str | None, optional
+    device : int | str | Device | None, optional
         Input device selector. ``None`` (default) uses the system
-        default input. Pass an integer index from ``input_devices()``
-        or a substring of the device name.
+        default input. Pass an integer index from ``input_devices()``,
+        a substring of the device name, or a ``Device`` object carrying
+        the stable per-host identifier ``MicrophoneInfo.id`` reports
+        (``device=Device(id=info.id)``).
 
     Notes
     -----
@@ -201,7 +204,7 @@ async def async_record_to_file(
     duration_seconds: float,
     sample_rate: int = 16000,
     channels: int = 1,
-    device: int | str | None = None,
+    device: int | str | Device | None = None,
 ) -> None:
     """Async parallel of ``record_to_file``.
 
@@ -267,6 +270,8 @@ __all__ = [
     "Aec",
     "AecMetrics",
     "AecChannelMetrics",
+    # Device selector object
+    "Device",
     # Whole-recording analysis report types
     "VadReport",
     "VadWindow",

--- a/bindings/python/python/decibri/__init__.pyi
+++ b/bindings/python/python/decibri/__init__.pyi
@@ -7,6 +7,7 @@ from decibri._classes import Aec as Aec
 from decibri._classes import AecChannelMetrics as AecChannelMetrics
 from decibri._classes import AecMetrics as AecMetrics
 from decibri._classes import Chunk as Chunk
+from decibri._classes import Device as Device
 from decibri._classes import File as File
 from decibri._classes import Microphone as Microphone
 from decibri._classes import SaveReport as SaveReport
@@ -97,12 +98,12 @@ def record_to_file(
     duration_seconds: float,
     sample_rate: int = 16000,
     channels: int = 1,
-    device: int | str | None = None,
+    device: int | str | Device | None = None,
 ) -> None: ...
 async def async_record_to_file(
     path: str,
     duration_seconds: float,
     sample_rate: int = 16000,
     channels: int = 1,
-    device: int | str | None = None,
+    device: int | str | Device | None = None,
 ) -> None: ...

--- a/bindings/python/python/decibri/_async_classes.py
+++ b/bindings/python/python/decibri/_async_classes.py
@@ -60,6 +60,7 @@ from decibri._classes import (
     Aec,
     AecMetrics,
     Chunk,
+    Device,
     File,
     SaveReport,
     Vad,
@@ -145,7 +146,7 @@ class AsyncMicrophone:
         channels: int = 1,
         frames_per_buffer: int = 1600,
         dtype: str = "int16",
-        device: int | str | None = None,
+        device: int | str | Device | None = None,
         vad: bool | str | Vad = False,
         model_path: str | Path | None = None,
         as_ndarray: bool = False,
@@ -833,7 +834,7 @@ class AsyncSpeaker:
         sample_rate: int = 16000,
         channels: int = 1,
         dtype: str = "int16",
-        device: int | str | None = None,
+        device: int | str | Device | None = None,
     ) -> None:
         """Construct an AsyncSpeaker audio output instance.
 
@@ -850,13 +851,15 @@ class AsyncSpeaker:
             Sample dtype: ``"int16"`` (default) or ``"float32"``. Must
             match the dtype of the data passed to ``write()``; mismatch
             raises ``TypeError`` at write time.
-        device : int | str | None, optional
+        device : int | str | Device | None, optional
             Output device selector. ``None`` (default) uses the system
             default output. Pass an integer index from
-            ``AsyncSpeaker.devices()`` or a substring of the device
-            name. ``AsyncSpeaker`` does not load ONNX Runtime, so there
-            is no ``ort_library_path`` parameter (output never invokes
-            VAD).
+            ``AsyncSpeaker.devices()``, a substring of the device name,
+            or a ``Device`` object carrying the stable per-host
+            identifier ``SpeakerInfo.id`` reports
+            (``device=Device(id=info.id)``), matched by exact equality.
+            ``AsyncSpeaker`` does not load ONNX Runtime, so there is no
+            ``ort_library_path`` parameter (output never invokes VAD).
         """
         if dtype not in _VALID_FORMATS:
             raise exceptions.InvalidFormat(

--- a/bindings/python/python/decibri/_classes.py
+++ b/bindings/python/python/decibri/_classes.py
@@ -65,6 +65,7 @@ __all__ = [
     "Aec",
     "AecMetrics",
     "AecChannelMetrics",
+    "Device",
     "Microphone",
     "Speaker",
     "File",
@@ -309,6 +310,51 @@ class Aec:
                 f"reference_channels must be at least 1; "
                 f"got {self.reference_channels}"
             )
+
+
+# ---------------------------------------------------------------------------
+# Device: named device selector object.
+#
+# Carries a device's stable per-host identifier, the ``id`` field
+# ``MicrophoneInfo`` and ``SpeakerInfo`` report, in the named-config-object
+# shape beside ``Vad`` and ``Aec``. Pass it as
+# ``Microphone(device=Device(id=info.id))``; a bare int keeps index selection
+# and a bare str keeps name-substring selection. The bridge reads the ``id``
+# field and hands it to the core as its identifier selector, which the core
+# matches by exact equality, so an identifier and a name never collide.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Device:
+    """Device selector by stable per-host identifier.
+
+    Pass an instance on the ``device`` parameter of ``Microphone`` /
+    ``AsyncMicrophone`` / ``Speaker`` / ``AsyncSpeaker`` (and of
+    ``record_to_file`` / ``async_record_to_file``) to select the device
+    whose ``id`` equals the one given. A bare ``int`` selects by index and a
+    bare ``str`` selects by case-insensitive name substring; a ``Device``
+    object is the way to select by identifier.
+
+    Attributes:
+        id: The device's stable per-host identifier, the ``id`` field of a
+            ``MicrophoneInfo`` or ``SpeakerInfo`` returned by ``devices()``,
+            ``input_devices()`` or ``output_devices()``: the lowercase host
+            name, a colon, then the platform's own device identifier. Matched
+            by exact equality when the stream starts; an identifier no device
+            carries raises ``MicrophoneNotFound`` or ``SpeakerNotFound`` from
+            ``start()``. Must be a ``str`` (``TypeError`` otherwise).
+
+    Example:
+        info = decibri.input_devices()[0]
+        Microphone(device=Device(id=info.id))
+    """
+
+    id: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.id, str):
+            raise TypeError(f"id must be a string; got {self.id!r}")
 
 
 @dataclass(frozen=True, slots=True)
@@ -665,6 +711,16 @@ class Microphone:
     channel count when the stream starts (``ChannelMapOutOfRange`` names an
     entry the device does not have); the device's report is the only ceiling.
 
+    The ``device`` parameter selects the input device. ``None`` (the default)
+    uses the system default input. An ``int`` is an index from
+    ``Microphone.devices()``; a ``str`` is a case-insensitive substring of the
+    device name (``MultipleDevicesMatch`` at ``start()`` when it matches more
+    than one device); a ``Device`` object (``device=Device(id=info.id)``)
+    selects by the stable per-host identifier ``MicrophoneInfo.id`` reports,
+    matched by exact equality. The device is resolved when the stream starts,
+    so a selector that matches no device raises ``MicrophoneNotFound`` from
+    ``start()``, and an index past the end raises ``DeviceIndexOutOfRange``.
+
     This class is synchronous. For async iteration, use ``AsyncMicrophone``.
 
     Cleanup and disconnect:
@@ -697,7 +753,7 @@ class Microphone:
         channels: int = 1,
         frames_per_buffer: int = 1600,
         dtype: str = "int16",
-        device: int | str | None = None,
+        device: int | str | Device | None = None,
         vad: bool | str | Vad = False,
         model_path: str | Path | None = None,
         as_ndarray: bool = False,
@@ -1402,7 +1458,7 @@ class Speaker:
         sample_rate: int = 16000,
         channels: int = 1,
         dtype: str = "int16",
-        device: int | str | None = None,
+        device: int | str | Device | None = None,
     ) -> None:
         """Construct a Speaker audio output instance.
 
@@ -1422,12 +1478,15 @@ class Speaker:
             Sample dtype: ``"int16"`` (default) or ``"float32"``. Must
             match the dtype of the data passed to ``write()``; mismatch
             raises ``TypeError`` at write time.
-        device : int | str | None, optional
+        device : int | str | Device | None, optional
             Output device selector. ``None`` (default) uses the system
             default output. Pass an integer index from
-            ``Speaker.devices()`` or a substring of the device name.
-            ``Speaker`` does not load ONNX Runtime, so there is no
-            ``ort_library_path`` parameter (output never invokes VAD).
+            ``Speaker.devices()``, a substring of the device name, or a
+            ``Device`` object carrying the stable per-host identifier
+            ``SpeakerInfo.id`` reports (``device=Device(id=info.id)``),
+            matched by exact equality. ``Speaker`` does not load ONNX
+            Runtime, so there is no ``ort_library_path`` parameter (output
+            never invokes VAD).
         """
         if dtype not in _VALID_FORMATS:
             raise exceptions.InvalidFormat(

--- a/bindings/python/python/decibri/_decibri.pyi
+++ b/bindings/python/python/decibri/_decibri.pyi
@@ -34,6 +34,8 @@ Wrapper-only naming translations:
 from pathlib import Path
 from typing import Awaitable, Coroutine, Any, TYPE_CHECKING, Union
 
+from decibri._classes import Device
+
 if TYPE_CHECKING:
     import numpy as np
 
@@ -210,7 +212,7 @@ class MicrophoneBridge:
         channels: int,
         frames_per_buffer: int,
         format: str,
-        device: int | str | None = None,
+        device: int | str | Device | None = None,
         vad: bool = False,
         vad_threshold: float = 0.5,
         vad_mode: str = "silero",
@@ -287,7 +289,7 @@ class SpeakerBridge:
         sample_rate: int,
         channels: int,
         format: str,
-        device: int | str | None = None,
+        device: int | str | Device | None = None,
     ) -> None: ...
     def start(self) -> None: ...
     def stop(self) -> None: ...
@@ -336,7 +338,7 @@ class AsyncMicrophoneBridge:
         channels: int,
         frames_per_buffer: int,
         format: str,
-        device: int | str | None = None,
+        device: int | str | Device | None = None,
         vad: bool = False,
         vad_threshold: float = 0.5,
         vad_mode: str = "silero",
@@ -410,7 +412,7 @@ class AsyncSpeakerBridge:
         sample_rate: int,
         channels: int,
         format: str,
-        device: int | str | None = None,
+        device: int | str | Device | None = None,
     ) -> None: ...
     def start(self) -> Coroutine[Any, Any, None]: ...
     def stop(self) -> Coroutine[Any, Any, None]: ...

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -459,10 +459,12 @@ impl From<CoreOutputDeviceInfo> for OutputDeviceInfo {
 
 // ---------------------------------------------------------------------------
 // Device selector helper: translates Python-side device parameter into the
-// core's DeviceSelector enum. Accepts None (Default), int (Index), or str
-// (Name). A string is always a name selector, which the core matches as a
-// case-insensitive substring of the display name; nothing here produces
-// DeviceSelector::Id.
+// core's DeviceSelector enum. Accepts None (Default), int (Index), str
+// (Name), or a `decibri.Device` object (Id). A string is always a name
+// selector, which the core matches as a case-insensitive substring of the
+// display name. A `Device` object carries the identifier its `id` field
+// names, which the core matches by exact equality against the `id` the
+// enumeration reports; it is the only form that produces DeviceSelector::Id.
 // ---------------------------------------------------------------------------
 
 fn build_device_selector(device: Option<&Bound<'_, PyAny>>) -> PyResult<DeviceSelector> {
@@ -478,7 +480,14 @@ fn build_device_selector(device: Option<&Bound<'_, PyAny>>) -> PyResult<DeviceSe
     if let Ok(s) = d.extract::<String>() {
         return Ok(DeviceSelector::Name(s));
     }
-    Err(PyValueError::new_err("device must be None, int, or str"))
+    let device_class = d.py().import("decibri._classes")?.getattr("Device")?;
+    if d.is_instance(&device_class)? {
+        let id: String = d.getattr("id")?.extract()?;
+        return Ok(DeviceSelector::Id(id));
+    }
+    Err(PyValueError::new_err(
+        "device must be None, int, str, or Device",
+    ))
 }
 
 // ---------------------------------------------------------------------------

--- a/bindings/python/tests/test_device.py
+++ b/bindings/python/tests/test_device.py
@@ -1,0 +1,186 @@
+"""Device selector tests.
+
+``Device`` carries a device's stable per-host identifier and is passed on
+the ``device`` parameter beside the index and name-substring forms. The
+object's construction, its export, its acceptance on every constructor and
+the refusal of any other shape need no hardware. Resolving an identifier
+against a real device does, so those tests carry the audio markers and CI
+auto-skips them.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import typing
+
+import pytest
+
+import decibri
+from decibri import (
+    AsyncMicrophone,
+    AsyncSpeaker,
+    Device,
+    Microphone,
+    MicrophoneNotFound,
+    Speaker,
+    SpeakerNotFound,
+)
+
+_REFUSAL = "device must be None, int, str, or Device"
+
+
+# ---------------------------------------------------------------------------
+# The object itself
+# ---------------------------------------------------------------------------
+
+
+def test_device_constructs_positionally_and_by_keyword() -> None:
+    """Both spellings carry the identifier through unchanged."""
+    assert Device("wasapi:{x}").id == "wasapi:{x}"
+    assert Device(id="coreaudio:uid").id == "coreaudio:uid"
+
+
+def test_device_is_frozen() -> None:
+    """The selector is immutable, like the Vad and Aec config objects."""
+    selector = Device("alsa:hw:0,0")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        selector.id = "other"  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        pytest.param(3, id="int"),
+        pytest.param(None, id="none"),
+        pytest.param(b"wasapi:{x}", id="bytes"),
+    ],
+)
+def test_device_rejects_non_string_id(bad_id: object) -> None:
+    """A non-string identifier is refused at construction with TypeError."""
+    with pytest.raises(TypeError, match="id must be a string"):
+        Device(bad_id)  # type: ignore[arg-type]
+
+
+def test_device_exported_from_package_root() -> None:
+    """``from decibri import Device`` resolves to the one class and is listed."""
+    assert decibri.Device is Device
+    assert "Device" in decibri.__all__
+
+
+# ---------------------------------------------------------------------------
+# Acceptance on every constructor (device resolution happens at start())
+# ---------------------------------------------------------------------------
+
+
+def test_every_constructor_accepts_a_device_object() -> None:
+    """All four classes construct with a Device and keep it for repr."""
+    selector = Device("host:never-resolved")
+    for obj in (
+        Microphone(device=selector),
+        AsyncMicrophone(device=selector),
+        Speaker(device=selector),
+        AsyncSpeaker(device=selector),
+    ):
+        assert "device=Device(id='host:never-resolved')" in repr(obj)
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param(Microphone.__init__, id="Microphone"),
+        pytest.param(AsyncMicrophone.__init__, id="AsyncMicrophone"),
+        pytest.param(Speaker.__init__, id="Speaker"),
+        pytest.param(AsyncSpeaker.__init__, id="AsyncSpeaker"),
+        pytest.param(decibri.record_to_file, id="record_to_file"),
+        pytest.param(decibri.async_record_to_file, id="async_record_to_file"),
+    ],
+)
+def test_device_parameter_is_annotated_with_device(target: object) -> None:
+    """Every ``device`` parameter names Device in its annotation.
+
+    The stub side of the same contract is held by ``mypy --strict``.
+    """
+    assert callable(target)
+    assert "device" in inspect.signature(target).parameters
+    assert typing.get_type_hints(target)["device"] == int | str | Device | None
+
+
+# ---------------------------------------------------------------------------
+# Refusal of any other shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_device",
+    [
+        pytest.param({"id": "wasapi:{x}"}, id="mapping"),
+        pytest.param(3.5, id="float"),
+        pytest.param(["wasapi:{x}"], id="list"),
+    ],
+)
+def test_wrong_shape_is_refused_on_capture_and_playback(bad_device: object) -> None:
+    """A value of any other type raises ValueError naming the four forms."""
+    with pytest.raises(ValueError, match=_REFUSAL):
+        Microphone(device=bad_device)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match=_REFUSAL):
+        Speaker(device=bad_device)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Resolution against real devices
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_audio_input
+def test_microphone_selects_every_input_device_by_id() -> None:
+    """Each enumerated input device opens through its own identifier.
+
+    Catches the identifier never reaching the core as its own selector:
+    read as a name it matches nothing and start() raises.
+    """
+    devices = Microphone.devices()
+    assert devices
+    for info in devices:
+        mic = Microphone(device=Device(id=info.id))
+        mic.start()
+        try:
+            assert mic.is_open is True
+        finally:
+            mic.stop()
+
+
+@pytest.mark.requires_audio_input
+def test_microphone_id_is_matched_exactly_not_as_a_name() -> None:
+    """A display name wrapped in Device is not an identifier and is not found.
+
+    Catches the object collapsing into the name-substring path, which would
+    resolve (or report an ambiguous name) instead of raising not found.
+    """
+    info = Microphone.devices()[0]
+    mic = Microphone(device=Device(id=info.name))
+    with pytest.raises(MicrophoneNotFound):
+        mic.start()
+
+
+@pytest.mark.requires_audio_output
+def test_speaker_selects_every_output_device_by_id() -> None:
+    """Each enumerated output device opens through its own identifier."""
+    devices = Speaker.devices()
+    assert devices
+    for info in devices:
+        spk = Speaker(device=Device(id=info.id))
+        spk.start()
+        try:
+            assert spk.is_playing is True
+        finally:
+            spk.stop()
+
+
+@pytest.mark.requires_audio_output
+def test_speaker_id_is_matched_exactly_not_as_a_name() -> None:
+    """A display name wrapped in Device is not found on the output side."""
+    info = Speaker.devices()[0]
+    spk = Speaker(device=Device(id=info.name))
+    with pytest.raises(SpeakerNotFound):
+        spk.start()

--- a/bindings/python/tests/test_smoke.py
+++ b/bindings/python/tests/test_smoke.py
@@ -144,7 +144,7 @@ def test_exception_intermediate_parents_importable() -> None:
 
 
 def test_public_surface_count() -> None:
-    """The public ``__all__`` enumerates the top-level surface (28 names).
+    """The public ``__all__`` enumerates the top-level surface (29 names).
 
     Composition: 3 sync wrappers (Microphone, Speaker, File) + 3 async
     wrappers (AsyncMicrophone, AsyncSpeaker, AsyncFile) + 3 module-level
@@ -154,13 +154,14 @@ def test_public_surface_count() -> None:
     + 1 audio chunk dataclass (Chunk)
     + 1 VAD config object (Vad)
     + 3 echo-cancellation types (Aec, AecMetrics, AecChannelMetrics)
+    + 1 device selector object (Device)
     + 3 whole-recording analysis types (VadReport, VadWindow, Segment)
     + 1 save report type (SaveReport)
     + 5 exception entries (DecibriError, DeviceError, ForkAfterOrtInit,
       OrtError, OrtPathError)
-    = 3 + 3 + 3 + 2 + 3 + 1 + 1 + 3 + 3 + 1 + 5 = 28.
+    = 3 + 3 + 3 + 2 + 3 + 1 + 1 + 3 + 1 + 3 + 1 + 5 = 29.
     """
-    assert len(decibri.__all__) == 28
+    assert len(decibri.__all__) == 29
     for name in decibri.__all__:
         assert hasattr(decibri, name), f"__all__ lists {name!r} but it is not exported"
 


### PR DESCRIPTION
`Device`, a frozen dataclass exported from the package root, carries the stable per-host identifier MicrophoneInfo.id and SpeakerInfo.id report. Passed on the device parameter of Microphone, AsyncMicrophone, Speaker, AsyncSpeaker, record_to_file and async_record_to_file, it selects the device whose identifier equals the one given: the bridge hands it to the core as DeviceSelector::Id, and an identifier no device carries raises MicrophoneNotFound or SpeakerNotFound from start(). None, an index and a name substring select as before. A device value of any other type raises ValueError naming the four accepted forms, and a non-string id raises TypeError from the dataclass. The wrappers, both package stubs and the bridge stub carry the Device annotation, the README documents the four forms, and the Python changelog carries the entry under Unreleased. The core and the Node binding are unchanged.